### PR TITLE
fix(build): get zip-build folder from a set

### DIFF
--- a/greengrassTools/commands/component/build.py
+++ b/greengrassTools/commands/component/build.py
@@ -154,7 +154,7 @@ def _build_system_zip():
         None
     """
     try:
-        zip_build = _get_build_folder_by_build_system()
+        zip_build = next(iter(_get_build_folder_by_build_system()))  # Only one zip-build folder in the set
         artifacts_zip_build = Path(zip_build).joinpath(utils.current_directory.name).resolve()
         utils.clean_dir(zip_build)
         logging.debug("Copying over component files to the '{}' folder.".format(artifacts_zip_build.name))

--- a/tests/greengrassTools/commands/component/test_build.py
+++ b/tests/greengrassTools/commands/component/test_build.py
@@ -199,7 +199,7 @@ def test_build_system_zip_valid(mocker):
     zip_build_path = Path("zip-build").resolve()
     zip_artifacts_path = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
     mock_build_info = mocker.patch(
-        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value={zip_build_path}
     )
     mock_clean_dir = mocker.patch("greengrassTools.common.utils.clean_dir", return_value=None)
     mock_copytree = mocker.patch("shutil.copytree")
@@ -240,7 +240,7 @@ def test_build_system_zip_error_archive(mocker):
     zip_artifacts_path = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
 
     mock_build_info = mocker.patch(
-        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value={zip_build_path}
     )
     mock_clean_dir = mocker.patch("greengrassTools.common.utils.clean_dir", return_value=None)
     mock_copytree = mocker.patch("shutil.copytree")
@@ -272,7 +272,7 @@ def test_build_system_zip_error_copytree(mocker):
     zip_artifacts_path = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
 
     mock_build_info = mocker.patch(
-        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value={zip_build_path}
     )
     mock_clean_dir = mocker.patch("greengrassTools.common.utils.clean_dir", return_value=None)
     mock_copytree = mocker.patch("shutil.copytree", side_effect=Error("some error"))
@@ -328,7 +328,7 @@ def test_build_system_zip_error_get_build_folder_by_build_system(mocker):
 def test_build_system_zip_error_clean_dir(mocker):
     zip_build_path = Path("zip-build").resolve()
     mock_build_info = mocker.patch(
-        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value=zip_build_path
+        "greengrassTools.commands.component.build._get_build_folder_by_build_system", return_value={zip_build_path}
     )
     mock_clean_dir = mocker.patch("greengrassTools.common.utils.clean_dir", return_value=None, side_effect=Error("some error"))
     mock_copytree = mocker.patch("shutil.copytree")


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
`build._get_build_folder_by_build_system` returns a set based on previous change. Update zip build system to get build folder from a set. 

**Why is this change necessary:**
Without this change, `greengrass-tools component build` command errors for`"build_system": "zip"` config. 

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.