### PR TITLE
feat(list): lists available templates and repositories from software catalog

### DIFF
--- a/greengrassTools/commands/component/component.py
+++ b/greengrassTools/commands/component/component.py
@@ -14,3 +14,9 @@ def publish(d_args):
     import greengrassTools.commands.component.publish as publish
 
     publish.run(d_args)
+
+
+def list(d_args):
+    import greengrassTools.commands.component.list as list
+
+    list.run(d_args)

--- a/greengrassTools/commands/component/list.py
+++ b/greengrassTools/commands/component/list.py
@@ -1,0 +1,45 @@
+import logging
+
+import greengrassTools.common.consts as consts
+import greengrassTools.common.exceptions.error_messages as error_messages
+import requests
+
+
+def run(command_args):
+    if "template" in command_args and command_args["template"]:
+        logging.info("Listing all the available component templates from Greengrass Software Catalog.")
+        li = get_component_list_from_github(consts.templates_list_url)
+        logging.info("Found '{}' component templates to display.".format(len(li)))
+        display_list(li)
+    elif "repository" in command_args and command_args["repository"]:
+        logging.info("Listing all the available component repositories from Greengrass Software Catalog.")
+        li = get_component_list_from_github(consts.repository_list_url)
+        logging.info("Found '{}' component repositories to display.".format(len(li)))
+        display_list(li)
+
+
+def get_component_list_from_github(url):
+    comp_list_response = requests.get(url)
+    if comp_list_response.status_code != 200:
+        try:
+            comp_list_response.raise_for_status()
+        except Exception as e:
+            logging.error(e)
+            raise e
+        finally:
+            raise Exception(error_messages.LISTING_COMPONENTS_FAILED)
+    try:
+        comp_list = comp_list_response.json()
+        return comp_list
+    except Exception as e:
+        logging.error(e)
+        return []
+
+
+def display_list(components):
+    # TODO: Add short description of what each component is for?
+    i = 1
+    for component in components:
+        # Do not use logging here.
+        print(f"{i}. {component}")
+        i += 1

--- a/greengrassTools/commands/methods.py
+++ b/greengrassTools/commands/methods.py
@@ -11,3 +11,7 @@ def _greengrass_tools_component_build(d_args):
 
 def _greengrass_tools_component_publish(d_args):
     component.publish(d_args)
+
+
+def _greengrass_tools_component_list(d_args):
+    component.list(d_args)

--- a/greengrassTools/common/consts.py
+++ b/greengrassTools/common/consts.py
@@ -19,3 +19,7 @@ arg_parameters = [
 config_schema_file = "config_schema.json"
 cli_model_file = "cli_model.json"
 cli_project_config_file = "greengrass-tools-config.json"
+
+# TODO: Update URLs
+templates_list_url = ""
+repository_list_url = ""

--- a/greengrassTools/common/exceptions/error_messages.py
+++ b/greengrassTools/common/exceptions/error_messages.py
@@ -9,3 +9,4 @@ PROJECT_RECIPE_FILE_NOT_FOUND = (
 PROJECT_CONFIG_FILE_INVALID = "Project configuration file '{}' is invalid. Please correct its format and try again. Error: {} "
 CLI_MODEL_FILE_NOT_EXISTS = "Model validation failed. CLI model file doesn't exist."
 INVALID_CLI_MODEL = "CLI model is invalid. Please provide a valid model to create the CLI parser."
+LISTING_COMPONENTS_FAILED = "Failed to list the available components from GitHub. Please try again after sometime."

--- a/tests/greengrassTools/commands/component/test_list.py
+++ b/tests/greengrassTools/commands/component/test_list.py
@@ -1,0 +1,61 @@
+import greengrassTools.commands.component.list as list
+import greengrassTools.common.consts as consts
+import greengrassTools.common.exceptions.error_messages as error_messages
+import pytest
+from urllib3.exceptions import HTTPError
+
+
+def test_display_list():
+    components = [1, 2, 4]
+    list.display_list(components)
+
+
+def test_get_component_list_from_github_valid_json(mocker):
+    res_json = {"template-name": "template-list"}
+    url = "url"
+    mock_response = mocker.Mock(status_code=200, json=lambda: res_json)
+    mock_template_list = mocker.patch("requests.get", return_value=mock_response)
+
+    templates_list = list.get_component_list_from_github(url)
+    assert templates_list == res_json
+    assert mock_template_list.call_count == 1
+
+
+def test_get_component_list_from_github_invalid_json(mocker):
+    res_json = {"template-name": "template-list"}
+    mock_response = mocker.Mock(status_code=200, json=res_json)
+    mock_template_list = mocker.patch("requests.get", return_value=mock_response)
+
+    templates_list = list.get_component_list_from_github("url")
+    assert templates_list == []
+    assert mock_template_list.call_count == 1
+
+
+def test_get_component_list_from_github_invalid_url(mocker):
+    mock_response = mocker.Mock(status_code=404, raise_for_status=mocker.Mock(side_effect=HTTPError("some error")))
+    mock_template_list = mocker.patch("requests.get", return_value=mock_response)
+
+    with pytest.raises(Exception) as e:
+        list.get_component_list_from_github("url")
+    assert e.value.args[0] == error_messages.LISTING_COMPONENTS_FAILED
+    assert mock_template_list.call_count == 1
+
+
+def test_run_template(mocker):
+    mock_get_component_list_from_github = mocker.patch(
+        "greengrassTools.commands.component.list.get_component_list_from_github", return_value=[]
+    )
+    mock_display_list = mocker.patch("greengrassTools.commands.component.list.display_list", return_value=None)
+    list.run({"template": True})
+    mock_get_component_list_from_github.assert_any_call(consts.templates_list_url)
+    assert mock_display_list.call_count == 1
+
+
+def test_run_repository(mocker):
+    mock_get_component_list_from_github = mocker.patch(
+        "greengrassTools.commands.component.list.get_component_list_from_github", return_value=[]
+    )
+    mock_display_list = mocker.patch("greengrassTools.commands.component.list.display_list", return_value=None)
+    list.run({"repository": True})
+    mock_get_component_list_from_github.assert_any_call(consts.repository_list_url)
+    assert mock_display_list.call_count == 1


### PR DESCRIPTION
**Issue #, if available:**


**Description of changes:**
- Add `list` sub-command to list the available component templates and repositories from GitHub that can be downloaded using the CLI tool.
- The component lists are maintained in the greengrass-software-catalog repo.
- Commands
  `greengrass-tools component list --template`
  `greengrass-tools component list --repository`

**Why is this change necessary:**
- Customers can use this command to first list the available components before initializing their project. They don't have to look into documentation or follow the github repos to get the same information. 
- This will be used in the `init` command as a check before downloading. 

**How was this change tested:**
`coverage run --source=greengrassTools -m pytest -v -s tests && coverage report --show-missing --fail-under=70`

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.