### PR TITLE
refactor(cli): rename cli tool to gdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-## Installing greengrass-tools CLI
+## Installing gdk CLI
 
-Use the following commands to install `greengrass-tools` cli inside a virtual environment. Replace `<venv-name>` with name of the virtual enviroment you want to create. 
+Use the following commands to install `gdk` cli inside a virtual environment. Replace `<venv-name>` with name of the virtual enviroment you want to create. 
 
 1. Install virtual env module.
 
@@ -17,5 +17,5 @@ Use the following commands to install `greengrass-tools` cli inside a virtual en
 
 4. Installing cli tool.
 
-    `pip3 install git+https://github.com/aws-greengrass/aws-greengrass-tools.git`
+    `pip3 install git+https://github.com/aws-greengrass/aws-greengrass-gdk-cli.git`
 

--- a/greengrassTools/commands/component/build.py
+++ b/greengrassTools/commands/component/build.py
@@ -180,7 +180,7 @@ def _ignore_files_during_zip(path, names):
     Creates a list of files or directories to ignore while copying a directory.
 
     Helper function to create custom list of files/directories to ignore. Here, we exclude,
-    1. project config file -> greengrass-tools-config.json
+    1. project config file -> gdk-config.json
     2. greengrass-build directory
     3. recipe file
     4. tests folder

--- a/greengrassTools/commands/component/publish.py
+++ b/greengrassTools/commands/component/publish.py
@@ -55,7 +55,7 @@ def upload_artifacts_s3(component_name, component_version):
             logging.error("Component '{}' is not build.".format(component_name))
             raise Exception(
                 f"Failed to publish the component '{component_name}' as it is not build.\nBuild the component"
-                " `greengrass-tools component build` before publishing it."
+                " `gdk component build` before publishing it."
             )
         create_bucket(bucket, region)
         build_component_artifacts = list(project_config["gg_build_component_artifacts_dir"].iterdir())
@@ -296,7 +296,7 @@ def update_and_create_recipe_file(component_name, component_version):
         if parsed_component_recipe["ComponentName"] != component_name:
             logging.error("Component '{}' is not build.".format(parsed_component_recipe["ComponentName"]))
             raise Exception(
-                "Failed to publish the component '{}' as it is not build.\nBuild the component `greengrass-tools component"
+                "Failed to publish the component '{}' as it is not build.\nBuild the component `gdk component"
                 " build` before publishing it.".format(parsed_component_recipe["ComponentName"])
             )
     gg_build_component_artifacts = project_config["gg_build_component_artifacts_dir"]

--- a/greengrassTools/commands/methods.py
+++ b/greengrassTools/commands/methods.py
@@ -1,17 +1,17 @@
 from greengrassTools.commands.component import component
 
 
-def _greengrass_tools_component_init(d_args):
+def _gdk_component_init(d_args):
     component.init(d_args)
 
 
-def _greengrass_tools_component_build(d_args):
+def _gdk_component_build(d_args):
     component.build(d_args)
 
 
-def _greengrass_tools_component_publish(d_args):
+def _gdk_component_publish(d_args):
     component.publish(d_args)
 
 
-def _greengrass_tools_component_list(d_args):
+def _gdk_component_list(d_args):
     component.list(d_args)

--- a/greengrassTools/common/consts.py
+++ b/greengrassTools/common/consts.py
@@ -1,6 +1,5 @@
-cli_tool_name = "greengrass-tools"
+cli_tool_name = "gdk"
 
-cli_tool_name_in_method_names = "greengrass_tools"
 
 arg_parameters = [
     "name",
@@ -18,7 +17,7 @@ arg_parameters = [
 
 config_schema_file = "config_schema.json"
 cli_model_file = "cli_model.json"
-cli_project_config_file = "greengrass-tools-config.json"
+cli_project_config_file = "gdk-config.json"
 
 # TODO: Update URLs
 templates_list_url = ""

--- a/greengrassTools/common/exceptions/error_messages.py
+++ b/greengrassTools/common/exceptions/error_messages.py
@@ -1,7 +1,6 @@
 # FILE
 CONFIG_FILE_NOT_EXISTS = (
-    "Config file doesn't exist. Please initialize the project using a template or a repository before using greengrass-tools"
-    " commands."
+    "Config file doesn't exist. Please initialize the project using a template or a repository before using gdk commands."
 )
 CONFIG_SCHEMA_FILE_NOT_EXISTS = "Configuration validation failed. Config schema file doesn't exist."
 PROJECT_RECIPE_FILE_NOT_FOUND = (
@@ -19,22 +18,22 @@ LISTING_COMPONENTS_FAILED = (
 )
 LIST_WITH_INVALID_ARGS = (
     "Could not list the components as the command arguments are invalid. Please supply either `--template` or `--repository`"
-    " as an argument to the list command.\nTry `greengrass-tools component list --help`"
+    " as an argument to the list command.\nTry `gdk component list --help`"
 )
 
 # INIT COMMAND
 INIT_FAILS_DURING_COMPONENT_DOWNLOAD = "Failed to download the selected component {{}}. Please try again after sometime."
 INIT_WITH_INVALID_ARGS = (
     "Could not initialize the project as the arguments passed are invalid. Please initialize the project with correct"
-    " arguments.\nTry `greengrass-tools component init --help`"
+    " arguments.\nTry `gdk component init --help`"
 )
 INIT_WITH_CONFLICTING_ARGS = (
     "Could not initialize the project as the command arguments are conflicting. Please initialize the project with correct"
-    " arguments.\nTry `greengrass-tools component init --help` "
+    " arguments.\nTry `gdk component init --help` "
 )
 INIT_NON_EMPTY_DIR_ERROR = (
     "Could not initialize the project as the directory is not empty. Please initialize the project in an empty directory.\nTry"
-    " `greengrass-tools component init --help`"
+    " `gdk component init --help`"
 )
 
 # BUILD COMMAND

--- a/greengrassTools/common/parse_args_actions.py
+++ b/greengrassTools/common/parse_args_actions.py
@@ -30,9 +30,6 @@ def call_action_by_name(method_name, d_args):
     """
     Identifies the method for given method name based on namespace and executes the method
 
-    Since method names cannot have "-" and "greengrass-tools" contain a "-", we substitute
-    "greengrass-tools" with "greengrass_tools"
-
     Parameters
     ----------
       method_name(string): Method name determined from the args namespace.
@@ -43,7 +40,6 @@ def call_action_by_name(method_name, d_args):
     -------
       None
     """
-    method_name = method_name.replace(consts.cli_tool_name, consts.cli_tool_name_in_method_names)
     method_to_call = getattr(command_methods, method_name, None)
     if method_to_call:
         logging.debug("Calling '{}'.".format(method_name))
@@ -56,12 +52,12 @@ def get_method_from_command(d_args, command, method_name):
     """
     A recursive function that builds the method_name from the command.
 
-    'greengrass-tools component init --lang python --template template-name'
+    'gdk component init --lang python --template template-name'
     When the above command is parsed(parse_args), the following namespace is returned.
-    Namespace(greengrass-tools='component', foo=None, component='init', init=None, lang='python', template='template-name')
+    Namespace(gdk='component', foo=None, component='init', init=None, lang='python', template='template-name')
     where,
-    greengrass-tools -> component, component -> init, init -> None and we derive the method name from this as
-    '_greengrass-tools_component_init'
+    gdk -> component, component -> init, init -> None and we derive the method name from this as
+    '_gdk_component_init'
 
     Parameters
     ----------

--- a/greengrassTools/static/cli_model.json
+++ b/greengrassTools/static/cli_model.json
@@ -1,5 +1,5 @@
 {
-    "greengrass-tools": {
+    "gdk": {
         "sub-commands": [
             "component"
         ],

--- a/integration_tests/greengrassTools/common/test_integ_parse_args_actions.py
+++ b/integration_tests/greengrassTools/common/test_integ_parse_args_actions.py
@@ -8,14 +8,12 @@ import pytest
 
 def test_run_command_with_valid_namespace_without_debug(mocker):
     # Integ test that appropriate action is called only once with valid command namespace.
-    args_namespace = argparse.Namespace(
-        component="init", init=None, lang="python", template="name", **{"greengrass-tools": "component"}
-    )
-    spy_component_build = mocker.spy(methods, "_greengrass_tools_component_build")
+    args_namespace = argparse.Namespace(component="init", init=None, lang="python", template="name", **{"gdk": "component"})
+    spy_component_build = mocker.spy(methods, "_gdk_component_build")
     spy_call_action_by_name = mocker.spy(actions, "call_action_by_name")
     spy_get_method_from_command = mocker.spy(actions, "get_method_from_command")
     spy_logger = mocker.spy(logging, "basicConfig")
-    mock_component_init = mocker.patch("greengrassTools.commands.methods._greengrass_tools_component_init", return_value=None)
+    mock_component_init = mocker.patch("greengrassTools.commands.methods._gdk_component_init", return_value=None)
     actions.run_command(args_namespace)
     assert mock_component_init.call_count == 1
     assert spy_component_build.call_count == 0
@@ -27,12 +25,12 @@ def test_run_command_with_valid_namespace_without_debug(mocker):
 def test_run_command_with_valid_debug_enabled(mocker):
     # Integ test that appropriate action is called only once with valid command namespace.
     args_namespace = argparse.Namespace(
-        component="init", init=None, lang="python", template="name", **{"greengrass-tools": "component"}, debug=True
+        component="init", init=None, lang="python", template="name", **{"gdk": "component"}, debug=True
     )
-    spy_component_build = mocker.spy(methods, "_greengrass_tools_component_build")
+    spy_component_build = mocker.spy(methods, "_gdk_component_build")
     spy_call_action_by_name = mocker.spy(actions, "call_action_by_name")
     spy_get_method_from_command = mocker.spy(actions, "get_method_from_command")
-    mock_component_init = mocker.patch("greengrassTools.commands.methods._greengrass_tools_component_init", return_value=None)
+    mock_component_init = mocker.patch("greengrassTools.commands.methods._gdk_component_init", return_value=None)
 
     spy_logging_ = mocker.spy(logging.getLogger(), "setLevel")
     actions.run_command(args_namespace)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ url = "https://aws.amazon.com/greengrass/"
 short_description = "Greengrass tools CLI for developing greengrass components."
 long_description = "Greengrass CLI Tool for creating Greengrass components."
 version_file = "greengrassTools/_version.py"
-cli_name = "greengrass-tools"
+cli_name = "gdk"
 key_words = "aws iot greengrass cli component"
 license = "Apache-2.0"
 classifiers = [
@@ -21,7 +21,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
 ]
-entry_points = {"console_scripts": ["greengrass-tools = greengrassTools.CLIParser:main"]}
+entry_points = {"console_scripts": ["gdk = greengrassTools.CLIParser:main"]}
 
 
 def get_requirements():

--- a/tests/greengrassTools/commands/component/test_publish.py
+++ b/tests/greengrassTools/commands/component/test_publish.py
@@ -179,9 +179,7 @@ def test_update_and_create_recipe_file_manifests_not_build(mocker):
 
     with pytest.raises(Exception) as e:
         publish.update_and_create_recipe_file(component_name, component_version)
-    assert (
-        "as it is not build.\nBuild the component `greengrass-tools component build` before publishing it." in e.value.args[0]
-    )
+    assert "as it is not build.\nBuild the component `gdk component build` before publishing it." in e.value.args[0]
     assert mock_create_publish_recipe.call_count == 0
 
 
@@ -451,8 +449,7 @@ def test_get_latest_component_version_exception(mocker):
     assert mock_get_latest_component_version.call_count == 1
     assert (
         e.value.args[0]
-        == "Error while getting the component versions of 'c_name' in 'region' from the account '1234' during"
-        " publish.\nlisting error"
+        == "Error while getting the component versions of 'c_name' in 'region' from the account '1234' during publish.\nlisting error"
     )
 
 
@@ -523,9 +520,7 @@ def test_upload_artifacts_no_artifacts_not_build(mocker):
     mock_dir_exists = mocker.patch("greengrassTools.common.utils.dir_exists", return_value=False)
     with pytest.raises(Exception) as e:
         publish.upload_artifacts_s3("name", "version")
-    assert (
-        "as it is not build.\nBuild the component `greengrass-tools component build` before publishing it." in e.value.args[0]
-    )
+    assert "as it is not build.\nBuild the component `gdk component build` before publishing it." in e.value.args[0]
     assert mock_dir_exists.call_count == 1
     assert mock_iter_dir.call_count == 0
     assert mock_create_bucket.call_count == 0

--- a/tests/greengrassTools/commands/test_methods.py
+++ b/tests/greengrassTools/commands/test_methods.py
@@ -1,25 +1,25 @@
 import greengrassTools.commands.methods as methods
 
 
-def test_greengrass_tools_component_init(mocker):
+def test_gdk_component_init(mocker):
     mock_component_init = mocker.patch("greengrassTools.commands.component.component.init", return_value=None)
-    methods._greengrass_tools_component_init({})
+    methods._gdk_component_init({})
     assert mock_component_init.call_count == 1
 
 
-def test_greengrass_tools_component_build(mocker):
+def test_gdk_component_build(mocker):
     mock_component_build = mocker.patch("greengrassTools.commands.component.component.build", return_value=None)
-    methods._greengrass_tools_component_build({})
+    methods._gdk_component_build({})
     assert mock_component_build.call_count == 1
 
 
-def test_greengrass_tools_component_publish(mocker):
+def test_gdk_component_publish(mocker):
     mock_component_publish = mocker.patch("greengrassTools.commands.component.component.publish", return_value=None)
-    methods._greengrass_tools_component_publish({})
+    methods._gdk_component_publish({})
     assert mock_component_publish.call_count == 1
 
 
-def test_greengrass_tools_component_list(mocker):
+def test_gdk_component_list(mocker):
     mock_component_list = mocker.patch("greengrassTools.commands.component.component.list", return_value=None)
-    methods._greengrass_tools_component_list({})
+    methods._gdk_component_list({})
     assert mock_component_list.call_count == 1

--- a/tests/greengrassTools/common/test_model_actions.py
+++ b/tests/greengrassTools/common/test_model_actions.py
@@ -66,7 +66,7 @@ def test_is_valid_argument_model_without_help():
 def test_is_valid_subcommand_model_valid():
     # Valid subcommand with valid commmand key in the cli model.
     model = {
-        "greengrass-tools": {"sub-commands": ["component"], "help": "help"},
+        "gdk": {"sub-commands": ["component"], "help": "help"},
         "component": {"help": "help", "sub-commands": ["init", "build"]},
         "build": {"help": "help"},
         "init": {"help": "help"},
@@ -78,7 +78,7 @@ def test_is_valid_subcommand_model_valid():
 def test_is_valid_subcommand_model_valid_without_help():
     # Valid subcommand without help in the cli model.
     model = {
-        "greengrass-tools": {"sub-commands": ["component"]},
+        "gdk": {"sub-commands": ["component"]},
         "component": {"sub-commands": ["init", "build"]},
         "build": {},
         "init": {},
@@ -90,7 +90,7 @@ def test_is_valid_subcommand_model_valid_without_help():
 def test_is_valid_subcommand_model_invalid():
     # Invalid subcommand with no key in the cli model.
     model = {
-        "greengrass-tools": {"sub-commands": ["component"]},
+        "gdk": {"sub-commands": ["component"]},
         "component": {"sub-commands": ["init", "build"]},
         "init": {},
         "build": {},
@@ -102,7 +102,7 @@ def test_is_valid_subcommand_model_invalid():
 def test_is_valid_model_without_help_in_command():
     # Invalid model without help for commands
     valid_model = {
-        "greengrass-tools": {"sub-commands": ["component"]},
+        "gdk": {"sub-commands": ["component"]},
         "component": {"sub-commands": ["init", "build"]},
         "init": {"arguments": {"lang": {"name": ["-l", "--lang"], "help": "help"}}},
         "build": {},
@@ -113,7 +113,7 @@ def test_is_valid_model_without_help_in_command():
 def test_is_valid_model():
     # Valid model with correct args ang sub-commands.
     valid_model = {
-        "greengrass-tools": {"sub-commands": ["component"], "help": "help"},
+        "gdk": {"sub-commands": ["component"], "help": "help"},
         "component": {"help": "help", "sub-commands": ["init", "build"]},
         "init": {"help": "help", "arguments": {"lang": {"name": ["-l", "--lang"], "help": "help"}}},
         "build": {"help": "help"},
@@ -124,7 +124,7 @@ def test_is_valid_model():
 def test_is_valid_model_without_name():
     # Invalid model with incorrect sub-commands. Subcommand with no key in the cli model.
     invalid_model_without_name_in_args = {
-        "greengrass-tools": {
+        "gdk": {
             "sub-commands": ["component"],
             "arguments": {"lang": {"names": ["-l", "--lang"], "help": "help"}},
         },
@@ -136,7 +136,7 @@ def test_is_valid_model_without_name():
 def test_is_valid_model_without_help():
     # Invalid model with incorrect arguments. Argument without name.
     invalid_model_args_without_help = {
-        "greengrass-tools": {
+        "gdk": {
             "sub-commands": ["component"],
             "arguments": {"lang": {"names": ["-l", "--lang"], "help": "help"}},
         },
@@ -148,7 +148,7 @@ def test_is_valid_model_without_help():
 def test_is_valid_model_with_invalid_sub_command():
     # Invalid model with incorrect sub-commands. Subcommand with no key in the cli model.
     invalid_model_subcommands = {
-        "greengrass-tools": {"sub-commands": ["component", "invalid-sub-command"]},
+        "gdk": {"sub-commands": ["component", "invalid-sub-command"]},
         "component": {},
     }
     assert not model_actions.is_valid_model(invalid_model_subcommands, consts.cli_tool_name)
@@ -157,7 +157,7 @@ def test_is_valid_model_with_invalid_sub_command():
 def test_is_valid_model_with_invalid_arg_group():
     # Valid model with correct args ang sub-commands.
     valid_model = {
-        "greengrass-tools": {"sub-commands": ["component"]},
+        "gdk": {"sub-commands": ["component"]},
         "component": {"sub-commands": ["init", "build"]},
         "init": {
             "arguments": {"lang": {"name": ["-l", "--lang"], "help": "help"}},

--- a/tests/greengrassTools/common/test_parse_args_actions.py
+++ b/tests/greengrassTools/common/test_parse_args_actions.py
@@ -9,13 +9,11 @@ import pytest
 
 def test_run_command_with_mocks(mocker):
     # Test that appropriate action is called only once with valid command namespace.
-    args_namespace = argparse.Namespace(
-        component="init", init=None, lang="python", template="name", **{"greengrass-tools": "component"}
-    )
+    args_namespace = argparse.Namespace(component="init", init=None, lang="python", template="name", **{"gdk": "component"})
     mock_get_method_from_command = mocker.patch(
-        "greengrassTools.common.parse_args_actions.get_method_from_command", return_value="_greengrass-tools_component_init"
+        "greengrassTools.common.parse_args_actions.get_method_from_command", return_value="_gdk_component_init"
     )
-    mock_component_init = mocker.patch("greengrassTools.commands.methods._greengrass_tools_component_init", return_value=None)
+    mock_component_init = mocker.patch("greengrassTools.commands.methods._gdk_component_init", return_value=None)
     spy_call_action_by_name = mocker.spy(actions, "call_action_by_name")
 
     actions.run_command(args_namespace)
@@ -27,7 +25,7 @@ def test_run_command_with_mocks(mocker):
 
 def test_run_command_with_invalid_namespace(mocker):
     # Test that action is not called when the namespace is invalid
-    args_namespace = argparse.Namespace(component="init", lang="python", template="name", **{"greengrass-tools": "component"})
+    args_namespace = argparse.Namespace(component="init", lang="python", template="name", **{"gdk": "component"})
     spy_get_method_from_command = mocker.spy(actions, "get_method_from_command")
     spy_call_action_by_name = mocker.spy(actions, "call_action_by_name")
 
@@ -38,33 +36,31 @@ def test_run_command_with_invalid_namespace(mocker):
 
 def test_run_command_namespace_as_dict(mocker):
     # Integ test that appropriate action is called only once with valid command namespace.
-    args_namespace = argparse.Namespace(
-        component="init", init=None, lang="python", template="name", **{"greengrass-tools": "component"}
-    )
-    spy_component_build = mocker.spy(methods, "_greengrass_tools_component_build")
+    args_namespace = argparse.Namespace(component="init", init=None, lang="python", template="name", **{"gdk": "component"})
+    spy_component_build = mocker.spy(methods, "_gdk_component_build")
     spy_call_action_by_name = mocker.spy(actions, "call_action_by_name")
     spy_get_method_from_command = mocker.spy(actions, "get_method_from_command")
-    mock_component_init = mocker.patch("greengrassTools.commands.methods._greengrass_tools_component_init", return_value=None)
+    mock_component_init = mocker.patch("greengrassTools.commands.methods._gdk_component_init", return_value=None)
     actions.run_command(args_namespace)
     assert mock_component_init.call_count == 1
     assert spy_component_build.call_count == 0
     assert spy_call_action_by_name.call_count == 1
     assert spy_get_method_from_command.call_count == 3  # Recursively called for three times
     spy_get_method_from_command.assert_any_call(vars(args_namespace), consts.cli_tool_name, "")
-    spy_get_method_from_command.assert_any_call(vars(args_namespace), "component", "_greengrass-tools")
-    spy_get_method_from_command.assert_any_call(vars(args_namespace), "init", "_greengrass-tools_component")
+    spy_get_method_from_command.assert_any_call(vars(args_namespace), "component", "_gdk")
+    spy_get_method_from_command.assert_any_call(vars(args_namespace), "init", "_gdk_component")
 
 
 def test_get_method_from_command(mocker):
     # Test if the method name is correctly formed from the command
-    test_d_args = {"greengrass-tools": "component", "component": "init", "init": None, "lang": "python", "template": "name"}
-    test_command = "greengrass-tools"
+    test_d_args = {"gdk": "component", "component": "init", "init": None, "lang": "python", "template": "name"}
+    test_command = "gdk"
     test_method_name = ""
     spy_get_method_from_command = mocker.spy(actions, "get_method_from_command")
-    mocker.patch("greengrassTools.commands.methods._greengrass_tools_component_init", return_value=None)
+    mocker.patch("greengrassTools.commands.methods._gdk_component_init", return_value=None)
     method_name_from_command = actions.get_method_from_command(test_d_args, test_command, test_method_name)
     spy_get_method_from_command.assert_any_call(test_d_args, test_command, test_method_name)
-    assert method_name_from_command == "_greengrass-tools_component_init"
+    assert method_name_from_command == "_gdk_component_init"
     assert spy_get_method_from_command.call_count == 3
 
     test_method_name = ""
@@ -78,7 +74,7 @@ def test_get_method_from_command(mocker):
 
 def test_get_method_from_command_invalid(mocker):
     # Test if the method name is None when the command is invalid
-    test_d_args = {"greengrass-tools": "component", "component": "init", "init": None, "lang": "python", "template": "name"}
+    test_d_args = {"gdk": "component", "component": "init", "init": None, "lang": "python", "template": "name"}
     test_method_name = ""
     test_command = ""
     spy_get_method_from_command = mocker.spy(actions, "get_method_from_command")
@@ -97,9 +93,9 @@ def test_get_method_from_command_invalid(mocker):
 def test_get_method_from_command_invalid_subcommand():
     # Test if the method name is None when the command is invalid.
     # There is no init-> None which is invalid for a parsed arg namespace.
-    test_d_args = {"greengrass-tools": "component", "component": "init", "lang": "python", "template": "name"}
+    test_d_args = {"gdk": "component", "component": "init", "lang": "python", "template": "name"}
     test_method_name = ""
-    test_command = "greengrass-tools"
+    test_command = "gdk"
     method_name_from_command = actions.get_method_from_command(test_d_args, test_command, test_method_name)
 
     assert method_name_from_command is None
@@ -107,9 +103,9 @@ def test_get_method_from_command_invalid_subcommand():
 
 def test_call_action_by_name_valid(mocker):
     # Action is called by its name when the method name is valid and exists in the methods file
-    test_d_args = {"greengrass-tools": "component", "component": "init", "init": None, "lang": "python", "template": "name"}
-    method_name = "_greengrass_tools_component_init"
-    method_mocker = mocker.patch("greengrassTools.commands.methods._greengrass_tools_component_init", return_value=None)
+    test_d_args = {"gdk": "component", "component": "init", "init": None, "lang": "python", "template": "name"}
+    method_name = "_gdk_component_init"
+    method_mocker = mocker.patch("greengrassTools.commands.methods._gdk_component_init", return_value=None)
     actions.call_action_by_name(method_name, test_d_args)
 
     assert method_mocker.call_count == 1
@@ -117,21 +113,12 @@ def test_call_action_by_name_valid(mocker):
 
 def test_call_action_by_name_invalid(mocker):
     # Action is not called by its name when the method name doesn't exists in the methods file
-    test_d_args = {"greengrass-tools": "component", "component": "init", "init": None, "lang": "python", "template": "name"}
+    test_d_args = {"gdk": "component", "component": "init", "init": None, "lang": "python", "template": "name"}
     method_name = "invalid_method_name"
     with pytest.raises(Exception) as e_info:
         actions.call_action_by_name(method_name, test_d_args)
     expected_err_message = "{} does not support the given command.".format(consts.cli_tool_name)
     assert e_info.value.args[0] == expected_err_message
-
-
-def test_call_action_by_name_replace_tool_name(mocker):
-    # Action is not called by its name when the method name doesn't exists in the methods file
-    test_d_args = {"greengrass-tools": "component", "component": "init", "init": None, "lang": "python", "template": "name"}
-    method_name = "_greengrass-tools_component_init"
-    method_mocker = mocker.patch("greengrassTools.commands.methods._greengrass_tools_component_init", return_value=None)
-    actions.call_action_by_name(method_name, test_d_args)
-    assert method_mocker.call_count == 1
 
 
 def test_dic_of_conflicting_args():
@@ -174,7 +161,7 @@ def test_list_of_command_args():
         "language": "python",
         "template": "HelloWorld-python",
         "repository": None,
-        "greengrass-tools": "component",
+        "gdk": "component",
     }
     conf_args_dict = {"language": {"language", "template"}, "template": {"language", "template"}, "repository": {"repository"}}
     expected_list = ["language", "template"]
@@ -196,7 +183,7 @@ def test_list_of_command_args():
         "lang": "python",
         "temp": "HelloWorld-python",
         "repository": None,
-        "greengrass-tools": "component",
+        "gdk": "component",
     }
     conf_args_dict = {"language": {"language", "template"}, "template": {"language", "template"}, "repository": {"repository"}}
     expected_list = []
@@ -264,7 +251,7 @@ def test_conflicting_args_with_conflict(mocker):
         "language": "python",
         "template": "HelloWorld-python",
         "repository": None,
-        "greengrass-tools": "component",
+        "gdk": "component",
     }
     cli_model = {"init": {"conflicting_arg_groups": [["language", "template"], ["repository"], ["project"], ["interactive"]]}}
     mocker.patch.object(greengrassTools.CLIParser.cli_tool, "cli_model", cli_model)
@@ -296,7 +283,7 @@ def test_conflicting_args_with_no_conflict(mocker):
         "language": "python",
         "template": "HelloWorld-python",
         "repository": None,
-        "greengrass-tools": "component",
+        "gdk": "component",
     }
     cli_model = {"init": {"conflicting_arg_groups": [["language", "template"], ["repository"], ["project"], ["interactive"]]}}
     mocker.patch.object(greengrassTools.CLIParser.cli_tool, "cli_model", cli_model)

--- a/tests/test_CLIParser.py
+++ b/tests/test_CLIParser.py
@@ -88,7 +88,7 @@ def test_add_arg_to_group_or_parser_with_parser(mocker):
 
 def test_model_file():
     model = {
-        "greengrass-tools": {"sub-commands": ["component"]},
+        "gdk": {"sub-commands": ["component"]},
         "component": {"sub-commands": ["init", "build", "publish"]},
         "init": {
             "arguments": {
@@ -114,9 +114,7 @@ def test_model_file():
 
 
 def test_main(mocker):
-    args_namespace = argparse.Namespace(
-        component="init", init=None, lang="python", template="name", **{"greengrass-tools": "component"}
-    )
+    args_namespace = argparse.Namespace(component="init", init=None, lang="python", template="name", **{"gdk": "component"})
     mock_cli_parser = mocker.patch("greengrassTools.CLIParser.cli_parser.parse_args", return_value=args_namespace)
     mock_run_command = mocker.patch("greengrassTools.common.parse_args_actions.run_command", return_value=None)
     cli_parser.main()
@@ -125,9 +123,7 @@ def test_main(mocker):
 
 
 def test_main_exception(mocker):
-    args_namespace = argparse.Namespace(
-        component="init", init=None, lang="python", template="name", **{"greengrass-tools": "component"}
-    )
+    args_namespace = argparse.Namespace(component="init", init=None, lang="python", template="name", **{"gdk": "component"})
     mock_cli_parser = mocker.patch("greengrassTools.CLIParser.cli_parser.parse_args", return_value=args_namespace)
     mock_run_command = mocker.patch(
         "greengrassTools.common.parse_args_actions.run_command", return_value=None, side_effect=HTTPError("some")


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Rename `greengrass-tools` to `gdk`. 



**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.