### PR TITLE
refactor(publish): display log to provide access to s3 bucket

### DIFF
--- a/gdk/commands/component/publish.py
+++ b/gdk/commands/component/publish.py
@@ -57,6 +57,12 @@ def upload_artifacts_s3(component_name, component_version):
                 f"Failed to publish the component '{component_name}' as it is not build.\nBuild the component"
                 " `gdk component build` before publishing it."
             )
+        logging.info(
+            f"Uploading component artifacts to S3 bucket: {bucket}. If this is your first time using this bucket, add the"
+            " 's3:GetObject' permission to each core device's token exchange role to allow it to download the component"
+            f" artifacts. For more information, see {utils.doc_link_device_role}."
+        )
+
         create_bucket(bucket, region)
         build_component_artifacts = list(project_config["gg_build_component_artifacts_dir"].iterdir())
         for artifact in build_component_artifacts:

--- a/gdk/common/utils.py
+++ b/gdk/common/utils.py
@@ -107,3 +107,4 @@ error_line = "\n=============================== ERROR ==========================
 help_line = "\n=============================== HELP ===============================\n"
 current_directory = Path(".").resolve()
 log_format = "[%(asctime)s] %(levelname)s - %(message)s"
+doc_link_device_role = "https://docs.aws.amazon.com/greengrass/v2/developerguide/device-service-role.html"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Print the S3 bucket name in component publish, and add a message that informs customers to add s3:GetObject for that bucket to their token exchange role so that core devices can download artifacts from that bucket.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.