### PR TITLE
test(integ): add integration tests on parser and static files

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,8 +39,7 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Testing CLI (Runs both unit and integration tests)
         run: |
-          coverage run --source=greengrassTools -m pytest -v -s tests && coverage report --show-missing --fail-under=70      
-        
+          coverage run --source=greengrassTools -m pytest -v -s . && coverage report --show-missing --fail-under=70              
   build-on-non-windows:
     runs-on: ${{ matrix.config.os }}
     strategy:
@@ -68,4 +67,4 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Testing CLI (Runs both unit and integration tests)
         run: |
-          coverage run --source=greengrassTools -m pytest -v -s tests && coverage report --show-missing --fail-under=70      
+          coverage run --source=greengrassTools -m pytest -v -s . && coverage report --show-missing --fail-under=70      

--- a/integration_tests/greengrassTools/common/test_integ_build_config.py
+++ b/integration_tests/greengrassTools/common/test_integ_build_config.py
@@ -1,0 +1,20 @@
+import json
+
+import greengrassTools.common.consts as consts
+import greengrassTools.common.utils as utils
+import jsonschema
+
+
+def test_builds_config_with_schema():
+    # Integ test for the existence of command model file even before building the cli tool.
+    builds_file = utils.get_static_file_path(consts.project_build_system_file)
+    project_build_schema = utils.get_static_file_path(consts.project_build_schema_file)
+    assert project_build_schema.exists()
+    assert builds_file.exists()
+
+    with open(builds_file, "r") as f:
+        data = json.loads(f.read())
+
+    with open(project_build_schema, "r") as schemaFile:
+        schema = json.loads(schemaFile.read())
+    jsonschema.validate(data, schema)

--- a/integration_tests/greengrassTools/common/test_integ_configuration.py
+++ b/integration_tests/greengrassTools/common/test_integ_configuration.py
@@ -1,0 +1,9 @@
+import greengrassTools.common.consts as consts
+import greengrassTools.common.utils as utils
+
+
+def test_get_static_file_path_cli_schema():
+    # Integ test for the existence of command model file even before building the cli tool.
+    model_file_path = utils.get_static_file_path(consts.config_schema_file)
+    assert model_file_path is not None
+    assert model_file_path.exists()

--- a/integration_tests/greengrassTools/common/test_integ_model_actions.py
+++ b/integration_tests/greengrassTools/common/test_integ_model_actions.py
@@ -1,0 +1,24 @@
+import greengrassTools.common.consts as consts
+import greengrassTools.common.model_actions as model_actions
+import greengrassTools.common.utils as utils
+
+
+def test_is_valid_model():
+    # Integ test for validating the cli model with arguments, commands and sub-commands.
+    model = model_actions.get_validated_model()
+    assert model_actions.is_valid_model(model, consts.cli_tool_name)
+
+
+def test_get_static_file_path_cli_model():
+    # Integ test for the existence of command model file even before building the cli tool.
+    model_file_path = utils.get_static_file_path(consts.cli_model_file)
+    assert model_file_path is not None
+    assert model_file_path.exists()
+
+
+def test_model_existence(mocker):
+    # Integ test for validating the cli model type
+    command_model = model_actions.get_validated_model()
+    assert type(command_model) == dict  # Command model obtained should always be a dictionary
+    assert len(command_model) > 0  # Command model is never empty
+    assert consts.cli_tool_name in command_model  # Command model should contain the name of CLI as a key

--- a/integration_tests/greengrassTools/common/test_integ_parse_args_actions.py
+++ b/integration_tests/greengrassTools/common/test_integ_parse_args_actions.py
@@ -1,0 +1,45 @@
+import argparse
+import logging
+
+import greengrassTools.commands.methods as methods
+import greengrassTools.common.parse_args_actions as actions
+import pytest
+
+
+def test_run_command_with_valid_namespace_without_debug(mocker):
+    # Integ test that appropriate action is called only once with valid command namespace.
+    args_namespace = argparse.Namespace(
+        component="init", init=None, lang="python", template="name", **{"greengrass-tools": "component"}
+    )
+    spy_component_build = mocker.spy(methods, "_greengrass_tools_component_build")
+    spy_call_action_by_name = mocker.spy(actions, "call_action_by_name")
+    spy_get_method_from_command = mocker.spy(actions, "get_method_from_command")
+    spy_logger = mocker.spy(logging, "basicConfig")
+    mock_component_init = mocker.patch("greengrassTools.commands.methods._greengrass_tools_component_init", return_value=None)
+    actions.run_command(args_namespace)
+    assert mock_component_init.call_count == 1
+    assert spy_component_build.call_count == 0
+    assert spy_call_action_by_name.call_count == 1
+    assert spy_get_method_from_command.call_count == 3  # Recursively called for three times
+    assert spy_logger.call_count == 0
+
+
+def test_run_command_with_valid_debug_enabled(mocker):
+    # Integ test that appropriate action is called only once with valid command namespace.
+    args_namespace = argparse.Namespace(
+        component="init", init=None, lang="python", template="name", **{"greengrass-tools": "component"}, debug=True
+    )
+    spy_component_build = mocker.spy(methods, "_greengrass_tools_component_build")
+    spy_call_action_by_name = mocker.spy(actions, "call_action_by_name")
+    spy_get_method_from_command = mocker.spy(actions, "get_method_from_command")
+    mock_component_init = mocker.patch("greengrassTools.commands.methods._greengrass_tools_component_init", return_value=None)
+
+    spy_logging_ = mocker.spy(logging.getLogger(), "setLevel")
+    actions.run_command(args_namespace)
+    assert mock_component_init.call_count == 1
+    assert spy_component_build.call_count == 0
+    assert spy_call_action_by_name.call_count == 1
+    assert spy_get_method_from_command.call_count == 3  # Recursively called for three times
+    spy_logging_.assert_called_once_with(logging.DEBUG)
+    with pytest.raises(AssertionError):
+        spy_logging_.assert_called_once_with(logging.WARN)

--- a/integration_tests/greengrassTools/components/test_integ_project_utils.py
+++ b/integration_tests/greengrassTools/components/test_integ_project_utils.py
@@ -1,0 +1,22 @@
+import greengrassTools.commands.component.project_utils as project_utils
+import greengrassTools.common.consts as consts
+import greengrassTools.common.utils as utils
+
+
+def test_get_static_file_path_supported_builds():
+    # Integ test for the existence of supported build file even before building the cli tool.
+    model_file_path = utils.get_static_file_path(consts.project_build_system_file)
+    assert model_file_path is not None
+    assert model_file_path.exists()
+
+
+def test_get_supported_component_builds():
+    # Integ test for the correctly parsing the  supported builds json file as dict
+    supported_component_builds = project_utils.get_supported_component_builds()
+    if supported_component_builds:
+        assert type(supported_component_builds) == dict
+        assert len(supported_component_builds) > 0
+        for k, v in supported_component_builds.items():
+            assert "build_folder" in v
+            assert "build_command" in v
+            assert type(v) == dict

--- a/integration_tests/greengrassTools/test_integ_CLIParser.py
+++ b/integration_tests/greengrassTools/test_integ_CLIParser.py
@@ -1,0 +1,32 @@
+import greengrassTools.CLIParser as CLIParser
+import greengrassTools.common.parse_args_actions as parse_args_actions
+
+
+def test_main_parse_args_init(mocker):
+    mock_component_init = mocker.patch("greengrassTools.commands.component.component.init", return_value=None)
+    parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "init", "-d"]))
+    assert mock_component_init.called
+
+
+def test_main_parse_args_case_insenstive_language(mocker):
+    mocker.patch("greengrassTools.commands.component.component.init", return_value=None)
+    x = CLIParser.cli_parser.parse_args(["component", "init", "-l", "PYTHON", "-d"])
+    assert x.language == "python"
+
+
+def test_main_parse_args_build(mocker):
+    mock_component_build = mocker.patch("greengrassTools.commands.component.component.build", return_value=None)
+    parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build", "-d"]))
+    assert mock_component_build.called
+
+
+def test_main_parse_args_publish(mocker):
+    mock_component_publish = mocker.patch("greengrassTools.commands.component.component.publish", return_value=None)
+    parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "publish", "-d"]))
+    assert mock_component_publish.called
+
+
+def test_main_parse_args_list(mocker):
+    mock_component_list = mocker.patch("greengrassTools.commands.component.component.list", return_value=None)
+    parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "list", "-d"]))
+    assert mock_component_list.called


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add integration tests to : 
- File ops
  - Check if build system file and its schema exists. 
  - Check if the cli model file  is present and valid to build the cli tool with commands and arguments. 
  - Check if the project configuration schema file exists to check project config 
- Parser
 - Check if the parser calls the right methods upon command execution. 
 - Checks if debug works as expected.
 
Update GitHub workflow to identify integration tests folder. 

**Why is this change necessary:**

To validate the tool and existence of certain files and their schema. 

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [x] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.