### PR TITLE
refactor(build): ignore all hidden files & node modules during zip

### DIFF
--- a/gdk/commands/component/build.py
+++ b/gdk/commands/component/build.py
@@ -184,6 +184,8 @@ def _ignore_files_during_zip(path, names):
     2. greengrass-build directory
     3. recipe file
     4. tests folder
+    5. node_modules
+    6. hidden files
 
     Parameters
     ----------
@@ -200,6 +202,8 @@ def _ignore_files_during_zip(path, names):
         consts.greengrass_build_dir,
         project_config["component_recipe_file"].name,
         "test*",
+        ".*",
+        "node_modules",
     ]
     return ignore_list
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
zip build system zips all contents in top-level directory ignoring certain files. This change adds hidden files and node modules to that ignore list. 

**Why is this change necessary:**
The artifacts that onto the edge device must be as small as possible avoiding all extra files. This change is needed to achieve that. 

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.