### PR TITLE
fix(build): fix gradle build folder & custom command schema

### DIFF
--- a/greengrassTools/commands/component/build.py
+++ b/greengrassTools/commands/component/build.py
@@ -16,11 +16,11 @@ def run(command_args):
     Builds the component based on the command arguments and the project configuration. The build files
     are created in current directory under "greengrass-build" folder.
 
-    If the project configuration specifies 'default' build command, the component build system is identified
-    based on some special files in the project. If this build system is supported by the tool, the command
-    builds the component artifacts and recipes.
+    If this build system specified in the project configuration is supported by the tool, the command
+    builds the component artifacts and recipes based on the build system.
 
-    If the project configuration specifies custom build command, the tool executes the command as it is.
+    If the project configuration specifies custom build system with a custom build command, then the tool executes
+    the command as it is.
 
     Parameters
     ----------

--- a/greengrassTools/static/config_schema.json
+++ b/greengrassTools/static/config_schema.json
@@ -30,8 +30,12 @@
                             "type": "object",
                             "properties": {
                                 "custom_build_command": {
-                                    "type": "array",
-                                    "minItems": 1
+                                    "type": [
+                                        "array",
+                                        "string"
+                                    ],
+                                    "minItems": 1,
+                                    "minLength": 1
                                 },
                                 "build_system": {
                                     "type": "string",

--- a/greengrassTools/static/project_build_system.json
+++ b/greengrassTools/static/project_build_system.json
@@ -5,17 +5,26 @@
             "clean",
             "package"
         ],
-        "build_folder":["target"]
+        "build_folder": [
+            "target"
+        ]
     },
     "gradle": {
         "build_command": [
             "gradle",
             "build"
         ],
-        "build_folder":["build","lib"]
+        "build_folder": [
+            "build",
+            "libs"
+        ]
     },
     "zip": {
-        "build_command": ["zip"],
-        "build_folder":["zip-build"]
+        "build_command": [
+            "zip"
+        ],
+        "build_folder": [
+            "zip-build"
+        ]
     }
 }

--- a/tests/greengrassTools/common/test_configuration.py
+++ b/tests/greengrassTools/common/test_configuration.py
@@ -36,29 +36,31 @@ def test_get_configuration_valid_component_config_found(mocker):
         "invalid_version_config.json",
         "invalid_multiple_components.json",
         "invalid_build_command.json",
+        "invalid_build_command_string.json",
+        "invalid_build_command_array.json",
     ],
 )
 def test_get_configuration_invalid_config_file(mocker, file_name):
-    mock__get_project_config_file = mocker.patch(
+    mock_get_project_config_file = mocker.patch(
         "greengrassTools.common.configuration._get_project_config_file",
         return_value=Path(".").joinpath("tests/greengrassTools/static").joinpath(file_name).resolve(),
     )
 
     with pytest.raises(Exception) as err:
         config.get_configuration()
-    assert mock__get_project_config_file.called
+    assert mock_get_project_config_file.called
     assert "Please correct its format and try again." in err.value.args[0]
 
 
 @pytest.mark.parametrize("file_name", ["valid_build_command.json"])
 def test_get_configuration_config_file(mocker, file_name):
-    mock__get_project_config_file = mocker.patch(
+    mock_get_project_config_file = mocker.patch(
         "greengrassTools.common.configuration._get_project_config_file",
         return_value=Path(".").joinpath("tests/greengrassTools/static").joinpath(file_name).resolve(),
     )
 
     config.get_configuration()
-    assert mock__get_project_config_file.called
+    assert mock_get_project_config_file.called
 
 
 def test_validate_configuration_schema_not_exists(mocker):

--- a/tests/greengrassTools/static/invalid_build_command_array.json
+++ b/tests/greengrassTools/static/invalid_build_command_array.json
@@ -1,0 +1,17 @@
+{
+    "component": {
+        "1": {
+            "author": "abc",
+            "version": "1.0.0",
+            "build": {
+                "build_system": "custom",
+                "custom_build_command": []
+            },
+            "publish": {
+                "bucket": "default",
+                "region": "some-region"
+            }
+        }
+    },
+    "tools_version": "1.0.0"
+}

--- a/tests/greengrassTools/static/invalid_build_command_string.json
+++ b/tests/greengrassTools/static/invalid_build_command_string.json
@@ -1,0 +1,17 @@
+{
+    "component": {
+        "1": {
+            "author": "abc",
+            "version": "1.0.0",
+            "build": {
+                "build_system": "custom",
+                "custom_build_command": ""
+            },
+            "publish": {
+                "bucket": "default",
+                "region": "some-region"
+            }
+        }
+    },
+    "tools_version": "1.0.0"
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Fix gradle build folder path.  
- Accept both string and array for custom build command as subprocess supports both. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.