### PR TITLE
test(uat): add cli list and init uats

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,7 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Testing CLI (Runs both unit and integration tests)
         run: |
+          pip install .
           coverage run --source=gdk -m pytest -v -s . && coverage report --show-missing --fail-under=70              
   build-on-ubuntu:
     runs-on: ${{ matrix.config.os }}
@@ -67,6 +68,7 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Testing CLI (Runs both unit and integration tests)
         run: |
+          pip install .
           coverage run --source=gdk -m pytest -v -s . && coverage report --show-missing --fail-under=70      
   build-on-macos:
     runs-on: ${{ matrix.config.os }}
@@ -94,4 +96,5 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Testing CLI (Runs both unit and integration tests)
         run: |
+          pip install .
           coverage run --source=gdk -m pytest -v -s . && coverage report --show-missing --fail-under=70 

--- a/uat/test_uat_CLIParser.py
+++ b/uat/test_uat_CLIParser.py
@@ -1,0 +1,53 @@
+import os
+import subprocess as sp
+import tempfile
+from pathlib import Path
+
+import gdk.common.exceptions.error_messages as error_messages
+
+
+def install_cli():
+    sp.run(["pip3", "install", "."])
+    check_installation = sp.run(["gdk", "--help"], check=True, stdout=sp.PIPE)
+    assert "Greengrass development kit - CLI" in check_installation.stdout.decode()
+
+
+install_cli()
+
+
+def test_list_template():
+    check_list_template = sp.run(["gdk", "component", "list", "--template"], check=True, stdout=sp.PIPE)
+    assert "HelloWorld-python" in check_list_template.stdout.decode()
+    assert "HelloWorld-java" in check_list_template.stdout.decode()
+
+
+def test_list_repository():
+    check_list_template = sp.run(["gdk", "component", "list", "--repository"], check=True, stdout=sp.PIPE)
+    assert "aws-greengrass-labs-database-influxdb" in check_list_template.stdout.decode()
+
+
+def test_init_template_non_empty_dir():
+    check_init_template = sp.run(["gdk", "component", "init", "-t", "HelloWorld", "-l", "python"], stdout=sp.PIPE)
+    assert check_init_template.returncode == 1
+    assert "Try `gdk component init --help`" in check_init_template.stdout.decode()
+
+
+def test_init_template():
+    dirpath = tempfile.mkdtemp()
+    os.chdir(dirpath)
+    check_init_template = sp.run(["gdk", "component", "init", "-t", "HelloWorld", "-l", "python"], check=True, stdout=sp.PIPE)
+    assert check_init_template.returncode == 0
+    assert Path(dirpath).joinpath("recipe.yaml").resolve().exists()
+    assert Path(dirpath).joinpath("gdk-config.json").resolve().exists()
+
+
+def test_init_repository():
+    dirpath = tempfile.mkdtemp()
+    os.chdir(dirpath)
+    check_init_repo = sp.run(
+        ["gdk", "component", "init", "-r", "aws-greengrass-labs-database-influxdb"], check=True, stdout=sp.PIPE
+    )
+
+    assert check_init_repo.returncode == 0
+    assert Path(dirpath).joinpath("recipe.yaml").exists()
+    assert Path(dirpath).joinpath("gdk-config.json").exists()

--- a/uat/test_uat_CLIParser.py
+++ b/uat/test_uat_CLIParser.py
@@ -6,15 +6,6 @@ from pathlib import Path
 import gdk.common.exceptions.error_messages as error_messages
 
 
-def install_cli():
-    sp.run(["pip3", "install", "."])
-    check_installation = sp.run(["gdk", "--help"], check=True, stdout=sp.PIPE)
-    assert "Greengrass development kit - CLI" in check_installation.stdout.decode()
-
-
-install_cli()
-
-
 def test_list_template():
     check_list_template = sp.run(["gdk", "component", "list", "--template"], check=True, stdout=sp.PIPE)
     assert "HelloWorld-python" in check_list_template.stdout.decode()


### PR DESCRIPTION
**Issue #, if available:**
#33 

**Description of changes:**
Add basic user acceptance tests for CLI list and init commands. 

**Why is this change necessary:**
Helps in testing python builtin functions per versions without mocking them. 

**How was this change tested:**
https://github.com/aws-greengrass/aws-greengrass-gdk-cli/actions/runs/1574368234/workflow

This workflow runs added UATs at this state of repo https://github.com/aws-greengrass/aws-greengrass-gdk-cli/commit/615e2aab6a5c3072ea0e89757d2a5c78de85cce6 which results in the issue error - 
- ubuntu https://github.com/aws-greengrass/aws-greengrass-gdk-cli/runs/4510503798?check_suite_focus=true#step:8:356
- windows https://github.com/aws-greengrass/aws-greengrass-gdk-cli/runs/4510504027?check_suite_focus=true#step:6:357

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [x] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.