### PR TITLE
feat(configuration): parse and validate for project configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 ## Build the tool
 ```
+pip3 install jsonschema
 python3 setup.py install 
 python3 setup.py sdist bdist_wheel 
 pip3 install dist/greengrass_tools-1.0.0-py3-none-any.whl --force-reinstall 

--- a/greengrassTools/common/configuration.py
+++ b/greengrassTools/common/configuration.py
@@ -1,0 +1,40 @@
+import json
+
+import greengrassTools.common.consts as consts
+import greengrassTools.common.utils as utils
+import jsonschema
+
+
+def get_configuration(file_name, component_name):
+    """
+     This method returns component configuration from the given file name.
+     If configuration in file, is not valid per defined schema it will throw ValidationError error.
+     If component configuration doesn't exists, then it will return None
+    :param file_name: file name for configuration file to read. This needs to be valid & absolute path.
+    :param component_name: name of the component
+    :return: Json object representing to component configuration
+    """
+    with open(file_name, "r") as config_file:
+        data = config_file.read()
+    try:
+        validate_configuration(json.loads(data))
+    except jsonschema.exceptions.ValidationError as err:
+        print("Configuration file provide {0} is not in correct format, details of error {1}".format(file_name, err))
+        raise err
+    config_data = json.loads(data)
+    try:
+        return config_data["component"][component_name]
+    except Exception as e:
+        print(e)
+        return None
+
+
+def validate_configuration(data):
+    """
+    This method validates the Json configuration object against json schema. It throws error if data is invalid.
+    :param data: Json configuration object
+    :return:
+    """
+    with open(utils.get_static_file_path(consts.config_schema_file), "r") as schemaFile:
+        schema = json.loads(schemaFile.read())
+    jsonschema.validate(data, schema)

--- a/greengrassTools/common/consts.py
+++ b/greengrassTools/common/consts.py
@@ -15,3 +15,6 @@ arg_parameters = [
     "metavar",
     "dest",
 ]
+
+config_schema_file = "config_schema.json"
+cli_model_file = "cli_model.json"

--- a/greengrassTools/common/model_actions.py
+++ b/greengrassTools/common/model_actions.py
@@ -1,6 +1,7 @@
-import os
 import json
-import greengrassTools
+
+import greengrassTools.common.consts as consts
+import greengrassTools.common.utils as utils
 
 
 def is_valid_model(cli_model, command):
@@ -27,9 +28,7 @@ def is_valid_model(cli_model, command):
 
         # Validate sub-commands
         if "sub-commands" in cli_model[command]:
-            if not is_valid_subcommand_model(
-                cli_model, cli_model[command]["sub-commands"]
-            ):
+            if not is_valid_subcommand_model(cli_model, cli_model[command]["sub-commands"]):
                 return False
     return True
 
@@ -89,12 +88,9 @@ def get_validated_model():
     -------
       cli_model(dict): Empty if the model is invalid otherwise returns cli model.
     """
-    cli_model_file = os.path.join(
-        os.path.dirname(greengrassTools.__file__), "static", "cli_model.json"
-    )
-    with open(cli_model_file) as f:
+    with open(utils.get_static_file_path(consts.cli_model_file)) as f:
         cli_model = json.loads(f.read())
-    if is_valid_model(cli_model, greengrassTools.common.consts.cli_tool_name):
+    if is_valid_model(cli_model, consts.cli_tool_name):
         return cli_model
     else:
         return {}

--- a/greengrassTools/common/utils.py
+++ b/greengrassTools/common/utils.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def get_static_file_path(file_name):
+    """
+    Returns the path of the file assuming that is in static directory. Note that this doesnt validate if path is correct
+    :param file_name: name of the file
+    :return: Path of the file
+    """
+    return Path(".").joinpath("greengrassTools/static").joinpath(file_name).resolve()

--- a/greengrassTools/static/config_schema.json
+++ b/greengrassTools/static/config_schema.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "component": {
+            "type": "object",
+            "patternProperties": {
+                "^[A-Za-z0-9 \\\\-]*[A-Za-z0-9 \\\\-][A-Za-z0-9 \\\\-]*$" : {
+                    "type": "object",
+                    "properties" : {
+                        "author": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string",
+                            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?"
+                        },
+                        "build" : {
+                            "type" : "object",
+                            "properties" : {
+                                "command": { "type" :  "string"}
+                            },
+                            "required": ["command"]
+                        },
+                        "publish" : {
+                            "type" : "object",
+                            "properties" : {
+
+                                "bucket_name": { "type" :  "string"}
+                            },
+                            "required": ["bucket_name"]
+                        }
+                    },
+                    "required": ["author","version","build", "publish"]
+                }
+            }
+        },
+        "tools-version": {
+            "type": "string",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?"
+        }
+    },
+    "required": ["component", "tools-version"]
+}

--- a/tests/greengrassTools/common/test_configuration.py
+++ b/tests/greengrassTools/common/test_configuration.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+import greengrassTools.common.configuration as config
+import jsonschema
+import pytest
+
+
+def test_get_configuration_valid_component_config_found():
+    component_config = (
+        '{"author": "abc","version": "1.0.0","build": {"command" : "default"},"publish": {"bucket_name": "default"}}'
+    )
+    expected_config = json.loads(component_config)
+    assert (
+        config.get_configuration(
+            Path(".").joinpath("tests/greengrassTools/static").joinpath("config.json").resolve(),
+            "1",
+        )
+        == expected_config
+    )
+
+
+def test_get_configuration_valid_component_config_no_found():
+    assert (
+        config.get_configuration(Path(".").joinpath("tests/greengrassTools/static").joinpath("config.json").resolve(), "2")
+        is None
+    )
+
+
+@pytest.mark.parametrize("file_name", ["invalid_config.json", "invalid_case_config.json", "invalid_version_config.json"])
+def test_get_configuration_invalid_config_file(file_name):
+    with pytest.raises(jsonschema.exceptions.ValidationError) as err:
+        config.get_configuration(
+            Path(".").joinpath("tests/greengrassTools/static").joinpath(file_name).resolve(),
+            "1",
+        )
+    assert type(err.value) == jsonschema.exceptions.ValidationError

--- a/tests/greengrassTools/static/config.json
+++ b/tests/greengrassTools/static/config.json
@@ -1,0 +1,15 @@
+{
+    "component" :{
+        "1": {
+            "author": "abc",
+            "version": "1.0.0",
+            "build": {
+                "command" : "default"
+            },
+            "publish": {
+                "bucket_name": "default"
+            }
+        }
+    },
+    "tools-version": "1.0.0"
+}

--- a/tests/greengrassTools/static/invalid_case_config.json
+++ b/tests/greengrassTools/static/invalid_case_config.json
@@ -1,0 +1,15 @@
+{
+    "Component" :{
+        "1": {
+            "author": "abc",
+            "version": "1.0.0",
+            "Build": {
+                "command" : "default"
+            },
+            "publish": {
+                "bucket_name": "default"
+            }
+        }
+    },
+    "tools-version": "1.0.0"
+}

--- a/tests/greengrassTools/static/invalid_config.json
+++ b/tests/greengrassTools/static/invalid_config.json
@@ -1,0 +1,14 @@
+{
+    "component" :{
+        "1": {
+            "author": "abc",
+            "version": "1.0.0",
+            "build": {
+                "command" : "default"
+            },
+            "publish": {
+            }
+        }
+    },
+    "tools-version": "1.0.0"
+}

--- a/tests/greengrassTools/static/invalid_version_config.json
+++ b/tests/greengrassTools/static/invalid_version_config.json
@@ -1,0 +1,15 @@
+{
+    "component" :{
+        "1": {
+            "author": "abc",
+            "version": "1.b.0",
+            "build": {
+                "command" : "default"
+            },
+            "publish": {
+                "bucket_name": "default"
+            }
+        }
+    },
+    "tools-version": "1.0.0"
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Added new functionality to read and validate the configuration from file. 
- Added jsonschema as dependency to be able to have robust config validation. 

**Why is this change necessary:**
- This change validates the configuration file "greengrass-tools-config.json" present in the cli project against definite schema that the cli tool expects. 

**How was this change tested:**
```
coverage run --source=greengrassTools -m pytest -v -s tests && coverage report --show-missing --fail-under=70
```

**Any additional information or context required to review the change:**

**Checklist:**
- [x] Updated the README if applicable
- [x] Updated or added new unit tests
- [x] Updated or added new integration tests
- [x] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.