### PR TITLE
feat(init): initializes project based on args

### DIFF
--- a/greengrassTools/commands/component/init.py
+++ b/greengrassTools/commands/component/init.py
@@ -1,2 +1,112 @@
-def run(args):
-    print(" I init the project based on args")
+import logging
+import os
+import shutil
+
+import greengrassTools.commands.component.list as list
+import greengrassTools.common.consts as consts
+import greengrassTools.common.exceptions.error_messages as error_messages
+import greengrassTools.common.parse_args_actions as parse_args_actions
+import greengrassTools.common.utils as utils
+import requests
+
+
+def run(command_args):
+    """
+    Initializes the current directory in which the command runs based on the command arguments.
+
+    This function checks if the current directory is empty before initiating the project. Raises an
+    exception otherwise.
+
+    Parameters
+    ----------
+      command_args(dict): A dictionary object that contains parsed args namespace of a command.
+
+    Returns
+    -------
+        None
+    """
+    # Check if directory is not empty
+    if not utils.is_directory_empty(utils.current_directory):
+        raise Exception(error_messages.INIT_NON_EMPTY_DIR_ERROR)
+
+    # Check if the command args are conflicting
+    if parse_args_actions.conflicting_arg_groups(command_args, "init"):
+        raise Exception(error_messages.INIT_WITH_CONFLICTING_ARGS)
+
+    # Choose appropriate action based on commands
+    if "template" in command_args and "language" in command_args:
+        template = command_args["template"]
+        language = command_args["language"]
+        if template and language:
+            logging.info("Initializing the project directory with a {} component template - '{}'.".format(language, template))
+            init_with_template(template, language)
+            return
+    elif "repository" in command_args:
+        repository = command_args["repository"]
+        if repository:
+            logging.info(
+                "Initializing the project directory with a component from repository catalog - '{}'.".format(repository)
+            )
+            init_with_repository(repository)
+            return
+    raise Exception(error_messages.INIT_WITH_INVALID_ARGS)
+
+
+def init_with_template(template, language):
+    try:
+        template_name = "{}-{}".format(template, language)
+        logging.info("Fetching the component template '{}' from Greengrass Software Catalog.".format(template_name))
+        download_and_clean(template_name, "template")
+    except Exception as e:
+        raise Exception("Could not initialize the project with component template '{}'.\n{}".format(template, e))
+
+
+def init_with_repository(repository):
+    try:
+        logging.info("Fetching the component repository '{}' from Greengrass Software Catalog.".format(repository))
+        download_and_clean(repository, "repository")
+    except Exception as e:
+        raise Exception("Could not initialize the project with component repository '{}'.\n{}".format(repository, e))
+
+
+def download_and_clean(comp_name, comp_type):
+    comp_url = get_download_url(comp_name, comp_type)
+
+    download_request = requests.get(comp_url, stream=True)
+    if download_request.status_code != 200:
+        try:
+            download_request.raise_for_status()
+        except Exception as e:
+            logging.error(e)
+            raise e
+        finally:
+            raise Exception(error_messages.INIT_FAILS_DURING_COMPONENT_DOWNLOAD.format(comp_type))
+
+    zip_comp_name = "{}.zip".format(comp_name)
+    with open(zip_comp_name, "wb") as f:
+        logging.debug("Downloading the component {}...".format(comp_type))
+        f.write(download_request.content)
+        logging.debug("Download complete.")
+
+    # unzip the template
+    logging.debug("Unzipping the downloaded component {}...".format(comp_type))
+    shutil.unpack_archive(zip_comp_name, utils.current_directory)
+    logging.debug("Unzip complete.")
+
+    # Delete the downloaded zip template
+    logging.debug("Deleting the downloaded zip component {}.".format(comp_type))
+    os.remove(zip_comp_name)
+    logging.debug("Delete complete.")
+
+
+def get_download_url(comp_name, comp_type):
+    if comp_type == "template":
+        url = consts.templates_list_url
+    elif comp_type == "repository":
+        url = consts.repository_list_url
+    available_components = list.get_component_list_from_github(url)
+    if comp_name in available_components:
+        logging.debug("Component {} '{}' is available in Greengrass Software Catalog.".format(comp_type, comp_name))
+        return available_components[comp_name]
+    else:
+        raise Exception("Could not find the component {} '{}' in Greengrass Software Catalog.".format(comp_type, comp_name))

--- a/greengrassTools/common/exceptions/error_messages.py
+++ b/greengrassTools/common/exceptions/error_messages.py
@@ -10,3 +10,16 @@ PROJECT_CONFIG_FILE_INVALID = "Project configuration file '{}' is invalid. Pleas
 CLI_MODEL_FILE_NOT_EXISTS = "Model validation failed. CLI model file doesn't exist."
 INVALID_CLI_MODEL = "CLI model is invalid. Please provide a valid model to create the CLI parser."
 LISTING_COMPONENTS_FAILED = "Failed to list the available components from GitHub. Please try again after sometime."
+INIT_FAILS_DURING_COMPONENT_DOWNLOAD = "Failed to download the selected component {{}}. Please try again after sometime."
+INIT_WITH_INVALID_ARGS = (
+    "Could not initialize the project as the arguments passed are invalid. Please initialize the project with correct"
+    " args.\nTry `greengrass-tools component init --help`"
+)
+INIT_WITH_CONFLICTING_ARGS = (
+    "Could not initialize the project as the command args are conflicting. Please initialize the project with correct"
+    " args.\nTry `greengrass-tools component init --help` "
+)
+INIT_NON_EMPTY_DIR_ERROR = (
+    "Could not initialize the project as the directory is not empty. Please initialize the project in an empty directory.\nTry"
+    " `greengrass-tools component init --help`"
+)

--- a/tests/greengrassTools/commands/component/test_init.py
+++ b/tests/greengrassTools/commands/component/test_init.py
@@ -1,0 +1,272 @@
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import greengrassTools.commands.component.init as init
+import greengrassTools.common.exceptions.error_messages as error_messages
+import pytest
+from urllib3.exceptions import HTTPError
+
+
+def test_init_run_with_non_empty_directory(mocker):
+    # Test that an exception is raised when init is run in non-empty directory
+    test_d_args = {"language": "python", "template": "name"}
+    mock_is_directory_empty = mocker.patch("greengrassTools.common.utils.is_directory_empty", return_value=False)
+    mock_init_with_template = mocker.patch("greengrassTools.commands.component.init.init_with_template", return_value=None)
+    mock_init_with_repository = mocker.patch("greengrassTools.commands.component.init.init_with_repository", return_value=None)
+    mock_conflicting_args = mocker.patch(
+        "greengrassTools.common.parse_args_actions.conflicting_arg_groups", return_value=False
+    )
+    with pytest.raises(Exception) as e:
+        init.run(test_d_args)
+
+    assert e.value.args[0] == error_messages.INIT_NON_EMPTY_DIR_ERROR
+
+    assert mock_is_directory_empty.call_count == 1
+    assert mock_conflicting_args.call_count == 0
+    assert mock_init_with_template.call_count == 0
+    assert mock_init_with_repository.call_count == 0
+
+
+def test_init_run_with_empty_directory(mocker):
+    # Test that an exception is not raised when init is run in an empty directory
+    test_d_args = {"repository": "repository"}
+    mock_is_directory_empty = mocker.patch("greengrassTools.common.utils.is_directory_empty", return_value=True)
+    mock_init_with_template = mocker.patch("greengrassTools.commands.component.init.init_with_template", return_value=None)
+    mock_init_with_repository = mocker.patch("greengrassTools.commands.component.init.init_with_repository", return_value=None)
+    mock_conflicting_args = mocker.patch(
+        "greengrassTools.common.parse_args_actions.conflicting_arg_groups", return_value=False
+    )
+    init.run(test_d_args)
+
+    assert mock_is_directory_empty.call_count == 1
+    assert mock_init_with_template.call_count == 0
+    assert mock_init_with_repository.call_count == 1
+    assert mock_conflicting_args.call_count == 1
+
+
+def test_init_run_with_empty_args_repository(mocker):
+    # Test that an exception is not raised when init is run in an empty directory
+    test_d_args = {"repository": None}
+    mock_is_directory_empty = mocker.patch("greengrassTools.common.utils.is_directory_empty", return_value=True)
+    mock_init_with_template = mocker.patch("greengrassTools.commands.component.init.init_with_template", return_value=None)
+    mock_init_with_repository = mocker.patch("greengrassTools.commands.component.init.init_with_repository", return_value=None)
+    mock_conflicting_args = mocker.patch(
+        "greengrassTools.common.parse_args_actions.conflicting_arg_groups", return_value=False
+    )
+
+    with pytest.raises(Exception) as e:
+        init.run(test_d_args)
+
+    assert e.value.args[0] == error_messages.INIT_WITH_INVALID_ARGS
+
+    assert mock_is_directory_empty.call_count == 1
+    assert mock_init_with_template.call_count == 0
+    assert mock_init_with_repository.call_count == 0
+    assert mock_conflicting_args.call_count == 1
+
+
+def test_init_run_with_empty_args_template(mocker):
+    # Test that an exception is not raised when init is run in an empty directory
+    test_d_args = {"template": None, "language": "python"}
+    mock_is_directory_empty = mocker.patch("greengrassTools.common.utils.is_directory_empty", return_value=True)
+    mock_init_with_template = mocker.patch("greengrassTools.commands.component.init.init_with_template", return_value=None)
+    mock_init_with_repository = mocker.patch("greengrassTools.commands.component.init.init_with_repository", return_value=None)
+    mock_conflicting_args = mocker.patch(
+        "greengrassTools.common.parse_args_actions.conflicting_arg_groups", return_value=False
+    )
+
+    with pytest.raises(Exception) as e:
+        init.run(test_d_args)
+
+    assert e.value.args[0] == error_messages.INIT_WITH_INVALID_ARGS
+
+    assert mock_is_directory_empty.call_count == 1
+    assert mock_init_with_template.call_count == 0
+    assert mock_init_with_repository.call_count == 0
+    assert mock_conflicting_args.call_count == 1
+
+
+def test_init_run_with_conflicting_args(mocker):
+    # Test that an exception is not raised when init is run in an empty directory
+    test_d_args = {"repository": "repository"}
+    mock_is_directory_empty = mocker.patch("greengrassTools.common.utils.is_directory_empty", return_value=True)
+    mock_init_with_template = mocker.patch("greengrassTools.commands.component.init.init_with_template", return_value=None)
+    mock_init_with_repository = mocker.patch("greengrassTools.commands.component.init.init_with_repository", return_value=None)
+    mock_conflicting_args = mocker.patch("greengrassTools.common.parse_args_actions.conflicting_arg_groups", return_value=True)
+
+    with pytest.raises(Exception) as e:
+        init.run(test_d_args)
+
+    assert e.value.args[0] == error_messages.INIT_WITH_CONFLICTING_ARGS
+
+    assert mock_is_directory_empty.call_count == 1
+    assert mock_init_with_template.call_count == 0
+    assert mock_init_with_repository.call_count == 0
+    assert mock_conflicting_args.call_count == 1
+
+
+def test_init_run_with_valid_args(mocker):
+    # Checks if args are used correctly to run correct init method
+    test_d_args = {"language": "python", "template": "name"}
+    mock_is_directory_empty = mocker.patch("greengrassTools.common.utils.is_directory_empty", return_value=True)
+    mock_init_with_template = mocker.patch("greengrassTools.commands.component.init.init_with_template", return_value=None)
+    mock_init_with_repository = mocker.patch("greengrassTools.commands.component.init.init_with_repository", return_value=None)
+
+    init.run(test_d_args)
+
+    assert mock_is_directory_empty.call_count == 1
+    assert mock_init_with_template.call_count == 1
+    assert mock_init_with_repository.call_count == 0
+
+
+def test_init_run_with_invalid_args(mocker):
+    test_d_args = {"lang": "python", "template": "name"}
+    mock_is_directory_empty = mocker.patch("greengrassTools.common.utils.is_directory_empty", return_value=True)
+    mock_init_with_template = mocker.patch("greengrassTools.commands.component.init.init_with_template", return_value=None)
+    mock_init_with_repository = mocker.patch("greengrassTools.commands.component.init.init_with_repository", return_value=None)
+    with pytest.raises(Exception) as e:
+        init.run(test_d_args)
+
+    assert e.value.args[0] == error_messages.INIT_WITH_INVALID_ARGS
+
+    assert mock_is_directory_empty.call_count == 1
+    assert mock_init_with_template.call_count == 0
+    assert mock_init_with_repository.call_count == 0
+
+
+def test_init_with_template_valid(mocker):
+    template = "template"
+    language = "language"
+    mock_download_and_clean = mocker.patch("greengrassTools.commands.component.init.download_and_clean", return_value=None)
+    init.init_with_template(template, language)
+    mock_download_and_clean.assert_any_call("template-language", "template")
+
+
+def test_init_with_template_exception(mocker):
+    template = "template"
+    language = "language"
+    mock_download_and_clean = mocker.patch(
+        "greengrassTools.commands.component.init.download_and_clean", side_effect=HTTPError("Some error")
+    )
+    with pytest.raises(Exception) as e:
+        init.init_with_template(template, language)
+    assert "Could not initialize the project with component template" in e.value.args[0]
+    mock_download_and_clean.assert_any_call("template-language", "template")
+
+
+def test_init_with_repository_valid(mocker):
+    repository = "repository_name"
+    mock_download_and_clean = mocker.patch("greengrassTools.commands.component.init.download_and_clean", return_value=None)
+    init.init_with_repository(repository)
+    mock_download_and_clean.assert_any_call(repository, "repository")
+
+
+def test_init_with_repository_exception(mocker):
+    repository = "repository_name"
+    mock_download_and_clean = mocker.patch(
+        "greengrassTools.commands.component.init.download_and_clean", side_effect=HTTPError("Some error")
+    )
+    with pytest.raises(Exception) as e:
+        init.init_with_repository(repository)
+    assert "Could not initialize the project with component repository" in e.value.args[0]
+    mock_download_and_clean.assert_any_call(repository, "repository")
+
+
+def test_download_and_clean_valid(mocker):
+    template_name_zip = "template-language.zip"
+    mock_get_available_templates = mocker.patch(
+        "greengrassTools.commands.component.list.get_component_list_from_github",
+        return_value={"template-language": "template-url"},
+    )
+
+    mock_response = mocker.Mock(status_code=200)
+    mock_template_download = mocker.patch("requests.get", return_value=mock_response)
+
+    mock_unzip_template_zip = mocker.patch("shutil.unpack_archive", return_value=None)
+    mock_remove_template_zip = mocker.patch("os.remove", return_value=None)
+    with patch("builtins.open", mock_open()) as mock_file:
+        init.download_and_clean("template-language", "template")
+        assert mock_remove_template_zip.call_count == 1
+        assert mock_unzip_template_zip.call_count == 1
+        assert mock_template_download.call_count == 1
+        assert mock_get_available_templates.call_count == 1
+        mock_file.assert_called_once_with(template_name_zip, "wb")
+
+        mock_remove_template_zip.assert_called_with(template_name_zip)
+        mock_unzip_template_zip.assert_called_with(template_name_zip, Path(".").resolve())
+
+
+def test_init_with_template_invalid_url(mocker):
+    # Raises an exception when the template url is not valid.
+    template = "template"
+    language = "language"
+    formatted_template_name = f"{template}-{language}"
+    mock_get_available_templates = mocker.patch(
+        "greengrassTools.commands.component.list.get_component_list_from_github",
+        return_value={formatted_template_name: "template-url"},
+    )
+    mock_response = mocker.Mock(status_code=404, raise_for_status=mocker.Mock(side_effect=HTTPError("some error")))
+    mock_template_download = mocker.patch("requests.get", return_value=mock_response)
+
+    mock_unzip_template_zip = mocker.patch("shutil.unpack_archive", return_value=None)
+    mock_remove_template_zip = mocker.patch("os.remove", return_value=None)
+
+    with patch("builtins.open", mock_open()) as mock_file:
+        with pytest.raises(Exception) as e:
+            init.download_and_clean(formatted_template_name, template)
+
+        assert "Failed to download the selected component" in e.value.args[0]
+        assert mock_remove_template_zip.call_count == 0
+        assert mock_unzip_template_zip.call_count == 0
+        assert mock_template_download.call_count == 1
+        assert mock_get_available_templates.call_count == 1
+        assert not mock_file.called
+
+
+def test_get_download_url_valid_template(mocker):
+    template = "template"
+    language = "language"
+    formatted_template_name = f"{template}-{language}"
+
+    mock_get_component_list_from_github = mocker.patch(
+        "greengrassTools.commands.component.list.get_component_list_from_github",
+        return_value={formatted_template_name: "template-url"},
+    )
+    url = init.get_download_url(formatted_template_name, "template")
+    assert url == "template-url"
+    assert mock_get_component_list_from_github.called
+
+
+def test_get_download_url_valid_repository(mocker):
+    repository = "repository_name"
+    mock_get_component_list_from_github = mocker.patch(
+        "greengrassTools.commands.component.list.get_component_list_from_github",
+        return_value={"repository_name": "repository-url"},
+    )
+    url = init.get_download_url(repository, "repository")
+    assert url == "repository-url"
+    assert mock_get_component_list_from_github.called
+
+
+def test_get_download_url_invalid_template(mocker):
+    template = "template-language"
+    mock_get_component_list_from_github = mocker.patch(
+        "greengrassTools.commands.component.list.get_component_list_from_github",
+        return_value={"repository_name": "repository-url"},
+    )
+    with pytest.raises(Exception) as e:
+        init.get_download_url(template, "template")
+    assert e.value.args[0] == "Could not find the component template 'template-language' in Greengrass Software Catalog."
+    assert mock_get_component_list_from_github.called
+
+
+def test_get_download_url_invalid_repository(mocker):
+    repository = "repository_name"
+    mock_get_component_list_from_github = mocker.patch(
+        "greengrassTools.commands.component.list.get_component_list_from_github",
+        return_value={"template-language": "template-url"},
+    )
+    with pytest.raises(Exception) as e:
+        init.get_download_url(repository, "repository")
+    assert e.value.args[0] == "Could not find the component repository 'repository_name' in Greengrass Software Catalog."
+    assert mock_get_component_list_from_github.called


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Initializes project with either a component template or repository from the Greengrass Software Catalog based on command args. Raise an exception as per the conflicting args rule if both of them are specified in the command at once.
- `init` command downloads archived components from their github releases. Unarchives the downloaded file in the current project directory and removes it. 
- Cannot `init` a project in a non-empty directory. 
- `init` command fails if listing the components from Greengrass Software Catalog fails.
- Commands:
   - `greegngrass-tools component init -t template_name - language language_name` - takes in both template name and language as args. 
   - `greegngrass-tools component init -r repository_name` - takes in repository name as an arg.

**Why is this change necessary:**
- Using tool, customers should be able to download necessary template or repository from the Greengrass Software Catalog
and be able to work on them with ease without having to start everything from scratch. This command helps in initializing the project with command args as needed.

**How was this change tested:**
``` 
coverage run --source=greengrassTools -m pytest -v -s tests && coverage report --show-missing --fail-under=70
```
**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.