### PR TITLE
refactor(list): raise an exception for invalid args

### DIFF
--- a/greengrassTools/commands/component/list.py
+++ b/greengrassTools/commands/component/list.py
@@ -11,11 +11,14 @@ def run(command_args):
         li = get_component_list_from_github(consts.templates_list_url)
         logging.info("Found '{}' component templates to display.".format(len(li)))
         display_list(li)
+        return
     elif "repository" in command_args and command_args["repository"]:
         logging.info("Listing all the available component repositories from Greengrass Software Catalog.")
         li = get_component_list_from_github(consts.repository_list_url)
         logging.info("Found '{}' component repositories to display.".format(len(li)))
         display_list(li)
+        return
+    raise Exception(error_messages.LIST_WITH_INVALID_ARGS)
 
 
 def get_component_list_from_github(url):

--- a/greengrassTools/common/exceptions/error_messages.py
+++ b/greengrassTools/common/exceptions/error_messages.py
@@ -1,3 +1,4 @@
+# FILE
 CONFIG_FILE_NOT_EXISTS = (
     "Config file doesn't exist. Please initialize the project using a template or a repository before using greengrass-tools"
     " commands."
@@ -8,20 +9,36 @@ PROJECT_RECIPE_FILE_NOT_FOUND = (
 )
 PROJECT_CONFIG_FILE_INVALID = "Project configuration file '{}' is invalid. Please correct its format and try again. Error: {} "
 CLI_MODEL_FILE_NOT_EXISTS = "Model validation failed. CLI model file doesn't exist."
+
+# CLI MODEL
 INVALID_CLI_MODEL = "CLI model is invalid. Please provide a valid model to create the CLI parser."
-LISTING_COMPONENTS_FAILED = "Failed to list the available components from GitHub. Please try again after sometime."
+
+# LIST COMMAND
+LISTING_COMPONENTS_FAILED = (
+    "Failed to list the available components from Greengrass Software Catalog. Please try again after sometime."
+)
+LIST_WITH_INVALID_ARGS = (
+    "Could not list the components as the command arguments are invalid. Please supply either `--template` or `--repository`"
+    " as an argument to the list command.\nTry `greengrass-tools component list --help`"
+)
+
+# INIT COMMAND
 INIT_FAILS_DURING_COMPONENT_DOWNLOAD = "Failed to download the selected component {{}}. Please try again after sometime."
 INIT_WITH_INVALID_ARGS = (
     "Could not initialize the project as the arguments passed are invalid. Please initialize the project with correct"
-    " args.\nTry `greengrass-tools component init --help`"
+    " arguments.\nTry `greengrass-tools component init --help`"
 )
 INIT_WITH_CONFLICTING_ARGS = (
-    "Could not initialize the project as the command args are conflicting. Please initialize the project with correct"
-    " args.\nTry `greengrass-tools component init --help` "
+    "Could not initialize the project as the command arguments are conflicting. Please initialize the project with correct"
+    " arguments.\nTry `greengrass-tools component init --help` "
 )
 INIT_NON_EMPTY_DIR_ERROR = (
     "Could not initialize the project as the directory is not empty. Please initialize the project in an empty directory.\nTry"
     " `greengrass-tools component init --help`"
 )
+
+# BUILD COMMAND
 BUILD_FAILED = "Failed to build the component with the given project configuration."
+
+# PUBLISH COMMAND
 PUBLISH_FAILED = "Failed to publish new version of component with the given configuration."

--- a/integration_tests/greengrassTools/components/test_integ_list.py
+++ b/integration_tests/greengrassTools/components/test_integ_list.py
@@ -1,0 +1,10 @@
+import greengrassTools.CLIParser as CLIParser
+import greengrassTools.common.exceptions.error_messages as error_messages
+import greengrassTools.common.parse_args_actions as parse_args_actions
+import pytest
+
+
+def test_list_run():
+    with pytest.raises(Exception) as e:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "list", "-d"]))
+    assert e.value.args[0] == error_messages.LIST_WITH_INVALID_ARGS

--- a/integration_tests/greengrassTools/test_integ_CLIParser.py
+++ b/integration_tests/greengrassTools/test_integ_CLIParser.py
@@ -28,5 +28,6 @@ def test_main_parse_args_publish(mocker):
 
 def test_main_parse_args_list(mocker):
     mock_component_list = mocker.patch("greengrassTools.commands.component.component.list", return_value=None)
-    parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "list", "-d"]))
+    args = CLIParser.cli_parser.parse_args(["component", "list", "--template", "-d"])
+    parse_args_actions.run_command(args)
     assert mock_component_list.called

--- a/tests/greengrassTools/commands/component/test_list.py
+++ b/tests/greengrassTools/commands/component/test_list.py
@@ -59,3 +59,15 @@ def test_run_repository(mocker):
     list.run({"repository": True})
     mock_get_component_list_from_github.assert_any_call(consts.repository_list_url)
     assert mock_display_list.call_count == 1
+
+
+def test_run_none(mocker):
+    mock_get_component_list_from_github = mocker.patch(
+        "greengrassTools.commands.component.list.get_component_list_from_github", return_value=[]
+    )
+    mock_display_list = mocker.patch("greengrassTools.commands.component.list.display_list", return_value=None)
+    with pytest.raises(Exception) as e:
+        list.run({})
+    assert e.value.args[0] == error_messages.LIST_WITH_INVALID_ARGS
+    assert mock_display_list.call_count == 0
+    assert mock_get_component_list_from_github.call_count == 0


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Raise an exception if the command args of list are incomplete or invalid. User has to supply either of --template or --repository args. 


**Why is this change necessary:**
Without this change user sees that the command is successful but with no output as it did not list any of the components. 
This change mandates that either of the args, --template and --repository is provided in the command. 

**How was this change tested:**
`coverage run --source=greengrassTools -m pytest -v -s . && coverage report --show-missing --fail-under=70`
**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [x] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.