### PR TITLE
feat(build): build component based on project configuration

### DIFF
--- a/greengrassTools/commands/component/build.py
+++ b/greengrassTools/commands/component/build.py
@@ -1,2 +1,319 @@
-def run(args):
-    print(" I build the project based on args")
+import json
+import logging
+import shutil
+import subprocess as sp
+from pathlib import Path
+
+import greengrassTools.commands.component.project_utils as project_utils
+import greengrassTools.common.consts as consts
+import greengrassTools.common.exceptions.error_messages as error_messages
+import greengrassTools.common.utils as utils
+import yaml
+
+
+def run(command_args):
+    """
+    Builds the component based on the command arguments and the project configuration. The build files
+    are created in current directory under "greengrass-build" folder.
+
+    If the project configuration specifies 'default' build command, the component build system is identified
+    based on some special files in the project. If this build system is supported by the tool, the command
+    builds the component artifacts and recipes.
+
+    If the project configuration specifies custom build command, the tool executes the command as it is.
+
+    Parameters
+    ----------
+        command_args(dict): A dictionary object that contains parsed args namespace of a command.
+
+    Returns
+    -------
+        None
+    """
+    component_build_config = project_config["component_build_config"]
+    build_system = component_build_config["build_system"]
+
+    logging.info("Building the component '{}' with the given project configuration.".format(project_config["component_name"]))
+    # Create build directories
+    create_gg_build_directories()
+
+    if build_system == "custom":
+        # Run custom command as is.
+        custom_build_command = component_build_config["custom_build_command"]
+        logging.info("Using custom build configuration to build the component.")
+        logging.info("Running the following command\n{}".format(custom_build_command))
+        sp.run(custom_build_command)
+    else:
+        logging.info(f"Using '{build_system}' build system to build the component.")
+        default_build_component()
+
+
+def create_gg_build_directories():
+    """
+    Creates "greengrass-build" directory with component artifacts and recipes sub directories.
+
+    This method removes the "greengrass-build" directory if it already exists.
+
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+        None
+    """
+    # Clean build directory if it exists already.
+    utils.clean_dir(project_config["gg_build_directory"])
+
+    logging.debug("Creating '{}' directory with artifacts and recipes.".format(consts.greengrass_build_dir))
+    # Create build artifacts and recipe directories
+    Path.mkdir(project_config["gg_build_recipes_dir"], parents=True, exist_ok=True)
+    Path.mkdir(project_config["gg_build_component_artifacts_dir"], parents=True, exist_ok=True)
+
+
+def default_build_component():
+    """
+    Builds the component artifacts and recipes based on the build system specfied in the project configuration.
+
+    Based on the artifacts specified in the recipe, the built component artifacts are copied over to greengrass
+    component artifacts build folder and the artifact uris in the recipe are updated to reflect the same.
+
+    Based on the project config file, component recipe is updated and a new recipe file is created in greengrass
+    component recipes build folder.
+
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+        None
+    """
+    try:
+        # Build the project with specified build system
+        run_build_command()
+
+        # From the recipe, copy necessary artifacts (depends on build system) to the build folder .
+        copy_artifacts_and_update_uris()
+
+        # Update recipe file with component configuration from project config file.
+        create_build_recipe_file()
+    except Exception as e:
+        raise Exception("""{}\n{}""".format(error_messages.BUILD_FAILED, e))
+
+
+def run_build_command():
+    """
+    Runs the build command based on the configuration in 'project_build_system.json' file and component project build
+    configuration.
+
+    For any build system other than 'zip', the build command obtained as a list from the
+    project_build_system.json is passed to the subprocess run command as it is.
+
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+        None
+    """
+    try:
+        build_system = project_config["component_build_config"]["build_system"]
+        build_command = supported_build_sytems[build_system]["build_command"]
+        logging.warning(
+            f"This component is identified as using '{build_system}' build system. If this is incorrect, please exit and"
+            f" specify custom build command in the '{consts.cli_project_config_file}'."
+        )
+
+        if build_system == "zip":
+            logging.info("Zipping source code files of the component.")
+            _build_system_zip()
+        else:
+            logging.info("Running the build command '{}'".format(" ".join(build_command)))
+            sp.run(build_command)
+    except Exception as e:
+        raise Exception(f"Error building the component with the given build system.\n{e}")
+
+
+def _build_system_zip():
+    """
+    Builds the component as a zip file.
+
+    Copies over necessary files by excluding certain files to a build folder identied for zip build system
+    (supported_component_builds.json has the build folder info).
+    This build folder is zipped completely as a component zip artifact.
+    Raises an exception if there's an error in the process of zippings.
+
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+        None
+    """
+    try:
+        zip_build = _get_build_folder_by_build_system()
+        utils.clean_dir(zip_build)
+
+        logging.debug("Copying over component files to the '{}' folder.".format(zip_build.name))
+        shutil.copytree(utils.current_directory, zip_build, dirs_exist_ok=True, ignore=_ignore_files_during_zip)
+
+        # Get build file name without extension. This will be used as name of the archive.
+        archive_file = utils.current_directory.name
+        logging.debug(
+            "Creating an archive named '{}.zip' in '{}' folder with the files in '{}' folder.".format(
+                archive_file, zip_build.name, zip_build.name
+            )
+        )
+        archive_file_name = Path(zip_build).joinpath(archive_file).resolve()
+        shutil.make_archive(archive_file_name, "zip", root_dir=zip_build)
+        logging.debug("Archive complete.")
+
+    except Exception as e:
+        raise Exception("""Failed to zip the component in default build mode.\n{}""".format(e))
+
+
+def _ignore_files_during_zip(path, names):
+    """
+    Creates a list of files or directories to ignore while copying a directory.
+
+    Helper function to create custom list of files/directories to ignore. Here, we exclude,
+    1. project config file -> greengrass-tools-config.json
+    2. greengrass-build directory
+    3. recipe file
+    4. tests folder
+
+    Parameters
+    ----------
+        path,names
+
+    Returns
+    -------
+        ignore_list(list): List of files or directories to ignore during zip.
+    """
+    # TODO: Identify individual files in recipe that are not same as zip and exclude them during zip.
+
+    ignore_list = [
+        consts.cli_project_config_file,
+        consts.greengrass_build_dir,
+        project_config["component_recipe_file"].name,
+        "test*",
+    ]
+    return ignore_list
+
+
+def _get_build_folder_by_build_system():
+    """
+    Returns build folder name specific to the build system. This folder contains component artifacts after the build
+    is complete.
+
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+        build_folder(Path): Path to the build folder created by component build system.
+    """
+    build_system = project_config["component_build_config"]["build_system"]
+    build_folder = supported_build_sytems[build_system]["build_folder"]
+    return Path(utils.current_directory).joinpath(*build_folder).resolve()
+
+
+def copy_artifacts_and_update_uris():
+    """
+    Copies over the build artifacts to the greengrass artifacts build folder and update URIs in the recipe.
+
+    The component artifacts created in the build process of the component are identied by the artifact URIs in
+    the recipe and copied over to the greengrass component's artifacts build folder. The parsed component
+    recipe file is also updated with the artifact URIs.
+
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+        None
+    """
+    # TODO: Case insenstive recipe keys?
+    logging.info("Copying over the build artifacts to the greengrass component artifacts build folder.")
+    logging.info("Updating artifact URIs in the recipe.")
+    parsed_component_recipe = project_config["parsed_component_recipe"]
+    gg_build_component_artifacts_dir = project_config["gg_build_component_artifacts_dir"]
+    artifact_uri = "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION"
+    if "Manifests" not in parsed_component_recipe:
+        logging.debug("No 'Manifests' key in the recipe.")
+        return
+
+    build_folder = _get_build_folder_by_build_system()
+    manifests = parsed_component_recipe["Manifests"]
+    for manifest in manifests:
+        if "Artifacts" not in manifest:
+            logging.debug("No 'Artifacts' key in the recipe manifest.")
+            continue
+        artifacts = manifest["Artifacts"]
+        for artifact in artifacts:
+            if "URI" not in artifact:
+                logging.debug("No 'URI' found in the recipe artifacts.")
+                continue
+            artifact_file = Path(artifact["URI"]).name
+
+            # If the artifact is present in build system specific build folder, copy it to greengrass artifacts build folder
+            build_files = list(build_folder.glob(artifact_file))
+            if len(build_files) == 1:
+                logging.debug(
+                    "Copying file '{}' from '{}' to '{}'.".format(
+                        artifact_file, build_folder, gg_build_component_artifacts_dir
+                    )
+                )
+                shutil.copy(build_files[0], gg_build_component_artifacts_dir)
+                logging.debug("Updating artifact URI of '{}' in the recipe file.".format(artifact_file))
+                artifact["URI"] = f"{artifact_uri}/{artifact_file}"
+            else:
+                raise Exception(
+                    f"Could not find the artifact file specified in the recipe '{artifact_file}' inside the build folder"
+                    f" '{build_folder}'."
+                )
+
+
+def create_build_recipe_file():
+    """
+    Creates a new recipe file(json or yaml) in the component recipes build directory.
+
+    This recipe is updated with the component configuration provided in the project config file.
+
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+        None
+    """
+    logging.debug(
+        "Updating component recipe with the 'component' configuration provided in '{}'.".format(consts.cli_project_config_file)
+    )
+    parsed_component_recipe = project_config["parsed_component_recipe"]
+    component_recipe_file_name = project_config["component_recipe_file"].name
+    parsed_component_recipe["ComponentName"] = project_config["component_name"]
+    parsed_component_recipe["ComponentVersion"] = project_config["component_version"]
+    parsed_component_recipe["ComponentPublisher"] = project_config["component_author"]
+    gg_build_recipe_file = Path(project_config["gg_build_recipes_dir"]).joinpath(component_recipe_file_name).resolve()
+
+    with open(gg_build_recipe_file, "w") as recipe_file:
+        try:
+            logging.info("Creating component recipe in '{}'.".format(project_config["gg_build_recipes_dir"]))
+            if component_recipe_file_name.endswith(".json"):
+                recipe_file.write(json.dumps(parsed_component_recipe, indent=4))
+            else:
+                yaml.dump(parsed_component_recipe, recipe_file)
+        except Exception as e:
+            raise Exception("""Failed to create build recipe file at '{}'.\n{}""".format(gg_build_recipe_file, e))
+
+
+project_config = project_utils.get_project_config_values()
+
+supported_build_sytems = project_utils.get_supported_component_builds()

--- a/greengrassTools/commands/component/project_utils.py
+++ b/greengrassTools/commands/component/project_utils.py
@@ -10,6 +10,26 @@ import greengrassTools.common.utils as utils
 import yaml
 
 
+def get_supported_component_builds():
+    """
+    Reads a json file from static location that contains information related to supported component build systems.
+
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+      (dict): Returns a dict object with supported component builds information.
+    """
+    supported_component_builds_file = utils.get_static_file_path(consts.project_build_system_file)
+    if supported_component_builds_file:
+        with open(supported_component_builds_file, "r") as supported_builds_file:
+            logging.debug("Identifying build systems supported by the CLI tool with default configuration.")
+            return json.loads(supported_builds_file.read())
+    return None
+
+
 def get_recipe_file():
     """
     Finds recipe file based on component name and its extension.

--- a/greengrassTools/common/exceptions/error_messages.py
+++ b/greengrassTools/common/exceptions/error_messages.py
@@ -23,3 +23,4 @@ INIT_NON_EMPTY_DIR_ERROR = (
     "Could not initialize the project as the directory is not empty. Please initialize the project in an empty directory.\nTry"
     " `greengrass-tools component init --help`"
 )
+BUILD_FAILED = "Failed to build the component with the given project configuration."

--- a/greengrassTools/static/project_build_schema.json
+++ b/greengrassTools/static/project_build_schema.json
@@ -1,0 +1,101 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "default": {},
+    "required": [
+        "maven",
+        "gradle",
+        "zip"
+    ],
+    "properties": {
+        "maven": {
+            "type": "object",
+            "required": [
+                "build_command",
+                "build_folder"
+            ],
+            "properties": {
+                "build_command": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                },
+                "build_folder": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "gradle": {
+            "type": "object",
+            "default": {},
+            "required": [
+                "build_command",
+                "build_folder"
+            ],
+            "properties": {
+                "build_command": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                },
+                "build_folder": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "zip": {
+            "type": "object",
+            "default": {},
+            "required": [
+                "build_command",
+                "build_folder"
+            ],
+            "properties": {
+                "build_command": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                },
+                "build_folder": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/greengrassTools/static/project_build_system.json
+++ b/greengrassTools/static/project_build_system.json
@@ -1,0 +1,21 @@
+{
+    "maven": {
+        "build_command": [
+            "mvn",
+            "clean",
+            "package"
+        ],
+        "build_folder":["target"]
+    },
+    "gradle": {
+        "build_command": [
+            "gradle",
+            "build"
+        ],
+        "build_folder":["build","lib"]
+    },
+    "zip": {
+        "build_command": ["zip"],
+        "build_folder":["zip-build"]
+    }
+}

--- a/tests/greengrassTools/commands/component/test_build.py
+++ b/tests/greengrassTools/commands/component/test_build.py
@@ -1,0 +1,597 @@
+from pathlib import Path
+from shutil import Error
+from unittest.mock import mock_open, patch
+
+import greengrassTools.common.utils as utils
+import pytest
+from greengrassTools.common.exceptions import error_messages
+
+json_values = {
+    "component_name": "component_name",
+    "component_build_config": {"build_system": "zip"},
+    "component_version": "1.0.0",
+    "component_author": "abc",
+    "bucket": "default",
+    "gg_build_directory": Path("/src/GDK-CLI-Internal/greengrass-build"),
+    "gg_build_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts"),
+    "gg_build_recipes_dir": Path("/src/GDK-CLI-Internal/greengrass-build/recipes"),
+    "gg_build_component_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts/component_name/1.0.0"),
+    "component_recipe_file": Path(
+        "/src/GDK-CLI-Internal/tests/greengrassTools/static/build_command/valid_component_recipe.json"
+    ),
+    "parsed_component_recipe": {
+        "RecipeFormatVersion": "2020-01-25",
+        "ComponentName": "com.example.HelloWorld",
+        "ComponentVersion": "1.0.0",
+        "ComponentDescription": "My first Greengrass component.",
+        "ComponentPublisher": "Amazon",
+        "ComponentConfiguration": {"DefaultConfiguration": {"Message": "world"}},
+        "Manifests": [
+            {
+                "Platform": {"os": "linux"},
+                "Lifecycle": {"Run": "python3 -u {artifacts:path}/hello_world.py '{configuration:/Message}'"},
+                "Artifacts": [{"URI": "s3://DOC-EXAMPLE-BUCKET/artifacts/com.example.HelloWorld/1.0.0/hello_world.py"}],
+            }
+        ],
+    },
+}
+
+
+def test_create_recipe_file_json_valid(mocker):
+    # Tests if a new recipe file is created with updated values - json
+    mock_get_parsed_config = mocker.patch(
+        "greengrassTools.commands.component.project_utils.get_project_config_values", return_value=json_values
+    )
+
+    import greengrassTools.commands.component.build as build
+
+    assert mock_get_parsed_config.call_count == 1
+    file_name = Path(json_values["gg_build_recipes_dir"]).joinpath(json_values["component_recipe_file"].name).resolve()
+    mock_json_dump = mocker.patch("json.dumps")
+    mock_yaml_dump = mocker.patch("yaml.dump")
+    with patch("builtins.open", mock_open()) as mock_file:
+        build.create_build_recipe_file()
+        mock_file.assert_any_call(file_name, "w")
+        mock_json_dump.call_count == 1
+        assert not mock_yaml_dump.called
+
+
+def test_create_recipe_file_yaml_valid(mocker):
+    # Tests if a new recipe file is created with updated values - yaml
+    # Tests if a new recipe file is created with updated values - json
+    import greengrassTools.commands.component.build as build
+
+    build.project_config["component_recipe_file"] = Path("some-yaml.yaml").resolve()
+    file_name = (
+        Path(json_values["gg_build_recipes_dir"])
+        .joinpath(build.project_config["component_recipe_file"].resolve().name)
+        .resolve()
+    )
+    mock_json_dump = mocker.patch("json.dumps")
+    mock_yaml_dump = mocker.patch("yaml.dump")
+    with patch("builtins.open", mock_open()) as mock_file:
+        build.create_build_recipe_file()
+        mock_file.assert_called_once_with(file_name, "w")
+        mock_json_dump.call_count == 1
+        assert mock_yaml_dump.called
+
+
+def test_create_recipe_file_json_invalid(mocker):
+    # Raise exception for when creating recipe failed due to invalid json
+    import greengrassTools.commands.component.build as build
+
+    build.project_config["component_recipe_file"] = Path("some-json.json").resolve()
+    file_name = Path(json_values["gg_build_recipes_dir"]).joinpath(json_values["component_recipe_file"].name).resolve()
+
+    def throw_error(*args, **kwargs):
+        if args[0] == json_values["parsed_component_recipe"]:
+            raise TypeError("I mock json error")
+
+    mock_json_dump = mocker.patch("json.dumps", side_effect=throw_error)
+    mock_yaml_dump = mocker.patch("yaml.dump")
+    with patch("builtins.open", mock_open()) as mock_file:
+        with pytest.raises(Exception) as e:
+            build.create_build_recipe_file()
+        assert "Failed to create build recipe file at" in e.value.args[0]
+        mock_file.assert_called_once_with(file_name, "w")
+        mock_json_dump.call_count == 1
+        assert not mock_yaml_dump.called
+
+
+def test_create_recipe_file_yaml_invalid(mocker):
+    # Raise exception for when creating recipe failed due to invalid yaml
+    import greengrassTools.commands.component.build as build
+
+    build.project_config["component_recipe_file"] = Path("some-yaml.yaml").resolve()
+    file_name = (
+        Path(json_values["gg_build_recipes_dir"]).joinpath(build.project_config["component_recipe_file"].name).resolve()
+    )
+
+    def throw_error(*args, **kwargs):
+        if args[0] == json_values["parsed_component_recipe"]:
+            raise TypeError("I mock yaml error")
+
+    mock_json_dump = mocker.patch("json.dumps")
+    mock_yaml_dump = mocker.patch("yaml.dump", side_effect=throw_error)
+    with patch("builtins.open", mock_open()) as mock_file:
+        with pytest.raises(Exception) as e:
+            build.create_build_recipe_file()
+        assert "Failed to create build recipe file at" in e.value.args[0]
+        mock_file.assert_called_once_with(file_name, "w")
+        mock_json_dump.call_count == 1
+        assert mock_yaml_dump.called
+
+
+def test_get_build_folder_by_build_system():
+    import greengrassTools.commands.component.build as build
+
+    path = build._get_build_folder_by_build_system()
+    assert path.resolve() == Path(utils.current_directory).joinpath(*["zip-build"]).resolve()
+
+
+def test_create_gg_build_directories(mocker):
+    mocker.patch("greengrassTools.commands.component.project_utils.get_project_config_values", return_value=json_values)
+    import greengrassTools.commands.component.build as build
+
+    mock_mkdir = mocker.patch("pathlib.Path.mkdir")
+    mock_clean = mocker.patch("greengrassTools.common.utils.clean_dir")
+    build.create_gg_build_directories()
+
+    assert mock_mkdir.call_count == 2
+    assert mock_clean.call_count == 1
+
+    mock_mkdir.assert_any_call(json_values["gg_build_recipes_dir"], parents=True, exist_ok=True)
+    mock_mkdir.assert_any_call(json_values["gg_build_component_artifacts_dir"], parents=True, exist_ok=True)
+    mock_clean.assert_called_once_with(json_values["gg_build_directory"])
+
+
+def test_run_build_command_with_error_not_zip(mocker):
+    mock_build_system_zip = mocker.patch("greengrassTools.commands.component.build._build_system_zip", return_value=None)
+    mock_subprocess_run = mocker.patch("subprocess.run", return_value=None, side_effect=Error("some error"))
+    import greengrassTools.commands.component.build as build
+
+    build.project_config["component_build_config"]["build_system"] = "maven"
+    with pytest.raises(Exception) as e:
+        build.run_build_command()
+    assert not mock_build_system_zip.called
+    assert mock_subprocess_run.called
+    assert "Error building the component with the given build system." in e.value.args[0]
+
+
+def test_run_build_command_with_error_with_zip_build(mocker):
+    mock_build_system_zip = mocker.patch(
+        "greengrassTools.commands.component.build._build_system_zip", return_value=None, side_effect=Error("some error")
+    )
+    import greengrassTools.commands.component.build as build
+
+    build.project_config["component_build_config"]["build_system"] = "zip"
+    with pytest.raises(Exception) as e:
+        build.run_build_command()
+    assert "Error building the component with the given build system." in e.value.args[0]
+    assert mock_build_system_zip.called
+
+
+def test_run_build_command_not_zip_build(mocker):
+    mock_build_system_zip = mocker.patch("greengrassTools.commands.component.build._build_system_zip", return_value=None)
+    mock_subprocess_run = mocker.patch("subprocess.run", return_value=None)
+    import greengrassTools.commands.component.build as build
+
+    build.project_config["component_build_config"]["build_system"] = "maven"
+    build.run_build_command()
+    assert not mock_build_system_zip.called
+    assert mock_subprocess_run.called
+
+
+def test_run_build_command_zip_build(mocker):
+    mock_build_system_zip = mocker.patch("greengrassTools.commands.component.build._build_system_zip", return_value=None)
+    mock_subprocess_run = mocker.patch("subprocess.run", return_value=None)
+    import greengrassTools.commands.component.build as build
+
+    build.project_config["component_build_config"]["build_system"] = "zip"
+    build.run_build_command()
+    assert not mock_subprocess_run.called
+    mock_build_system_zip.assert_called_with()
+
+
+def test_build_system_zip_valid(mocker):
+    # build_file = Path('mock-file.py').resolve()
+    zip_build_path = Path("zip-build").resolve()
+    mock_build_info = mocker.patch(
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
+    )
+    mock_clean_dir = mocker.patch("greengrassTools.common.utils.clean_dir", return_value=None)
+    mock_copytree = mocker.patch("shutil.copytree")
+    mock_subprocess_run = mocker.patch("subprocess.run", return_value=None)
+    mock_ignore_files_during_zip = mocker.patch(
+        "greengrassTools.commands.component.build._ignore_files_during_zip", return_value=[]
+    )
+    mock_make_archive = mocker.patch("shutil.make_archive")
+    import greengrassTools.commands.component.build as build
+
+    build.project_config["component_build_config"]["build_system"] = "zip"
+    build._build_system_zip()
+
+    assert not mock_subprocess_run.called
+    mock_build_info.assert_called_with()
+    mock_clean_dir.assert_called_with(zip_build_path)
+
+    curr_dir = Path(".").resolve()
+
+    mock_copytree.assert_called_with(curr_dir, zip_build_path, dirs_exist_ok=True, ignore=mock_ignore_files_during_zip)
+    assert mock_make_archive.called
+    zip_build_file = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
+    mock_make_archive.assert_called_with(zip_build_file, "zip", root_dir=zip_build_path)
+
+
+def test_ignore_files_during_zip():
+    import greengrassTools.commands.component.build as build
+
+    path = Path(".")
+    names = ["1", "2"]
+    li = build._ignore_files_during_zip(path, names)
+    assert type(li) == list
+
+
+def test_build_system_zip_error_archive(mocker):
+
+    zip_build_path = Path("zip-build").resolve()
+    mock_build_info = mocker.patch(
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
+    )
+    mock_clean_dir = mocker.patch("greengrassTools.common.utils.clean_dir", return_value=None)
+    mock_copytree = mocker.patch("shutil.copytree")
+    mock_subprocess_run = mocker.patch("subprocess.run", return_value=None)
+    mock_ignore_files_during_zip = mocker.patch(
+        "greengrassTools.commands.component.build._ignore_files_during_zip", return_value=[]
+    )
+    mock_make_archive = mocker.patch("shutil.make_archive", side_effect=Error("some error"))
+    import greengrassTools.commands.component.build as build
+
+    with pytest.raises(Exception) as e:
+        build._build_system_zip()
+
+    assert "Failed to zip the component in default build mode." in e.value.args[0]
+    assert not mock_subprocess_run.called
+    mock_build_info.assert_called_with()
+    mock_clean_dir.assert_called_with(zip_build_path)
+
+    curr_dir = Path(".").resolve()
+
+    mock_copytree.assert_called_with(curr_dir, zip_build_path, dirs_exist_ok=True, ignore=mock_ignore_files_during_zip)
+    assert mock_make_archive.called
+    zip_build_file = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
+    mock_make_archive.assert_called_with(zip_build_file, "zip", root_dir=zip_build_path)
+
+
+def test_build_system_zip_error_copytree(mocker):
+    zip_build_path = Path("zip-build").resolve()
+    mock_build_info = mocker.patch(
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
+    )
+    mock_clean_dir = mocker.patch("greengrassTools.common.utils.clean_dir", return_value=None)
+    mock_copytree = mocker.patch("shutil.copytree", side_effect=Error("some error"))
+    mock_subprocess_run = mocker.patch("subprocess.run", return_value=None)
+    mock_ignore_files_during_zip = mocker.patch(
+        "greengrassTools.commands.component.build._ignore_files_during_zip", return_value=[]
+    )
+    mock_make_archive = mocker.patch("shutil.make_archive")
+    import greengrassTools.commands.component.build as build
+
+    with pytest.raises(Exception) as e:
+        build._build_system_zip()
+
+    assert "Failed to zip the component in default build mode." in e.value.args[0]
+    assert not mock_subprocess_run.called
+    mock_build_info.assert_called_with()
+    mock_clean_dir.assert_called_with(zip_build_path)
+
+    curr_dir = Path(".").resolve()
+
+    mock_copytree.assert_called_with(curr_dir, zip_build_path, dirs_exist_ok=True, ignore=mock_ignore_files_during_zip)
+    assert not mock_make_archive.called
+
+
+def test_build_system_zip_error_get_build_folder_by_build_system(mocker):
+    zip_build_path = Path("zip-build").resolve()
+    mock_build_info = mocker.patch(
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system",
+        return_value=zip_build_path,
+        side_effect=Error("some error"),
+    )
+    mock_clean_dir = mocker.patch("greengrassTools.common.utils.clean_dir", return_value=None)
+    mock_copytree = mocker.patch("shutil.copytree")
+    mock_subprocess_run = mocker.patch("subprocess.run", return_value=None)
+    mock_ignore_files_during_zip = mocker.patch(
+        "greengrassTools.commands.component.build._ignore_files_during_zip", return_value=[]
+    )
+    mock_make_archive = mocker.patch("shutil.make_archive")
+    import greengrassTools.commands.component.build as build
+
+    with pytest.raises(Exception) as e:
+        build._build_system_zip()
+
+    assert "Failed to zip the component in default build mode." in e.value.args[0]
+    assert not mock_subprocess_run.called
+    mock_build_info.assert_called_with()
+    assert not mock_clean_dir.called
+    assert not mock_copytree.called
+    assert not mock_make_archive.called
+    assert not mock_ignore_files_during_zip.called
+
+
+def test_build_system_zip_error_clean_dir(mocker):
+    zip_build_path = Path("zip-build").resolve()
+    mock_build_info = mocker.patch(
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
+    )
+    mock_clean_dir = mocker.patch("greengrassTools.common.utils.clean_dir", return_value=None, side_effect=Error("some error"))
+    mock_copytree = mocker.patch("shutil.copytree")
+    mock_subprocess_run = mocker.patch("subprocess.run", return_value=None)
+    mock_make_archive = mocker.patch("shutil.make_archive")
+    import greengrassTools.commands.component.build as build
+
+    with pytest.raises(Exception) as e:
+        build._build_system_zip()
+
+    assert "Failed to zip the component in default build mode." in e.value.args[0]
+    assert not mock_subprocess_run.called
+    mock_build_info.assert_called_with()
+    assert mock_clean_dir.called
+    assert not mock_copytree.called
+    assert not mock_make_archive.called
+
+
+def test_copy_artifacts_and_update_uris_valid(mocker):
+    zip_build_path = Path("zip-build").resolve()
+    mock_build_info = mocker.patch(
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
+    )
+    mock_shutil_copy = mocker.patch("shutil.copy")
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=[Path(".").joinpath("hello_world.py")])
+    import greengrassTools.commands.component.build as build
+
+    build.copy_artifacts_and_update_uris()
+    assert mock_build_info.assert_called_once
+    assert mock_glob.assert_called_once
+    assert mock_shutil_copy.called
+
+
+def test_copy_artifacts_and_update_uris_recipe_uri_matches(mocker):
+    # Copy only if the uri in recipe matches the artifact in build folder
+    zip_build_path = Path("zip-build").resolve()
+    mock_build_info = mocker.patch(
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
+    )
+    mock_iter_dir_list = [Path("hello_world.py").resolve()]
+    mock_shutil_copy = mocker.patch("shutil.copy")
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=mock_iter_dir_list)
+    import greengrassTools.commands.component.build as build
+
+    build.copy_artifacts_and_update_uris()
+    assert mock_shutil_copy.called
+    assert mock_build_info.assert_called_once
+    assert mock_glob.assert_called_once
+    mock_shutil_copy.assert_called_with(Path("hello_world.py").resolve(), json_values["gg_build_component_artifacts_dir"])
+
+
+def test_copy_artifacts_and_update_uris_recipe_uri_not_matches(mocker):
+    # Do not copy if the uri in recipe doesnt match the artifact in build folder
+
+    zip_build_path = Path("zip-build").resolve()
+    mock_build_info = mocker.patch(
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
+    )
+    mock_shutil_copy = mocker.patch("shutil.copy")
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=[])
+    import greengrassTools.commands.component.build as build
+
+    with pytest.raises(Exception) as e:
+        build.copy_artifacts_and_update_uris()
+
+    assert (
+        "Could not find the artifact file specified in the recipe 'hello_world.py' inside the build folder" in e.value.args[0]
+    )
+    assert not mock_shutil_copy.called
+    assert mock_build_info.assert_called_once
+    assert mock_glob.assert_called_once
+
+
+def test_default_build_component(mocker):
+    mock_run_build_command = mocker.patch("greengrassTools.commands.component.build.run_build_command")
+    mock_copy_artifacts_and_update_uris = mocker.patch(
+        "greengrassTools.commands.component.build.copy_artifacts_and_update_uris"
+    )
+    mock_create_build_recipe_file = mocker.patch("greengrassTools.commands.component.build.create_build_recipe_file")
+    import greengrassTools.commands.component.build as build
+
+    build.default_build_component()
+    assert mock_run_build_command.assert_called_once
+    assert mock_copy_artifacts_and_update_uris.assert_called_once
+    assert mock_create_build_recipe_file.assert_called_once
+
+
+def test_default_build_component_error_run_build_command(mocker):
+    mock_run_build_command = mocker.patch(
+        "greengrassTools.commands.component.build.run_build_command", side_effect=Error("command")
+    )
+    mock_copy_artifacts_and_update_uris = mocker.patch(
+        "greengrassTools.commands.component.build.copy_artifacts_and_update_uris"
+    )
+    mock_create_build_recipe_file = mocker.patch("greengrassTools.commands.component.build.create_build_recipe_file")
+    import greengrassTools.commands.component.build as build
+
+    with pytest.raises(Exception) as e:
+        build.default_build_component()
+
+    assert "\ncommand" in e.value.args[0]
+    assert error_messages.BUILD_FAILED in e.value.args[0]
+    assert mock_run_build_command.assert_called_once
+    assert not mock_copy_artifacts_and_update_uris.called
+    assert not mock_create_build_recipe_file.called
+
+
+def test_default_build_component_error_copy_artifacts_and_update_uris(mocker):
+    mock_run_build_command = mocker.patch("greengrassTools.commands.component.build.run_build_command")
+    mock_copy_artifacts_and_update_uris = mocker.patch(
+        "greengrassTools.commands.component.build.copy_artifacts_and_update_uris", side_effect=Error("copying")
+    )
+    mock_create_build_recipe_file = mocker.patch("greengrassTools.commands.component.build.create_build_recipe_file")
+    import greengrassTools.commands.component.build as build
+
+    with pytest.raises(Exception) as e:
+        build.default_build_component()
+
+    assert "\ncopy" in e.value.args[0]
+    assert error_messages.BUILD_FAILED in e.value.args[0]
+    assert mock_run_build_command.assert_called_once
+    assert mock_copy_artifacts_and_update_uris.assert_called_once
+    assert not mock_create_build_recipe_file.called
+
+
+def test_default_build_component_error_create_build_recipe_file(mocker):
+    mock_run_build_command = mocker.patch("greengrassTools.commands.component.build.run_build_command")
+    mock_copy_artifacts_and_update_uris = mocker.patch(
+        "greengrassTools.commands.component.build.copy_artifacts_and_update_uris"
+    )
+    mock_create_build_recipe_file = mocker.patch(
+        "greengrassTools.commands.component.build.create_build_recipe_file", side_effect=Error("recipe")
+    )
+    import greengrassTools.commands.component.build as build
+
+    with pytest.raises(Exception) as e:
+        build.default_build_component()
+
+    assert "\nrecipe" in e.value.args[0]
+    assert error_messages.BUILD_FAILED in e.value.args[0]
+    assert mock_run_build_command.assert_called_once
+    assert mock_copy_artifacts_and_update_uris.assert_called_once
+    assert mock_create_build_recipe_file.assert_called_once
+
+
+def test_build_run_default(mocker):
+    mock_create_gg_build_directories = mocker.patch("greengrassTools.commands.component.build.create_gg_build_directories")
+    mock_default_build_component = mocker.patch("greengrassTools.commands.component.build.default_build_component")
+    mock_subprocess_run = mocker.patch("subprocess.run")
+    import greengrassTools.commands.component.build as build
+
+    build.run({})
+
+    assert mock_create_gg_build_directories.assert_called_once
+    assert mock_default_build_component.assert_called_once
+    assert not mock_subprocess_run.called
+
+
+def test_build_run_custom(mocker):
+    mock_create_gg_build_directories = mocker.patch("greengrassTools.commands.component.build.create_gg_build_directories")
+    mock_default_build_component = mocker.patch("greengrassTools.commands.component.build.default_build_component")
+    mock_subprocess_run = mocker.patch("subprocess.run")
+    import greengrassTools.commands.component.build as build
+
+    modify_build = build.project_config
+    modify_build["component_build_config"]["build_system"] = "custom"
+    modify_build["component_build_config"]["custom_build_command"] = ["a"]
+    build.run({})
+    assert mock_create_gg_build_directories.assert_called_once
+    assert not mock_default_build_component.called
+    assert mock_subprocess_run.called
+
+
+def test_copy_artifacts_and_update_uris_no_manifest_in_recipe(mocker):
+    # Nothing to copy if manifest file doesnt exist
+    # recipe with no manifest key
+
+    import greengrassTools.commands.component.build as build
+
+    zip_build_path = Path("zip-build").resolve()
+    mock_build_info = mocker.patch(
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
+    )
+    mock_iter_dir_list = [Path("this-recipe-uri-not-exists.sh").resolve()]
+    mock_shutil_copy = mocker.patch("shutil.copy")
+    mock_glob = mocker.patch("pathlib.Path.iterdir", return_value=mock_iter_dir_list)
+
+    modify_build = build.project_config
+    modify_build["parsed_component_recipe"] = {
+        "RecipeFormatVersion": "2020-01-25",
+        "ComponentName": "com.example.HelloWorld",
+        "ComponentVersion": "1.0.0",
+        "ComponentDescription": "My first Greengrass component.",
+        "ComponentPublisher": "Amazon",
+        "ComponentConfiguration": {"DefaultConfiguration": {"Message": "world"}},
+    }
+    build.copy_artifacts_and_update_uris()
+    assert not mock_shutil_copy.called
+    assert not mock_build_info.called
+    assert not mock_glob.called
+
+
+def test_copy_artifacts_and_update_uris_no_artifacts_in_recipe(mocker):
+    # Nothing to copy if artifacts uri in recipe manifest doesnt exist
+
+    import greengrassTools.commands.component.build as build
+
+    zip_build_path = Path("zip-build").resolve()
+    mock_build_info = mocker.patch(
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
+    )
+    mock_iter_dir_list = Path("this-recipe-uri-not-exists.sh").resolve()
+    mock_shutil_copy = mocker.patch("shutil.copy")
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=mock_iter_dir_list)
+
+    modify_build = build.project_config
+    modify_build["parsed_component_recipe"] = {
+        "RecipeFormatVersion": "2020-01-25",
+        "ComponentName": "com.example.HelloWorld",
+        "ComponentVersion": "1.0.0",
+        "ComponentDescription": "My first Greengrass component.",
+        "ComponentPublisher": "Amazon",
+        "ComponentConfiguration": {"DefaultConfiguration": {"Message": "world"}},
+        "Manifests": [
+            {
+                "Platform": {"os": "linux"},
+                "Lifecycle": {"Run": "python3 -u {artifacts:path}/hello_world.py '{configuration:/Message}'"},
+            }
+        ],
+    }
+
+    build.copy_artifacts_and_update_uris()
+    assert not mock_shutil_copy.called
+    assert mock_build_info.called
+    assert not mock_glob.called
+
+
+def test_copy_artifacts_and_update_uris_no_artifact_uri_in_recipe(mocker):
+    # Nothing to copy if manifest file doesnt exist
+    # recipe with no manifest key
+
+    import greengrassTools.commands.component.build as build
+
+    zip_build_path = Path("zip-build").resolve()
+    mock_build_info = mocker.patch(
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
+    )
+    mock_iter_dir_list = Path("this-recipe-uri-not-exists.sh").resolve()
+    mock_shutil_copy = mocker.patch("shutil.copy")
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=mock_iter_dir_list)
+
+    modify_build = build.project_config
+    modify_build["parsed_component_recipe"] = {
+        "RecipeFormatVersion": "2020-01-25",
+        "ComponentName": "com.example.HelloWorld",
+        "ComponentVersion": "1.0.0",
+        "ComponentDescription": "My first Greengrass component.",
+        "ComponentPublisher": "Amazon",
+        "ComponentConfiguration": {"DefaultConfiguration": {"Message": "world"}},
+        "Manifests": [
+            {
+                "Platform": {"os": "linux"},
+                "Lifecycle": {"Run": "python3 -u {artifacts:path}/hello_world.py '{configuration:/Message}'"},
+                "Artifacts": [{}],
+            }
+        ],
+    }
+
+    build.copy_artifacts_and_update_uris()
+    assert not mock_shutil_copy.called
+    assert mock_build_info.called
+    assert not mock_glob.called

--- a/tests/greengrassTools/commands/component/test_project_utils.py
+++ b/tests/greengrassTools/commands/component/test_project_utils.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from unittest.mock import mock_open, patch
 
 import greengrassTools.commands.component.project_utils as project_utils
 import greengrassTools.common.exceptions.error_messages as error_messages
@@ -303,3 +304,20 @@ def test_service_clients_with_sts_region(mocker):
     project_utils.create_sts_client("region")
     assert mock_boto3_client.call_count == 1
     mock_boto3_client.assert_called_once_with("sts", region_name="region")
+
+
+def test_get_supported_component_builds_not_exists(mocker):
+    mock_file_not_exists = mocker.patch("greengrassTools.common.utils.get_static_file_path", return_value=None)
+    project_utils.get_supported_component_builds()
+    assert mock_file_not_exists.called
+
+
+def test_get_supported_component_builds_exists(mocker):
+    mock_file_path = Path(".").resolve()
+    mock_file_not_exists = mocker.patch("greengrassTools.common.utils.get_static_file_path", return_value=mock_file_path)
+    mock_json_loads = mocker.patch("json.loads")
+    with patch("builtins.open", mock_open(read_data="{}")) as mock_file:
+        project_utils.get_supported_component_builds()
+        mock_file.assert_called_once_with(mock_file_path, "r")
+        assert mock_file_not_exists.called
+        assert mock_json_loads.called


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
When `greengrass-tools component build` is run form the component directory, project configuration file - `greengrass-tools-config.json` file is used to get the build configuration.

- If the `build_system` is set to `custom`, we run the `custom_build_command` provided in the project configuration file. 
- If customer sets the `build_system` key to the build_system the tool supports, we run the default build command set for each build system. 
  - CLI tool maintains a separate file for the build types it supports - `project_build_system.json`. This file is validated by the tool in integration tests(will be added) using schema file to keep the changes consistent. This file contains 
    - `build_system`s supported by the tool.
    - `build_folder` identified by the build_system. 
    -  `build_command` run  by the tool for each build system
  - After the component is build, we copy the artifact files specified in the component recipe from component build folders to `greengrass-build` component artifacts folder. We also update the artifact URIs in recipe.
  - The component recipe file is also updated with component configuration of project. (name, author, version as set in the config)
- Irrespective of the `build_system`, we create `greengrass-build` directory with `artifacts` and `recipe` sub-folders for component. 

**Why is this change necessary:**
This change helps the customers to build components in artifacts and recipes format. The source code of the component is built and relevant artifacts are identified from the recipe which will later be uploaded to s3 during publish. 

**How was this change tested:**
```
coverage run --source=greengrassTools -m pytest -v -s tests && coverage report --show-missing --fail-under=70
```
**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.