### PR TITLE
fix(build): create zip file outside of archiving folder

### DIFF
--- a/greengrassTools/commands/component/build.py
+++ b/greengrassTools/commands/component/build.py
@@ -155,20 +155,20 @@ def _build_system_zip():
     """
     try:
         zip_build = _get_build_folder_by_build_system()
+        artifacts_zip_build = Path(zip_build).joinpath(utils.current_directory.name).resolve()
         utils.clean_dir(zip_build)
-
-        logging.debug("Copying over component files to the '{}' folder.".format(zip_build.name))
-        shutil.copytree(utils.current_directory, zip_build, dirs_exist_ok=True, ignore=_ignore_files_during_zip)
+        logging.debug("Copying over component files to the '{}' folder.".format(artifacts_zip_build.name))
+        shutil.copytree(utils.current_directory, artifacts_zip_build, dirs_exist_ok=True, ignore=_ignore_files_during_zip)
 
         # Get build file name without extension. This will be used as name of the archive.
         archive_file = utils.current_directory.name
         logging.debug(
             "Creating an archive named '{}.zip' in '{}' folder with the files in '{}' folder.".format(
-                archive_file, zip_build.name, zip_build.name
+                archive_file, zip_build.name, artifacts_zip_build.name
             )
         )
         archive_file_name = Path(zip_build).joinpath(archive_file).resolve()
-        shutil.make_archive(archive_file_name, "zip", root_dir=zip_build)
+        shutil.make_archive(archive_file_name, "zip", root_dir=artifacts_zip_build)
         logging.debug("Archive complete.")
 
     except Exception as e:

--- a/tests/greengrassTools/commands/component/test_build.py
+++ b/tests/greengrassTools/commands/component/test_build.py
@@ -196,6 +196,7 @@ def test_run_build_command_zip_build(mocker):
 def test_build_system_zip_valid(mocker):
     # build_file = Path('mock-file.py').resolve()
     zip_build_path = Path("zip-build").resolve()
+    zip_artifacts_path = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
     mock_build_info = mocker.patch(
         "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
     )
@@ -217,10 +218,10 @@ def test_build_system_zip_valid(mocker):
 
     curr_dir = Path(".").resolve()
 
-    mock_copytree.assert_called_with(curr_dir, zip_build_path, dirs_exist_ok=True, ignore=mock_ignore_files_during_zip)
+    mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, dirs_exist_ok=True, ignore=mock_ignore_files_during_zip)
     assert mock_make_archive.called
     zip_build_file = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
-    mock_make_archive.assert_called_with(zip_build_file, "zip", root_dir=zip_build_path)
+    mock_make_archive.assert_called_with(zip_build_file, "zip", root_dir=zip_artifacts_path)
 
 
 def test_ignore_files_during_zip():
@@ -235,6 +236,8 @@ def test_ignore_files_during_zip():
 def test_build_system_zip_error_archive(mocker):
 
     zip_build_path = Path("zip-build").resolve()
+    zip_artifacts_path = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
+
     mock_build_info = mocker.patch(
         "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
     )
@@ -257,14 +260,16 @@ def test_build_system_zip_error_archive(mocker):
 
     curr_dir = Path(".").resolve()
 
-    mock_copytree.assert_called_with(curr_dir, zip_build_path, dirs_exist_ok=True, ignore=mock_ignore_files_during_zip)
+    mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, dirs_exist_ok=True, ignore=mock_ignore_files_during_zip)
     assert mock_make_archive.called
     zip_build_file = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
-    mock_make_archive.assert_called_with(zip_build_file, "zip", root_dir=zip_build_path)
+    mock_make_archive.assert_called_with(zip_build_file, "zip", root_dir=zip_artifacts_path)
 
 
 def test_build_system_zip_error_copytree(mocker):
     zip_build_path = Path("zip-build").resolve()
+    zip_artifacts_path = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
+
     mock_build_info = mocker.patch(
         "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
     )
@@ -287,7 +292,7 @@ def test_build_system_zip_error_copytree(mocker):
 
     curr_dir = Path(".").resolve()
 
-    mock_copytree.assert_called_with(curr_dir, zip_build_path, dirs_exist_ok=True, ignore=mock_ignore_files_during_zip)
+    mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, dirs_exist_ok=True, ignore=mock_ignore_files_during_zip)
     assert not mock_make_archive.called
 
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Creating an archive file inside of the archiving folder is recursively creating the archive files. 
i.e in a case where archiving folder is `zip-build` and name of the archive file is `abc.zip`, the unarchived contents of abc.zip (created this way) are

> -- contents of `zip-build` (expected)
> -- `abc.zip` (recursive- unzipping abc.zip contains one more abc.zip in it and so on..)
 
To fix this, we create a new folder inside `zip-build` with the name of curr_dir and copy the files to zip to it.  An archive file is then created in `zip-build` folder with the contents of` zip-build/curr_dir_name`
 
**Why is this change necessary:**
Fix incorrect archiving of files in zip build system. 

**How was this change tested:**
Manual testing and fixed tests.
`coverage run --source=greengrassTools -m pytest -v -s . && coverage report --show-missing --fail-under=70`

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.