### PR TITLE
fix(zip-build): remove directory check while copying

### DIFF
--- a/gdk/commands/component/build.py
+++ b/gdk/commands/component/build.py
@@ -158,7 +158,7 @@ def _build_system_zip():
         artifacts_zip_build = Path(zip_build).joinpath(utils.current_directory.name).resolve()
         utils.clean_dir(zip_build)
         logging.debug("Copying over component files to the '{}' folder.".format(artifacts_zip_build.name))
-        shutil.copytree(utils.current_directory, artifacts_zip_build, dirs_exist_ok=True, ignore=_ignore_files_during_zip)
+        shutil.copytree(utils.current_directory, artifacts_zip_build, ignore=_ignore_files_during_zip)
 
         # Get build file name without extension. This will be used as name of the archive.
         archive_file = utils.current_directory.name

--- a/tests/gdk/commands/component/test_build.py
+++ b/tests/gdk/commands/component/test_build.py
@@ -215,7 +215,7 @@ def test_build_system_zip_valid(mocker):
 
     curr_dir = Path(".").resolve()
 
-    mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, dirs_exist_ok=True, ignore=mock_ignore_files_during_zip)
+    mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, ignore=mock_ignore_files_during_zip)
     assert mock_make_archive.called
     zip_build_file = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
     mock_make_archive.assert_called_with(zip_build_file, "zip", root_dir=zip_artifacts_path)
@@ -255,7 +255,7 @@ def test_build_system_zip_error_archive(mocker):
 
     curr_dir = Path(".").resolve()
 
-    mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, dirs_exist_ok=True, ignore=mock_ignore_files_during_zip)
+    mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, ignore=mock_ignore_files_during_zip)
     assert mock_make_archive.called
     zip_build_file = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
     mock_make_archive.assert_called_with(zip_build_file, "zip", root_dir=zip_artifacts_path)
@@ -285,7 +285,7 @@ def test_build_system_zip_error_copytree(mocker):
 
     curr_dir = Path(".").resolve()
 
-    mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, dirs_exist_ok=True, ignore=mock_ignore_files_during_zip)
+    mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, ignore=mock_ignore_files_during_zip)
     assert not mock_make_archive.called
 
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Remove dir_exist_ok in shutil copytree as it is already taken care by the cleaning the zip-build folder before copying. 


**Why is this change necessary:**
As zip-build is incompatible with py versions < 3.8, we need to change this. 

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.