### PR TITLE
refactor(config): change version from LATEST to NEXT_PATCH

### DIFF
--- a/gdk/commands/component/publish.py
+++ b/gdk/commands/component/publish.py
@@ -170,15 +170,15 @@ def get_next_version():
         c_name = project_config["component_name"]
         region = project_config["region"]
         account_num = project_config["account_number"]
-        c_latest_version = get_latest_component_version(c_name, region, account_num)
-        if not c_latest_version:
+        c_next_patch_version = get_next_patch_component_version(c_name, region, account_num)
+        if not c_next_patch_version:
             logging.info(
                 "No private version of the component '{}' exist in the account. Using '{}' as the next version to create."
                 .format(c_name, fallback_version)
             )
             return fallback_version
-        logging.debug("Found latest version '{}' of the component '{}' in the account.".format(c_latest_version, c_name))
-        semver_alphanumeric = c_latest_version.split("-")
+        logging.debug("Found latest version '{}' of the component '{}' in the account.".format(c_next_patch_version, c_name))
+        semver_alphanumeric = c_next_patch_version.split("-")
         semver_numeric = semver_alphanumeric[0].split(".")
         major = semver_numeric[0]
         minor = semver_numeric[1]
@@ -214,7 +214,7 @@ def get_account_number():
         raise Exception("Error while fetching account number from credentials.\n{}".format(e))
 
 
-def get_latest_component_version(component_name, region, account_num):
+def get_next_patch_component_version(component_name, region, account_num):
     """
     Gets highest version of the component from the sorted order of its versions from an account in a region.
 
@@ -248,7 +248,7 @@ def get_component_version_from_config():
     """
     Returns component version based on the project configuration.
 
-    If component version is set to LATEST, patch version of the latest component version is calculated. Otherwise,
+    If component version is set to NEXT_PATCH, patch version of the latest component version is calculated. Otherwise,
     exact version specified will be used as the component version during creation of the component.
 
     Parameters
@@ -261,11 +261,10 @@ def get_component_version_from_config():
     """
     try:
         component_name = project_config["component_name"]
-        if project_config["component_version"] == "LATEST":
+        if project_config["component_version"] == "NEXT_PATCH":
             logging.debug(
-                "Component version set to 'LATEST' in the config file. Calculating next version of the component '{}'".format(
-                    project_config["component_name"]
-                )
+                "Component version set to 'NEXT_PATCH' in the config file. Calculating next version of the component '{}'"
+                .format(project_config["component_name"])
             )
             return get_next_version()
         logging.info("Using the version set for the component '{}' in the config file.".format(component_name))

--- a/gdk/static/config_schema.json
+++ b/gdk/static/config_schema.json
@@ -21,7 +21,7 @@
                                 },
                                 {
                                     "enum": [
-                                        "LATEST"
+                                        "NEXT_PATCH"
                                     ]
                                 }
                             ]

--- a/tests/gdk/commands/component/test_publish.py
+++ b/tests/gdk/commands/component/test_publish.py
@@ -331,10 +331,10 @@ def test_get_component_version_from_config(mocker):
     assert not mock_get_next_version.called
 
 
-def test_get_component_version_from_config_latest(mocker):
+def test_get_component_version_from_config_next_patch(mocker):
     publish.project_config = {
         "component_name": "component_name",
-        "component_version": "LATEST",
+        "component_version": "NEXT_PATCH",
         "component_author": "abc",
         "bucket": "default",
         "region": "default",
@@ -357,76 +357,76 @@ def test_get_component_version_from_config_exception(mocker):
 
 def test_get_next_version_component_not_exists(mocker):
     publish.project_config["account_number"] = "1234"
-    mock_get_latest_component_version = mocker.patch(
-        "gdk.commands.component.publish.get_latest_component_version", return_value=None
+    mock_get_next_patch_component_version = mocker.patch(
+        "gdk.commands.component.publish.get_next_patch_component_version", return_value=None
     )
     version = publish.get_next_version()
     assert version == "1.0.0"  # Fallback version
-    assert mock_get_latest_component_version.call_count == 1
-    mock_get_latest_component_version.assert_any_call("component_name", "default", "1234")
+    assert mock_get_next_patch_component_version.call_count == 1
+    mock_get_next_patch_component_version.assert_any_call("component_name", "default", "1234")
 
 
 def test_get_next_version_component_already_exists(mocker):
-    mock_get_latest_component_version = mocker.patch(
-        "gdk.commands.component.publish.get_latest_component_version", return_value="1.0.6"
+    mock_get_next_patch_component_version = mocker.patch(
+        "gdk.commands.component.publish.get_next_patch_component_version", return_value="1.0.6"
     )
 
     version = publish.get_next_version()
     assert version == "1.0.7"
-    assert mock_get_latest_component_version.call_count == 1
+    assert mock_get_next_patch_component_version.call_count == 1
 
 
 def test_get_next_version_component_already_exists_semver(mocker):
-    mock_get_latest_component_version = mocker.patch(
-        "gdk.commands.component.publish.get_latest_component_version", return_value="1.0.6-x-y-z"
+    mock_get_next_patch_component_version = mocker.patch(
+        "gdk.commands.component.publish.get_next_patch_component_version", return_value="1.0.6-x-y-z"
     )
     version = publish.get_next_version()
     assert version == "1.0.7"
-    assert mock_get_latest_component_version.call_count == 1
+    assert mock_get_next_patch_component_version.call_count == 1
 
 
 def test_get_next_version_component_exception(mocker):
     publish.project_config["account_number"] = "1234"
-    mock_get_latest_component_version = mocker.patch(
-        "gdk.commands.component.publish.get_latest_component_version", side_effect=HTTPError("some error")
+    mock_get_next_patch_component_version = mocker.patch(
+        "gdk.commands.component.publish.get_next_patch_component_version", side_effect=HTTPError("some error")
     )
     with pytest.raises(Exception) as e:
         publish.get_next_version()
-    assert mock_get_latest_component_version.call_count == 1
+    assert mock_get_next_patch_component_version.call_count == 1
     assert e.value.args[0] == "Failed to calculate the next version of the component during publish.\nsome error"
 
 
-def test_get_latest_component_version(mocker):
+def test_get_next_patch_component_version(mocker):
     publish.project_config["account_number"] = "1234"
     mock_client = mocker.patch("boto3.client", return_value=None)
     publish.service_clients = {"greengrass_client": mock_client}
     response = {"componentVersions": [{"componentVersion": "1.0.4"}, {"componentVersion": "1.0.1"}]}
-    mock_get_latest_component_version = mocker.patch("boto3.client.list_component_versions", return_value=response)
-    li = publish.get_latest_component_version("c_name", "region", "1234")
-    assert mock_get_latest_component_version.call_count == 1
+    mock_get_next_patch_component_version = mocker.patch("boto3.client.list_component_versions", return_value=response)
+    li = publish.get_next_patch_component_version("c_name", "region", "1234")
+    assert mock_get_next_patch_component_version.call_count == 1
     assert li == "1.0.4"
 
 
-def test_get_latest_component_version_no_components(mocker):
+def test_get_next_patch_component_version_no_components(mocker):
     mock_client = mocker.patch("boto3.client", return_value=None)
     publish.service_clients = {"greengrass_client": mock_client}
-    mock_get_latest_component_version = mocker.patch(
+    mock_get_next_patch_component_version = mocker.patch(
         "boto3.client.list_component_versions", return_value={"componentVersions": []}
     )
-    li = publish.get_latest_component_version("c_name", "region", "1234")
-    assert mock_get_latest_component_version.call_count == 1
+    li = publish.get_next_patch_component_version("c_name", "region", "1234")
+    assert mock_get_next_patch_component_version.call_count == 1
     assert not li
 
 
-def test_get_latest_component_version_exception(mocker):
+def test_get_next_patch_component_version_exception(mocker):
     mock_client = mocker.patch("boto3.client", return_value=None)
     publish.service_clients = {"greengrass_client": mock_client}
-    mock_get_latest_component_version = mocker.patch(
+    mock_get_next_patch_component_version = mocker.patch(
         "boto3.client.list_component_versions", side_effect=HTTPError("listing error")
     )
     with pytest.raises(Exception) as e:
-        publish.get_latest_component_version("c_name", "region", "1234")
-    assert mock_get_latest_component_version.call_count == 1
+        publish.get_next_patch_component_version("c_name", "region", "1234")
+    assert mock_get_next_patch_component_version.call_count == 1
     assert (
         e.value.args[0]
         == "Error while getting the component versions of 'c_name' in 'region' from the account '1234' during"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Replace LATEST with NEXT_PATCH in the gdk-config.json to create next patch version of a component during publish. 
 
**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.