### PR TITLE
Fix failure in shutil.move

### DIFF
--- a/gdk/commands/component/init.py
+++ b/gdk/commands/component/init.py
@@ -107,7 +107,7 @@ def download_and_clean(comp_name, comp_type):
             zfile.extractall(tmpdirname)
             # Moves the unarchived contents from temporary folder (downloaded-zip-folder) to current directory.
             for f in Path(tmpdirname).joinpath(zfile.namelist()[0]).iterdir():
-                shutil.move(str(f), str(utils.current_directory))
+                shutil.move(str(f), utils.current_directory)
 
 
 def get_download_url(comp_name, comp_type):

--- a/gdk/commands/component/init.py
+++ b/gdk/commands/component/init.py
@@ -107,7 +107,7 @@ def download_and_clean(comp_name, comp_type):
             zfile.extractall(tmpdirname)
             # Moves the unarchived contents from temporary folder (downloaded-zip-folder) to current directory.
             for f in Path(tmpdirname).joinpath(zfile.namelist()[0]).iterdir():
-                shutil.move(f, utils.current_directory)
+                shutil.move(str(f), str(utils.current_directory))
 
 
 def get_download_url(comp_name, comp_type):


### PR DESCRIPTION
**Issue #, if available:** #33

**Description of changes:**
Ensure arguments to `shutil.move` are strings.

**Why is this change necessary:**
Failure on `gdk component init`

**How was this change tested:**
Manually
```
gdk component init -t HelloWorld -l python
```

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.