### PR TITLE
feat(publish): publish component based on project config

### DIFF
--- a/greengrassTools/commands/component/publish.py
+++ b/greengrassTools/commands/component/publish.py
@@ -1,2 +1,371 @@
+import json
+import logging
+from pathlib import Path
+
+import greengrassTools.commands.component.project_utils as project_utils
+import greengrassTools.common.exceptions.error_messages as error_messages
+import greengrassTools.common.utils as utils
+import yaml
+from botocore.exceptions import ClientError
+
+
 def run(args):
-    print(" I publish the project based on args")
+    try:
+        project_config["account_number"] = get_account_number()
+        project_config["bucket"] = "{}-{}-{}".format(
+            project_config["bucket"], project_config["region"], project_config["account_number"]
+        )
+
+        component_name = project_config["component_name"]
+        logging.info(f"Publishing the component '{component_name}' with the given project configuration.")
+        component_version = get_component_version_from_config()
+
+        logging.info("Uploading the component built artifacts to s3 bucket.")
+        upload_artifacts_s3(component_name, component_version)
+
+        logging.info(f"Updating the component recipe {component_name}-{component_version}.")
+        update_and_create_recipe_file(component_name, component_version)
+
+        logging.info(f"Creating a new greengrass component {component_name}-{component_version}")
+        create_gg_component(component_name, component_version)
+    except Exception as e:
+        logging.error("Failed to publish new version of the component '{}'".format(project_config["component_name"]))
+        raise Exception("{}\n{}".format(error_messages.PUBLISH_FAILED, e))
+
+
+def upload_artifacts_s3(component_name, component_version):
+    """
+    Uploads all the artifacts from component artifacts build folder to s3 bucket.
+
+    Raises an exception when the request is not successful.
+
+    Parameters
+    ----------
+        component_name(string): Name of the component to use in the s3 file path.
+        component_version(string): Version of the component to use in the s3 file path.
+
+    Returns
+    -------
+        None
+    """
+    try:
+        bucket = project_config["bucket"]
+        region = project_config["region"]
+        if not utils.dir_exists(project_config["gg_build_component_artifacts_dir"]):
+            logging.error("Component '{}' is not build.".format(component_name))
+            raise Exception(
+                f"Failed to publish the component '{component_name}' as it is not build.\nBuild the component"
+                " `greengrass-tools component build` before publishing it."
+            )
+        create_bucket(bucket, region)
+        build_component_artifacts = list(project_config["gg_build_component_artifacts_dir"].iterdir())
+        for artifact in build_component_artifacts:
+            s3_file_path = f"{component_name}/{component_version}/{artifact.name}"
+            logging.debug("Uploading artifact '{}' to the bucket '{}'.".format(artifact.resolve(), bucket))
+            service_clients["s3_client"].upload_file(str(artifact.resolve()), bucket, s3_file_path)
+    except Exception as e:
+        raise Exception("Error while uploading the artifacts to s3 during publish.\n{}".format(e))
+
+
+def create_bucket(bucket, region):
+    """
+    Creates a new s3 bucket for artifacts if it doesn't exist already.
+
+    Raises an exception when the request is not successful.
+
+    Parameters
+    ----------
+        bucket(string): Name of the bucket to create.
+        region(string): Region is which the bucket is created.
+
+    Returns
+    -------
+        None
+    """
+    try:
+        if region is None or region == "us-east-1":
+            service_clients["s3_client"].create_bucket(Bucket=bucket)
+        else:
+            location = {"LocationConstraint": region}
+            service_clients["s3_client"].create_bucket(Bucket=bucket, CreateBucketConfiguration=location)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "BucketAlreadyExists":
+            logging.error("Bucket already exists. Please provide a different name for the bucket in the configuration.")
+        elif e.response["Error"]["Code"] == "BucketAlreadyOwnedByYou":
+            if bucket_exists_in_same_region(bucket, region):
+                logging.info("Not creating an artifacts bucket as it already exists.")
+                return
+            logging.error("Cannot create the artifacts bucket '{}' as it is already owned by you in other region.")
+        raise Exception(e)
+    except Exception as e:
+        logging.error("Failed to create the bucket '{}' in region '{}'".format(bucket, region))
+        raise Exception(e)
+    logging.info("Successfully created the artifacts bucket '{}' in region '{}'".format(bucket, region))
+
+
+def bucket_exists_in_same_region(bucket, region):
+    """
+    Checks if region of the bucket is same as the given region.
+
+
+    Parameters
+    ----------
+        bucket(string): Name of the bucket to create.
+        region(string): Name of the region to check.
+
+    Returns
+    -------
+        bool: Returns true if the bucket region is same as the region in check. Else false.
+    """
+    try:
+        response = service_clients["s3_client"].get_bucket_location(Bucket=bucket)
+        if response["LocationConstraint"] == region:
+            return True
+        return False
+    except Exception as e:
+        raise Exception("Unable to fetch the location of the bucket '{}'.\n{}".format(bucket, e))
+
+
+def create_gg_component(c_name, c_version):
+    """
+    Creates a greengrassv2 private component using its recipe.
+
+    Raises an exception if the recipe is invalid or the request is not successful.
+
+    Parameters
+    ----------
+        c_name(string): Name of the component to create.
+        c_version(string): Version of the component to create.
+
+    Returns
+    -------
+        None
+    """
+    publish_recipe_file = project_config["publish_recipe_file"]
+    with open(publish_recipe_file) as f:
+        try:
+            service_clients["greengrass_client"].create_component_version(inlineRecipe=f.read())
+        except Exception as e:
+            logging.error("Failed to create the component using the recipe at '{}'.".format(publish_recipe_file))
+            raise Exception("Creating private version '{}' of the component '{}' failed.\n{}".format(c_version, c_name, e))
+        logging.info("Created private version '{}' of the component in the account.'{}'.".format(c_version, c_name))
+
+
+def get_next_version():
+    """
+    Calculates the next patch version of the component if it already exists in the account. Otherwise, it uses 1.0.0 as
+    the fallback version.
+
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+        version(string): Version of the component to create.
+    """
+    fallback_version = "1.0.0"
+    logging.debug("Fetching private components from the account.")
+    try:
+        c_name = project_config["component_name"]
+        region = project_config["region"]
+        account_num = project_config["account_number"]
+        c_latest_version = get_latest_component_version(c_name, region, account_num)
+        if not c_latest_version:
+            logging.info(
+                "No private version of the component '{}' exist in the account. Using '{}' as the next version to create."
+                .format(c_name, fallback_version)
+            )
+            return fallback_version
+        logging.debug("Found latest version '{}' of the component '{}' in the account.".format(c_latest_version, c_name))
+        semver_alphanumeric = c_latest_version.split("-")
+        semver_numeric = semver_alphanumeric[0].split(".")
+        major = semver_numeric[0]
+        minor = semver_numeric[1]
+        patch = semver_numeric[2]
+        next_patch_version = int(patch) + 1
+        next_version = "{}.{}.{}".format(major, minor, str(next_patch_version))
+        logging.info("Using '{}' as the next version of the component '{}' to create.".format(next_version, c_name))
+        return next_version
+    except Exception as e:
+        raise Exception("Failed to calculate the next version of the component during publish.\n{}".format(e))
+
+
+def get_account_number():
+    """
+    Uses STS client to get account number from the credentials provided using AWS cli.
+
+    Raises an exception when the request is unsuccessful.
+
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+        account_num: Returns account number.
+    """
+    try:
+        caller_identity_response = service_clients["sts_client"].get_caller_identity()
+        account_num = caller_identity_response["Account"]
+        logging.debug("Identified account number as '{}'.".format(account_num))
+        return account_num
+    except Exception as e:
+        raise Exception("Error while fetching account number from credentials.\n{}".format(e))
+
+
+def get_latest_component_version(component_name, region, account_num):
+    """
+    Gets highest version of the component from the sorted order of its versions from an account in a region.
+
+    Makes a boto3 request with greengrass service client to list all versions of a component in an account.
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+        version(string): Highest version of the component if it exists already. Else returns 1.0.0.
+    """
+
+    try:
+        comp_list_response = service_clients["greengrass_client"].list_component_versions(
+            arn="arn:aws:greengrass:{}:{}:components:{}".format(region, account_num, component_name)
+        )
+        component_versions = comp_list_response["componentVersions"]
+        if not component_versions:
+            return None
+        return component_versions[0]["componentVersion"]
+    except Exception as e:
+        raise Exception(
+            "Error while getting the component versions of '{}' in '{}' from the account '{}' during publish.\n{}".format(
+                component_name, region, account_num, e
+            )
+        )
+
+
+def get_component_version_from_config():
+    """
+    Returns component version based on the project configuration.
+
+    If component version is set to LATEST, patch version of the latest component version is calculated. Otherwise,
+    exact version specified will be used as the component version during creation of the component.
+
+    Parameters
+    ----------
+        None
+
+    Returns
+    -------
+        None
+    """
+    try:
+        component_name = project_config["component_name"]
+        if project_config["component_version"] == "LATEST":
+            logging.debug(
+                "Component version set to 'LATEST' in the config file. Calculating next version of the component '{}'".format(
+                    project_config["component_name"]
+                )
+            )
+            return get_next_version()
+        logging.info("Using the version set for the component '{}' in the config file.".format(component_name))
+        return project_config["component_version"]
+    except Exception as e:
+        logging.error("Failed to calculate the version of component '{}' based on the configuration.".format(component_name))
+        raise (e)
+
+
+def update_and_create_recipe_file(component_name, component_version):
+    """
+    Updates recipe with the component version calculated and artifact URIs of the artifacts. This updated recipe is
+    used to create a new publish recipe file in build recipes directory.
+
+    Parameters
+    ----------
+        component_name(string): Name of the component. This is also used in the name of the recipe file.
+        component_version(string): Version of the component calculated based on the configuration.
+
+    Returns
+    -------
+        None
+    """
+    logging.debug("Updating artifact URIs in the recipe...")
+    build_recipe = Path(project_config["gg_build_recipes_dir"]).joinpath(project_config["component_recipe_file"].name)
+    parsed_component_recipe = project_utils.parse_recipe_file(build_recipe)
+    if "ComponentName" in parsed_component_recipe:
+        if parsed_component_recipe["ComponentName"] != component_name:
+            logging.error("Component '{}' is not build.".format(parsed_component_recipe["ComponentName"]))
+            raise Exception(
+                "Failed to publish the component '{}' as it is not build.\nBuild the component `greengrass-tools component"
+                " build` before publishing it.".format(parsed_component_recipe["ComponentName"])
+            )
+    gg_build_component_artifacts = project_config["gg_build_component_artifacts_dir"]
+    bucket = project_config["bucket"]
+    artifact_uri = f"s3://{bucket}/{component_name}/{component_version}"
+
+    if "Manifests" not in parsed_component_recipe:
+        logging.debug("No 'Manifests' key in the recipe.")
+        return
+    for manifest in parsed_component_recipe["Manifests"]:
+        if "Artifacts" not in manifest:
+            logging.debug("No 'Artifacts' key in the recipe manifest.")
+            continue
+        for artifact in manifest["Artifacts"]:
+            if "URI" not in artifact:
+                logging.debug("No 'URI' found in the recipe artifacts.")
+                continue
+            artifact_file = Path(artifact["URI"]).name
+
+            # For artifact in build component artifacts folder, update its URI
+            build_artifact_files = list(gg_build_component_artifacts.glob(artifact_file))
+            if len(build_artifact_files) == 1:
+                logging.debug("Updating artifact URI of '{}' in the recipe file.".format(artifact_file))
+                artifact["URI"] = f"{artifact_uri}/{artifact_file}"
+            else:
+                raise Exception(
+                    f"Could not find the artifact file specified in the recipe '{artifact_file}' inside the build folder"
+                    f" '{gg_build_component_artifacts}'."
+                )
+
+    # Update the version of the component in the recipe
+    parsed_component_recipe["ComponentVersion"] = component_version
+    create_publish_recipe_file(component_name, component_version, parsed_component_recipe)
+
+
+def create_publish_recipe_file(component_name, component_version, parsed_component_recipe):
+    """
+    Creates a new recipe file(json or yaml) with anme `<component_name>-<component_version>.extension` in the component
+    recipes build directory.
+
+    This recipe is updated with the component version calculated and artifact URIs of the artifacts.
+
+    Parameters
+    ----------
+        component_name(string): Name of the component. This is also used in the name of the recipe file.
+        component_version(string): Version of the component calculated based on the configuration.
+        parsed_component_recipe(dict): Updated publish recipe with component version and s3 artifact uris
+    Returns
+    -------
+        None
+    """
+    ext = project_config["component_recipe_file"].name.split(".")[-1]  # json or yaml
+    publish_recipe_file_name = f"{component_name}-{component_version}.{ext}"  # Eg. HelloWorld-1.0.0.yaml
+    publish_recipe_file = Path(project_config["gg_build_recipes_dir"]).joinpath(publish_recipe_file_name).resolve()
+    project_config["publish_recipe_file"] = publish_recipe_file
+    with open(publish_recipe_file, "w") as prf:
+        try:
+            logging.debug(
+                "Creating component recipe '{}' in '{}'.".format(
+                    publish_recipe_file_name, project_config["gg_build_recipes_dir"]
+                )
+            )
+            if publish_recipe_file_name.endswith(".json"):
+                prf.write(json.dumps(parsed_component_recipe, indent=4))
+            else:
+                yaml.dump(parsed_component_recipe, prf)
+        except Exception as e:
+            raise Exception("""Failed to create publish recipe file at '{}'.\n{}""".format(publish_recipe_file, e))
+
+
+project_config = project_utils.get_project_config_values()
+service_clients = project_utils.get_service_clients(project_config["region"])

--- a/greengrassTools/common/exceptions/error_messages.py
+++ b/greengrassTools/common/exceptions/error_messages.py
@@ -24,3 +24,4 @@ INIT_NON_EMPTY_DIR_ERROR = (
     " `greengrass-tools component init --help`"
 )
 BUILD_FAILED = "Failed to build the component with the given project configuration."
+PUBLISH_FAILED = "Failed to publish new version of component with the given configuration."

--- a/tests/greengrassTools/commands/component/test_publish.py
+++ b/tests/greengrassTools/commands/component/test_publish.py
@@ -1,0 +1,736 @@
+from pathlib import Path
+from unittest import mock
+
+import boto3
+import pytest
+from greengrassTools.common.exceptions import error_messages
+from urllib3.exceptions import HTTPError
+
+json_values = {
+    "component_name": "component_name",
+    "component_config": {
+        "author": "abc",
+        "version": "1.0.0",
+        "build": {"build_system": "zip"},
+        "publish": {"bucket": "default"},
+    },
+    "component_version": "1.0.0",
+    "component_author": "abc",
+    "bucket": "default",
+    "region": "default",
+    "gg_build_directory": Path("/src/GDK-CLI-Internal/greengrass-build"),
+    "gg_build_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts"),
+    "gg_build_recipes_dir": Path("/src/GDK-CLI-Internal/greengrass-build/recipes"),
+    "gg_build_component_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts/component_name/1.0.0"),
+    "component_recipe_file": Path("/src/GDK-CLI-Internal/tests/greengrassTools/static/build_command/recipe.json"),
+    "parsed_component_recipe": {
+        "RecipeFormatVersion": "2020-01-25",
+        "ComponentName": "com.example.HelloWorld",
+        "ComponentVersion": "1.0.0",
+        "ComponentDescription": "My first Greengrass component.",
+        "ComponentPublisher": "Amazon",
+        "ComponentConfiguration": {"DefaultConfiguration": {"Message": "world"}},
+        "Manifests": [
+            {
+                "Platform": {"os": "linux"},
+                "Lifecycle": {"Run": "python3 -u {artifacts:path}/hello_world.py '{configuration:/Message}'"},
+                "Artifacts": [{"URI": "s3://DOC-EXAMPLE-BUCKET/artifacts/com.example.HelloWorld/1.0.0/hello_world.py"}],
+            }
+        ],
+    },
+    "artifact_uri": "s3://default/component_name/1.0.0",
+}
+
+with mock.patch(
+    "greengrassTools.commands.component.project_utils.get_project_config_values", return_value=json_values
+) as mock_method:
+    mock_client = mock.patch("boto3.client", return_value=None)
+    mock.patch("greengrassTools.commands.component.project_utils.get_service_clients", return_value={})
+    import greengrassTools.commands.component.publish as publish
+
+
+def test_create_publish_recipe_file_json(mocker):
+    component_name = "component_name"
+    component_version = "1.0.0"
+    parsed_recipe_file = {"componentName": component_name, "componentVersion": component_version}
+
+    file_name = Path(json_values["gg_build_recipes_dir"]).joinpath("component_name-1.0.0.json").resolve()
+    mock_json_dump = mocker.patch("json.dumps")
+    mock_yaml_dump = mocker.patch("yaml.dump")
+    with mock.patch("builtins.open", mock.mock_open()) as mock_file:
+        publish.create_publish_recipe_file(component_name, component_version, parsed_recipe_file)
+        mock_file.assert_any_call(file_name, "w")
+        mock_json_dump.call_count == 1
+        assert not mock_yaml_dump.called
+    assert "publish_recipe_file" in publish.project_config
+
+
+def test_create_publish_recipe_file_yaml(mocker):
+    component_name = "component_name"
+    component_version = "1.0.0"
+    parsed_recipe_file = {"componentName": component_name, "componentVersion": component_version}
+    publish.project_config["component_recipe_file"] = Path("some-yaml.yaml").resolve()
+    file_name = Path(json_values["gg_build_recipes_dir"]).joinpath("component_name-1.0.0.yaml").resolve()
+    mock_json_dump = mocker.patch("json.dumps")
+    mock_yaml_dump = mocker.patch("yaml.dump")
+    with mock.patch("builtins.open", mock.mock_open()) as mock_file:
+        publish.create_publish_recipe_file(component_name, component_version, parsed_recipe_file)
+        mock_file.assert_any_call(file_name, "w")
+        mock_yaml_dump.call_count == 1
+        assert not mock_json_dump.called
+    assert "publish_recipe_file" in publish.project_config
+
+
+def test_create_recipe_file_json_invalid(mocker):
+    # Raise exception for when creating recipe failed due to invalid json
+    component_name = "component_name"
+    component_version = "1.0.0"
+    parsed_recipe_file = {"componentName": component_name, "componentVersion": component_version}
+    publish.project_config["component_recipe_file"] = Path("some-json.json").resolve()
+    file_name = Path(json_values["gg_build_recipes_dir"]).joinpath("component_name-1.0.0.json").resolve()
+
+    def throw_error(*args, **kwargs):
+        if args[0] == parsed_recipe_file:
+            raise TypeError("I mock json error")
+
+    mock_json_dump = mocker.patch("json.dumps", side_effect=throw_error)
+    mock_yaml_dump = mocker.patch("yaml.dump")
+    with mock.patch("builtins.open", mock.mock_open()) as mock_file:
+        with pytest.raises(Exception) as e:
+            publish.create_publish_recipe_file(component_name, component_version, parsed_recipe_file)
+        assert "Failed to create publish recipe file at" in e.value.args[0]
+        mock_file.assert_called_once_with(file_name, "w")
+        mock_json_dump.call_count == 1
+        assert not mock_yaml_dump.called
+    assert "publish_recipe_file" in publish.project_config
+
+
+def test_create_recipe_file_yaml_invalid(mocker):
+    # Raise exception for when creating recipe failed due to invalid yaml
+    component_name = "component_name"
+    component_version = "1.0.0"
+    parsed_recipe_file = {"componentName": component_name, "componentVersion": component_version}
+    publish.project_config["component_recipe_file"] = Path("some-yaml.yaml").resolve()
+    file_name = Path(json_values["gg_build_recipes_dir"]).joinpath("component_name-1.0.0.yaml").resolve()
+
+    def throw_error(*args, **kwargs):
+        if args[0] == parsed_recipe_file:
+            raise TypeError("I mock yaml error")
+
+    mock_json_dump = mocker.patch("json.dumps")
+    mock_yaml_dump = mocker.patch("yaml.dump", side_effect=throw_error)
+    with mock.patch("builtins.open", mock.mock_open()) as mock_file:
+        with pytest.raises(Exception) as e:
+            publish.create_publish_recipe_file(component_name, component_version, parsed_recipe_file)
+        assert "Failed to create publish recipe file at" in e.value.args[0]
+        mock_file.assert_called_once_with(file_name, "w")
+        mock_json_dump.call_count == 1
+        assert mock_yaml_dump.called
+    assert "publish_recipe_file" in publish.project_config
+
+
+def test_update_and_create_recipe_file_no_manifests(mocker):
+    mocker.patch("greengrassTools.commands.component.project_utils.parse_recipe_file", return_value={})
+    mock_create_publish_recipe = mocker.patch(
+        "greengrassTools.commands.component.publish.create_publish_recipe_file", return_value=None
+    )
+
+    component_name = "component_name"
+    component_version = "1.0.0"
+    publish.update_and_create_recipe_file(component_name, component_version)
+    assert not mock_create_publish_recipe.called  # No 'Manifests' in recipe
+
+
+def test_update_and_create_recipe_file_manifests_build(mocker):
+    mocker.patch(
+        "greengrassTools.commands.component.project_utils.parse_recipe_file",
+        return_value=json_values["parsed_component_recipe"],
+    )
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=[Path("hello_world.py")])
+    mock_create_publish_recipe = mocker.patch(
+        "greengrassTools.commands.component.publish.create_publish_recipe_file", return_value=None
+    )
+
+    component_name = "com.example.HelloWorld"
+    component_version = "1.0.0"
+    publish.update_and_create_recipe_file(component_name, component_version)
+    publish_component_recipe = json_values["parsed_component_recipe"]
+    assert mock_glob.call_count == 1
+    assert mock_create_publish_recipe.call_count == 1
+    mock_create_publish_recipe.assert_any_call(component_name, component_version, publish_component_recipe)
+    assert publish_component_recipe["ComponentVersion"] == component_version
+    assert (
+        publish_component_recipe["Manifests"][0]["Artifacts"][0]["URI"]
+        == f"s3://default/{component_name}/{component_version}/hello_world.py"
+    )
+
+
+def test_update_and_create_recipe_file_manifests_not_build(mocker):
+    mocker.patch(
+        "greengrassTools.commands.component.project_utils.parse_recipe_file",
+        return_value=json_values["parsed_component_recipe"],
+    )
+    mock_create_publish_recipe = mocker.patch(
+        "greengrassTools.commands.component.publish.create_publish_recipe_file", return_value=None
+    )
+
+    component_name = "component_name"
+    component_version = "1.0.0"
+
+    with pytest.raises(Exception) as e:
+        publish.update_and_create_recipe_file(component_name, component_version)
+    assert (
+        "as it is not build.\nBuild the component `greengrass-tools component build` before publishing it." in e.value.args[0]
+    )
+    assert mock_create_publish_recipe.call_count == 0
+
+
+def test_update_and_create_recipe_file_uri_not_matches(mocker):
+    mocker.patch(
+        "greengrassTools.commands.component.project_utils.parse_recipe_file",
+        return_value=json_values["parsed_component_recipe"],
+    )
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=[Path("hello_world.py")])
+    mock_create_publish_recipe = mocker.patch(
+        "greengrassTools.commands.component.publish.create_publish_recipe_file", return_value=None
+    )
+
+    component_name = "com.example.HelloWorld"
+    component_version = "1.0.0"
+    publish.update_and_create_recipe_file(component_name, component_version)
+    publish_component_recipe = json_values["parsed_component_recipe"]
+    assert mock_glob.call_count == 1
+    assert mock_create_publish_recipe.call_count == 1
+    mock_create_publish_recipe.assert_any_call(component_name, component_version, publish_component_recipe)
+    assert publish_component_recipe["ComponentVersion"] == component_version
+
+
+def test_update_and_create_recipe_file_artifact_file_not_exists(mocker):
+    mocker.patch(
+        "greengrassTools.commands.component.project_utils.parse_recipe_file",
+        return_value=json_values["parsed_component_recipe"],
+    )
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=[])
+    mock_create_publish_recipe = mocker.patch(
+        "greengrassTools.commands.component.publish.create_publish_recipe_file", return_value=None
+    )
+
+    component_name = "com.example.HelloWorld"
+    component_version = "1.0.0"
+    with pytest.raises(Exception) as e:
+        publish.update_and_create_recipe_file(component_name, component_version)
+    assert (
+        "Could not find the artifact file specified in the recipe 'hello_world.py' inside the build folder" in e.value.args[0]
+    )
+    assert mock_glob.call_count == 1
+    assert not mock_create_publish_recipe.called
+
+
+def test_update_and_create_recipe_file_no_artifacts(mocker):
+    no_artifacts_key = {
+        "RecipeFormatVersion": "2020-01-25",
+        "ComponentName": "com.example.HelloWorld",
+        "ComponentVersion": "1.0.0",
+        "ComponentDescription": "My first Greengrass component.",
+        "ComponentPublisher": "Amazon",
+        "ComponentConfiguration": {"DefaultConfiguration": {"Message": "world"}},
+        "Manifests": [
+            {
+                "Platform": {"os": "linux"},
+                "Lifecycle": {"Run": "python3 -u {artifacts:path}/hello_world.py '{configuration:/Message}'"},
+            }
+        ],
+    }
+    mocker.patch("greengrassTools.commands.component.project_utils.parse_recipe_file", return_value=no_artifacts_key)
+    mock_create_publish_recipe = mocker.patch(
+        "greengrassTools.commands.component.publish.create_publish_recipe_file", return_value=None
+    )
+
+    component_name = "com.example.HelloWorld"
+    component_version = "1.0.0"
+    publish.update_and_create_recipe_file(component_name, component_version)
+    assert mock_create_publish_recipe.call_count == 1
+    mock_create_publish_recipe.assert_any_call(component_name, component_version, no_artifacts_key)
+    assert no_artifacts_key["ComponentVersion"] == component_version
+
+
+def test_update_and_create_recipe_file_no_artifacts_uri(mocker):
+    no_artifacts_uri_key = {
+        "RecipeFormatVersion": "2020-01-25",
+        "ComponentName": "com.example.HelloWorld",
+        "ComponentVersion": "1.0.0",
+        "ComponentDescription": "My first Greengrass component.",
+        "ComponentPublisher": "Amazon",
+        "ComponentConfiguration": {"DefaultConfiguration": {"Message": "world"}},
+        "Manifests": [
+            {
+                "Platform": {"os": "linux"},
+                "Lifecycle": {"Run": "python3 -u {artifacts:path}/hello_world.py '{configuration:/Message}'"},
+                "Artifacts": [{}],
+            }
+        ],
+    }
+    mocker.patch("greengrassTools.commands.component.project_utils.parse_recipe_file", return_value=no_artifacts_uri_key)
+    mock_create_publish_recipe = mocker.patch(
+        "greengrassTools.commands.component.publish.create_publish_recipe_file", return_value=None
+    )
+
+    component_name = "com.example.HelloWorld"
+    component_version = "1.0.0"
+    publish.update_and_create_recipe_file(component_name, component_version)
+    assert mock_create_publish_recipe.call_count == 1
+    mock_create_publish_recipe.assert_any_call(component_name, component_version, no_artifacts_uri_key)
+    assert no_artifacts_uri_key["ComponentVersion"] == component_version
+
+
+def test_get_component_version_from_config(mocker):
+    mock_get_next_version = mocker.patch("greengrassTools.commands.component.publish.get_next_version", return_value="")
+    version = publish.get_component_version_from_config()
+    assert version == json_values["component_version"]
+    assert not mock_get_next_version.called
+
+
+def test_get_component_version_from_config_latest(mocker):
+    publish.project_config = {
+        "component_name": "component_name",
+        "component_version": "LATEST",
+        "component_author": "abc",
+        "bucket": "default",
+        "region": "default",
+    }
+    mock_get_next_version = mocker.patch("greengrassTools.commands.component.publish.get_next_version", return_value="1.0.1")
+    version = publish.get_component_version_from_config()
+    assert version == mock_get_next_version.return_value
+    assert mock_get_next_version.called
+
+
+def test_get_component_version_from_config_exception(mocker):
+    mock_get_next_version = mocker.patch(
+        "greengrassTools.commands.component.publish.get_next_version", return_value="", side_effect=HTTPError("some error")
+    )
+    with pytest.raises(Exception) as e:
+        publish.get_component_version_from_config()
+        assert mock_get_next_version.call_count == 1
+    assert e.value.args[0] == "some error"
+
+
+def test_get_next_version_component_not_exists(mocker):
+    publish.project_config["account_number"] = "1234"
+    mock_get_latest_component_version = mocker.patch(
+        "greengrassTools.commands.component.publish.get_latest_component_version", return_value=None
+    )
+    version = publish.get_next_version()
+    assert version == "1.0.0"  # Fallback version
+    assert mock_get_latest_component_version.call_count == 1
+    mock_get_latest_component_version.assert_any_call("component_name", "default", "1234")
+
+
+def test_get_next_version_component_already_exists(mocker):
+    mock_get_latest_component_version = mocker.patch(
+        "greengrassTools.commands.component.publish.get_latest_component_version", return_value="1.0.6"
+    )
+
+    version = publish.get_next_version()
+    assert version == "1.0.7"
+    assert mock_get_latest_component_version.call_count == 1
+
+
+def test_get_next_version_component_already_exists_semver(mocker):
+    mock_get_latest_component_version = mocker.patch(
+        "greengrassTools.commands.component.publish.get_latest_component_version", return_value="1.0.6-x-y-z"
+    )
+    version = publish.get_next_version()
+    assert version == "1.0.7"
+    assert mock_get_latest_component_version.call_count == 1
+
+
+def test_get_next_version_component_exception(mocker):
+    publish.project_config["account_number"] = "1234"
+    mock_get_latest_component_version = mocker.patch(
+        "greengrassTools.commands.component.publish.get_latest_component_version", side_effect=HTTPError("some error")
+    )
+    with pytest.raises(Exception) as e:
+        publish.get_next_version()
+    assert mock_get_latest_component_version.call_count == 1
+    assert e.value.args[0] == "Failed to calculate the next version of the component during publish.\nsome error"
+
+
+def test_get_latest_component_version(mocker):
+    publish.project_config["account_number"] = "1234"
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"greengrass_client": mock_client}
+    response = {"componentVersions": [{"componentVersion": "1.0.4"}, {"componentVersion": "1.0.1"}]}
+    mock_get_latest_component_version = mocker.patch("boto3.client.list_component_versions", return_value=response)
+    li = publish.get_latest_component_version("c_name", "region", "1234")
+    assert mock_get_latest_component_version.call_count == 1
+    assert li == "1.0.4"
+
+
+def test_get_latest_component_version_no_components(mocker):
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"greengrass_client": mock_client}
+    mock_get_latest_component_version = mocker.patch(
+        "boto3.client.list_component_versions", return_value={"componentVersions": []}
+    )
+    li = publish.get_latest_component_version("c_name", "region", "1234")
+    assert mock_get_latest_component_version.call_count == 1
+    assert not li
+
+
+def test_get_latest_component_version_exception(mocker):
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"greengrass_client": mock_client}
+    mock_get_latest_component_version = mocker.patch(
+        "boto3.client.list_component_versions", side_effect=HTTPError("listing error")
+    )
+    with pytest.raises(Exception) as e:
+        publish.get_latest_component_version("c_name", "region", "1234")
+    assert mock_get_latest_component_version.call_count == 1
+    assert (
+        e.value.args[0]
+        == "Error while getting the component versions of 'c_name' in 'region' from the account '1234' during"
+        " publish.\nlisting error"
+    )
+
+
+def test_create_gg_component(mocker):
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"greengrass_client": mock_client}
+    mock_create_component = mocker.patch("boto3.client.create_component_version", return_value=None)
+    publish.project_config["publish_recipe_file"] = Path("some-recipe.yaml")
+    component_name = "component_name"
+    component_version = "1.0.0"
+
+    with mock.patch("builtins.open", mock.mock_open()) as mock_file:
+        publish.create_gg_component(component_name, component_version)
+        mock_file.assert_any_call(publish.project_config["publish_recipe_file"])
+        assert mock_create_component.call_count == 1
+
+
+def test_create_gg_component_exception(mocker):
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"greengrass_client": mock_client}
+    mock_create_component = mocker.patch(
+        "boto3.client.create_component_version", return_value=None, side_effect=HTTPError("error")
+    )
+    publish.project_config["publish_recipe_file"] = Path("some-recipe.yaml")
+    component_name = "component_name"
+    component_version = "1.0.0"
+
+    with mock.patch("builtins.open", mock.mock_open()) as mock_file:
+        with pytest.raises(Exception) as e:
+            publish.create_gg_component(component_name, component_version)
+        assert "Creating private version '1.0.0' of the component 'component_name' failed." in e.value.args[0]
+        mock_file.assert_any_call(publish.project_config["publish_recipe_file"])
+        assert mock_create_component.call_count == 1
+
+
+def test_create_bucket_exists(mocker):
+    bucket = "test-bucket"
+    region = "region"
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"s3_client": mock_client}
+    response = {"Buckets": [{"Name": "test-bucket"}]}
+    mock_create_bucket = mocker.patch("boto3.client.create_bucket", return_value=response)
+    publish.create_bucket(bucket, region)
+    assert mock_create_bucket.called
+
+
+def test_create_bucket_exception(mocker):
+    bucket = "test-bucket"
+    region = "region"
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"s3_client": mock_client}
+    response = {"Buckets": [{"Name": "test-bucket"}]}
+    mock_create_bucket = mocker.patch("boto3.client.create_bucket", return_value=response, side_effect=HTTPError("some error"))
+    with pytest.raises(Exception) as e:
+        publish.create_bucket(bucket, region)
+    assert mock_create_bucket.call_count == 1
+    assert type(e.value.args[0]) == HTTPError
+
+
+def test_upload_artifacts_no_artifacts_not_build(mocker):
+    publish.project_config = json_values
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"s3_client": mock_client}
+    response = {"Buckets": [{"Name": "test-bucket"}]}
+    mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=[])
+    mock_create_bucket = mocker.patch("boto3.client.create_bucket", return_value=response)
+    mock_upload_file = mocker.patch("boto3.client.upload_file", return_value=response)
+    mock_dir_exists = mocker.patch("greengrassTools.common.utils.dir_exists", return_value=False)
+    with pytest.raises(Exception) as e:
+        publish.upload_artifacts_s3("name", "version")
+    assert (
+        "as it is not build.\nBuild the component `greengrass-tools component build` before publishing it." in e.value.args[0]
+    )
+    assert mock_dir_exists.call_count == 1
+    assert mock_iter_dir.call_count == 0
+    assert mock_create_bucket.call_count == 0
+    assert not mock_upload_file.called
+
+
+def test_upload_artifacts_no_artifacts(mocker):
+    publish.project_config = json_values
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"s3_client": mock_client}
+    response = {"Buckets": [{"Name": "test-bucket"}]}
+    mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=[])
+    mock_create_bucket = mocker.patch("boto3.client.create_bucket", return_value=response)
+    mock_upload_file = mocker.patch("boto3.client.upload_file", return_value=response)
+    mock_dir_exists = mocker.patch("greengrassTools.common.utils.dir_exists", return_value=True)
+    publish.upload_artifacts_s3("name", "version")
+    assert mock_iter_dir.call_count == 1
+    assert mock_create_bucket.call_count == 1
+    assert not mock_upload_file.called
+    assert mock_dir_exists.call_count == 1
+
+
+def test_upload_artifacts(mocker):
+    publish.project_config = json_values
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"s3_client": mock_client}
+    mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=[Path("hello.py")])
+    mock_create_bucket = mocker.patch("boto3.client.create_bucket", return_value=None)
+    mock_upload_file = mocker.patch("boto3.client.upload_file", return_value=None)
+    mock_dir_exists = mocker.patch("greengrassTools.common.utils.dir_exists", return_value=True)
+    publish.upload_artifacts_s3("name", "1.0.0")
+    assert mock_dir_exists.call_count == 1
+    assert mock_iter_dir.call_count == 1
+    assert mock_create_bucket.call_count == 1
+    assert mock_upload_file.call_count == 1
+    s3_file_path = "name/1.0.0/hello.py"
+    mock_upload_file.assert_any_call(str(Path("hello.py").resolve()), json_values["bucket"], s3_file_path)
+
+
+def test_upload_artifacts_region_us_east_1(mocker):
+    publish.project_config = json_values
+    publish.project_config["region"] = "us-east-1"
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"s3_client": mock_client}
+    mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=[Path("hello.py")])
+    mock_create_bucket = mocker.patch("boto3.client.create_bucket", return_value=None)
+    mock_upload_file = mocker.patch("boto3.client.upload_file", return_value=None)
+    mock_dir_exists = mocker.patch("greengrassTools.common.utils.dir_exists", return_value=True)
+    publish.upload_artifacts_s3("name", "1.0.0")
+    assert mock_dir_exists.call_count == 1
+    assert mock_iter_dir.call_count == 1
+    assert mock_create_bucket.call_count == 1
+    assert mock_upload_file.call_count == 1
+    s3_file_path = "name/1.0.0/hello.py"
+    mock_upload_file.assert_any_call(str(Path("hello.py").resolve()), json_values["bucket"], s3_file_path)
+
+
+def test_upload_artifacts_exception(mocker):
+    publish.project_config = json_values
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"s3_client": mock_client}
+    mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=[Path("hello.py")])
+    mock_create_bucket = mocker.patch("boto3.client.create_bucket", return_value=None)
+    mock_dir_exists = mocker.patch("greengrassTools.common.utils.dir_exists", return_value=True)
+    mock_upload_file = mocker.patch("boto3.client.upload_file", return_value=None, side_effect=HTTPError("some error"))
+    with pytest.raises(Exception) as e:
+        publish.upload_artifacts_s3("name", "1.0.0")
+    assert "some error" in e.value.args[0]
+    assert mock_dir_exists.call_count == 1
+    assert mock_iter_dir.call_count == 1
+    assert mock_create_bucket.call_count == 1
+    assert mock_upload_file.call_count == 1
+    s3_file_path = "name/1.0.0/hello.py"
+    mock_upload_file.assert_any_call(str(Path("hello.py").resolve()), json_values["bucket"], s3_file_path)
+
+
+def test_publish_run(mocker):
+    mock_get_account_num = mocker.patch("greengrassTools.commands.component.publish.get_account_number", return_value="1234")
+    mock_get_component_version_from_config = mocker.patch(
+        "greengrassTools.commands.component.publish.get_component_version_from_config", return_value=None
+    )
+    mock_upload_artifacts_s3 = mocker.patch(
+        "greengrassTools.commands.component.publish.upload_artifacts_s3", return_value=None
+    )
+    mock_update_and_create_recipe_file = mocker.patch(
+        "greengrassTools.commands.component.publish.update_and_create_recipe_file", return_value=None
+    )
+    mock_create_gg_component = mocker.patch(
+        "greengrassTools.commands.component.publish.create_gg_component", return_value=None
+    )
+    publish.run({})
+    assert publish.project_config["account_number"] == "1234"
+    assert publish.project_config["bucket"] == "default-us-east-1-1234"
+    assert mock_get_account_num.call_count == 1
+    assert mock_get_component_version_from_config.call_count == 1
+    assert mock_upload_artifacts_s3.call_count == 1
+    assert mock_update_and_create_recipe_file.call_count == 1
+    assert mock_create_gg_component.call_count == 1
+
+
+def test_publish_run_exception(mocker):
+    mock_get_account_num = mocker.patch("greengrassTools.commands.component.publish.get_account_number", return_value="1234")
+    mock_get_component_version_from_config = mocker.patch(
+        "greengrassTools.commands.component.publish.get_component_version_from_config",
+        return_value=None,
+        side_effect=HTTPError("some error"),
+    )
+    mock_upload_artifacts_s3 = mocker.patch(
+        "greengrassTools.commands.component.publish.upload_artifacts_s3", return_value=None
+    )
+    mock_update_and_create_recipe_file = mocker.patch(
+        "greengrassTools.commands.component.publish.update_and_create_recipe_file", return_value=None
+    )
+    mock_create_gg_component = mocker.patch(
+        "greengrassTools.commands.component.publish.create_gg_component", return_value=None
+    )
+    publish.project_config["bucket"] = "default"
+    with pytest.raises(Exception) as e:
+        publish.run({})
+    assert publish.project_config["account_number"] == "1234"
+    assert publish.project_config["bucket"] == "default-us-east-1-1234"
+    assert e.value.args[0] == "{}\n{}".format(error_messages.PUBLISH_FAILED, "some error")
+    assert mock_get_account_num.call_count == 1
+    assert mock_get_component_version_from_config.call_count == 1
+    assert mock_upload_artifacts_s3.call_count == 0
+    assert mock_update_and_create_recipe_file.call_count == 0
+    assert mock_create_gg_component.call_count == 0
+
+
+def test_create_bucket_exception_bucket_exists(mocker):
+    bucket = "test-bucket"
+    region = "region"
+
+    def throw_err(*args, **kwargs):
+        ex = boto3.client("s3").exceptions.BucketAlreadyExists(
+            {"Error": {"Code": "BucketAlreadyExists", "Message": "fake message"}}, "CreateBucket"
+        )
+        raise ex
+
+    mock_client = mocker.patch("boto3.client", return_value=boto3.client("s3"))
+    mock_create_bucket = mocker.patch("boto3.client.create_bucket", side_effect=throw_err)
+    publish.service_clients = {"s3_client": mock_client}
+
+    with pytest.raises(Exception) as e:
+        publish.create_bucket(bucket, region)
+    assert mock_create_bucket.call_count == 1
+    assert "An error occurred (BucketAlreadyExists) when calling the CreateBucket operation: fake message" == str(
+        e.value.args[0]
+    )
+
+
+def test_create_bucket_exception_bucket_owned(mocker):
+    bucket = "test-bucket"
+    region = "region"
+
+    def throw_err(*args, **kwargs):
+        ex = boto3.client("s3").exceptions.BucketAlreadyOwnedByYou(
+            {"Error": {"Code": "BucketAlreadyOwnedByYou", "Message": "fake message"}}, "CreateBucket"
+        )
+        raise ex
+
+    mock_client = mocker.patch("boto3.client", return_value=boto3.client("s3"))
+    mock_create_bucket = mocker.patch("boto3.client.create_bucket", side_effect=throw_err)
+    publish.service_clients = {"s3_client": mock_client}
+
+    with pytest.raises(Exception) as e:
+        publish.create_bucket(bucket, region)
+    assert mock_create_bucket.call_count == 1
+    assert "An error occurred (BucketAlreadyOwnedByYou) when calling the CreateBucket operation: fake message" == str(
+        e.value.args[0]
+    )
+
+
+def test_create_bucket_exception_bucket_owned_not_in_region(mocker):
+    bucket = "test-bucket"
+    region = "region"
+    mock_check_in_same_region = mocker.patch(
+        "greengrassTools.commands.component.publish.bucket_exists_in_same_region", return_value=False
+    )
+
+    def throw_err(*args, **kwargs):
+        ex = boto3.client("s3").exceptions.BucketAlreadyOwnedByYou(
+            {"Error": {"Code": "BucketAlreadyOwnedByYou", "Message": "fake message"}}, "CreateBucket"
+        )
+        raise ex
+
+    mock_client = mocker.patch("boto3.client", return_value=boto3.client("s3"))
+    mock_create_bucket = mocker.patch("boto3.client.create_bucket", side_effect=throw_err)
+    publish.service_clients = {"s3_client": mock_client}
+
+    with pytest.raises(Exception) as e:
+        publish.create_bucket(bucket, region)
+    assert mock_create_bucket.call_count == 1
+    assert mock_check_in_same_region.called
+    print(e.value.args[0])
+    assert "An error occurred (BucketAlreadyOwnedByYou) when calling the CreateBucket operation: fake message" == str(
+        e.value.args[0]
+    )
+
+
+def test_create_bucket_exception_bucket_owned_in_region(mocker):
+    bucket = "test-bucket"
+    region = "region"
+    mock_check_in_same_region = mocker.patch(
+        "greengrassTools.commands.component.publish.bucket_exists_in_same_region", return_value=True
+    )
+
+    def throw_err(*args, **kwargs):
+        ex = boto3.client("s3").exceptions.BucketAlreadyOwnedByYou(
+            {"Error": {"Code": "BucketAlreadyOwnedByYou", "Message": "fake message"}}, "CreateBucket"
+        )
+        raise ex
+
+    mock_client = mocker.patch("boto3.client", return_value=boto3.client("s3"))
+    mock_create_bucket = mocker.patch("boto3.client.create_bucket", side_effect=throw_err)
+    publish.service_clients = {"s3_client": mock_client}
+
+    publish.create_bucket(bucket, region)
+    assert mock_create_bucket.call_count == 1
+    assert mock_check_in_same_region.called
+
+
+def test_get_account_number_exception(mocker):
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"sts_client": mock_client}
+    mock_get_caller_identity = mocker.patch("boto3.client.get_caller_identity", return_value=None)
+    with pytest.raises(Exception) as e:
+        publish.get_account_number()
+    assert mock_get_caller_identity.call_count == 1
+    assert "Error while fetching account number from credentials." in e.value.args[0]
+
+
+def test_get_account_number(mocker):
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"sts_client": mock_client}
+    mock_get_caller_identity = mocker.patch("boto3.client.get_caller_identity", return_value={"Account": 124})
+    num = publish.get_account_number()
+    assert mock_get_caller_identity.call_count == 1
+    assert num == 124
+
+
+def test_bucket_exists_in_same_region_exists(mocker):
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"s3_client": mock_client}
+    mock_get_bucket_location = mocker.patch(
+        "boto3.client.get_bucket_location", return_value={"LocationConstraint": "us-east-1"}
+    )
+    exists = publish.bucket_exists_in_same_region("bucket", "us-east-1")
+    assert mock_get_bucket_location.call_count == 1
+    assert exists
+
+
+def test_bucket_exists_in_same_region_not_exists(mocker):
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"s3_client": mock_client}
+    mock_get_bucket_location = mocker.patch(
+        "boto3.client.get_bucket_location", return_value={"LocationConstraint": "us-west-2"}
+    )
+    exists = publish.bucket_exists_in_same_region("bucket", "us-east-1")
+    assert mock_get_bucket_location.call_count == 1
+    assert not exists
+
+
+def test_bucket_exists_in_same_region_exception(mocker):
+    mock_client = mocker.patch("boto3.client", return_value=None)
+    publish.service_clients = {"s3_client": mock_client}
+    mock_get_bucket_location = mocker.patch("boto3.client.get_bucket_location", side_effect=HTTPError("some eror"))
+    with pytest.raises(Exception) as e:
+        publish.bucket_exists_in_same_region("bucket", "us-east-1")
+    assert "Unable to fetch the location of the bucket" in e.value.args[0]
+    assert mock_get_bucket_location.call_count == 1


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Use boto3 to make AWS cloud api calls. Gets credentials from aws cli.
- Gets component version based on the config. If set to `latest` in config, calculate the next patch version. Else use the hard-coded version from config.
- Reads bucket name and region from config. Creates bucket if it doesn't exist. Raises an exception in all other cases.
- Uploads artifacts in component artifacts builder folder to s3 where s3 folder path contains component-name/component-version/artifact-name. Raise an exception to build first if component artifacts builder folder doesn't exist.
- Updates component build recipe with calculated version and s3 URIs. Raises an exception to build first if component build recipe doesn't exist. Name of the new recipe will be <component-name>- <component-verion><.json/.yaml>
- Creates a greengrass component with updated recipe and uploaded artifacts in the region specified.
- Command: `greengrass-tools component publish`
  

**Why is this change necessary:**
Using this tool, customers can publish the component with the built artifacts and recipe. This command uploads artifacts to S3 and updates recipes with s3 uris and creates a component in the region specified. 

**How was this change tested:**

```
coverage run --source=greengrassTools -m pytest -v -s tests && coverage report --show-missing --fail-under=70
```
**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.