### PR TITLE
fix(commands): skip docker uris while updating recipes

### DIFF
--- a/greengrassTools/commands/component/build.py
+++ b/greengrassTools/commands/component/build.py
@@ -289,6 +289,9 @@ def copy_artifacts_and_update_uris():
             if "URI" not in artifact:
                 logging.debug("No 'URI' found in the recipe artifacts.")
                 continue
+            # Skip non-s3 URIs in the recipe. Eg docker URIs
+            if not artifact["URI"].startswith("s3://"):
+                continue
             artifact_file = Path(artifact["URI"]).name
             artifact_found = False
             # If the artifact is present in build system specific build folder, copy it to greengrass artifacts build folder

--- a/greengrassTools/commands/component/publish.py
+++ b/greengrassTools/commands/component/publish.py
@@ -314,8 +314,10 @@ def update_and_create_recipe_file(component_name, component_version):
             if "URI" not in artifact:
                 logging.debug("No 'URI' found in the recipe artifacts.")
                 continue
+            # Skip non-s3 URIs in the recipe. Eg docker URIs
+            if not artifact["URI"].startswith("s3://"):
+                continue
             artifact_file = Path(artifact["URI"]).name
-
             # For artifact in build component artifacts folder, update its URI
             build_artifact_files = list(gg_build_component_artifacts.glob(artifact_file))
             if len(build_artifact_files) == 1:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Docker artifact URIs in the recipes are not same as s3 artifact URIs. These URIs don't correspond to a file in build folders (build command). They can't be uploaded or modified to s3 artifacts URIs (publish command). So, skip all non s3 URIs while creating and updating the recipes.

**Why is this change necessary:**
Without this change, build and publish commands fail as they're unable to find artifact files with docker URIs. 

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.