### PR TITLE
feat(bucket): pass bucket name in publish command

### DIFF
--- a/gdk/commands/component/publish.py
+++ b/gdk/commands/component/publish.py
@@ -10,13 +10,16 @@ import yaml
 from botocore.exceptions import ClientError
 
 
-def run(args):
+def run(command_args):
     try:
 
         project_config["account_number"] = get_account_number()
-        project_config["bucket"] = "{}-{}-{}".format(
-            project_config["bucket"], project_config["region"], project_config["account_number"]
-        )
+        if command_args["bucket"]:
+            project_config["bucket"] = command_args["bucket"]
+        else:
+            project_config["bucket"] = "{}-{}-{}".format(
+                project_config["bucket"], project_config["region"], project_config["account_number"]
+            )
 
         component_name = project_config["component_name"]
         component_version = get_component_version_from_config()

--- a/gdk/static/cli_model.json
+++ b/gdk/static/cli_model.json
@@ -75,7 +75,16 @@
         "help": "Build GreengrassV2 component artifacts and recipes from its source code."
     },
     "publish": {
-        "help": "Create a new version of a GreengrassV2 component from its built artifacts and recipes."
+        "help": "Create a new version of a GreengrassV2 component from its built artifacts and recipes.",
+        "arguments": {
+            "bucket": {
+                "name": [
+                    "-b",
+                    "--bucket"
+                ],
+                "help": "Name of the s3 bucket to use for uploading component artifacts."
+            }
+        }
     },
     "list": {
         "help": "List all the available component templates and repositories from Greengrass Software Catalog",

--- a/gdk/static/cli_model_schema.json
+++ b/gdk/static/cli_model_schema.json
@@ -79,11 +79,23 @@
             "type": "object",
             "description": "Sub command under 'component' command. This is one of the sub-parsers under 'component' parser.",
             "required": [
-                "help"
+                "help",
+                "arguments"
             ],
             "properties": {
                 "help": {
                     "$ref": "#/$defs/help"
+                },
+                "arguments": {
+                    "description": "List of all the arguments that can be passed with the publish command.",
+                    "required": [
+                        "bucket"
+                    ],
+                    "properties": {
+                        "bucket": {
+                            "$ref": "#/$defs/argument"
+                        }
+                    }
                 }
             }
         },

--- a/tests/gdk/commands/component/test_publish.py
+++ b/tests/gdk/commands/component/test_publish.py
@@ -565,9 +565,33 @@ def test_publish_run_not_build(mocker):
     mock_dir_exists = mocker.patch("gdk.common.utils.dir_exists", return_value=False)
     mock_build = mocker.patch("gdk.commands.component.component.build", return_value=None)
     mock_create_gg_component = mocker.patch("gdk.commands.component.publish.create_gg_component", return_value=None)
-    publish.run({})
+    publish.run({"bucket": None})
     assert publish.project_config["account_number"] == "1234"
     assert publish.project_config["bucket"] == "default-us-east-1-1234"
+    assert mock_dir_exists.call_count == 1
+    assert mock_build.call_count == 1
+    assert mock_get_account_num.call_count == 1
+    assert mock_get_component_version_from_config.call_count == 1
+    assert mock_upload_artifacts_s3.call_count == 1
+    assert mock_update_and_create_recipe_file.call_count == 1
+    assert mock_create_gg_component.call_count == 1
+
+
+def test_publish_run_not_build_command_bucket(mocker):
+    mock_get_account_num = mocker.patch("gdk.commands.component.publish.get_account_number", return_value="1234")
+    mock_get_component_version_from_config = mocker.patch(
+        "gdk.commands.component.publish.get_component_version_from_config", return_value=None
+    )
+    mock_upload_artifacts_s3 = mocker.patch("gdk.commands.component.publish.upload_artifacts_s3", return_value=None)
+    mock_update_and_create_recipe_file = mocker.patch(
+        "gdk.commands.component.publish.update_and_create_recipe_file", return_value=None
+    )
+    mock_dir_exists = mocker.patch("gdk.common.utils.dir_exists", return_value=False)
+    mock_build = mocker.patch("gdk.commands.component.component.build", return_value=None)
+    mock_create_gg_component = mocker.patch("gdk.commands.component.publish.create_gg_component", return_value=None)
+    publish.run({"bucket": "exact-bucket"})
+    assert publish.project_config["account_number"] == "1234"
+    assert publish.project_config["bucket"] == "exact-bucket"
     assert mock_dir_exists.call_count == 1
     assert mock_build.call_count == 1
     assert mock_get_account_num.call_count == 1
@@ -590,7 +614,7 @@ def test_publish_run_build(mocker):
     mock_build = mocker.patch("gdk.commands.component.component.build", return_value=None)
     publish.project_config["bucket"] = "default"
     mock_create_gg_component = mocker.patch("gdk.commands.component.publish.create_gg_component", return_value=None)
-    publish.run({})
+    publish.run({"bucket": None})
     assert publish.project_config["account_number"] == "1234"
     assert publish.project_config["bucket"] == "default-us-east-1-1234"
     assert mock_dir_exists.call_count == 1
@@ -616,7 +640,7 @@ def test_publish_run_exception(mocker):
     mock_create_gg_component = mocker.patch("gdk.commands.component.publish.create_gg_component", return_value=None)
     publish.project_config["bucket"] = "default"
     with pytest.raises(Exception) as e:
-        publish.run({})
+        publish.run({"bucket": None})
     assert publish.project_config["account_number"] == "1234"
     assert publish.project_config["bucket"] == "default-us-east-1-1234"
     assert e.value.args[0] == "{}\n{}".format(error_messages.PUBLISH_FAILED, "some error")


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Publish command now takes in additional argument (optional) for the bucket name. 

**Why is this change necessary:**
Using gdk-config.json file, customers can only provide bucket prefix to which account and region are appended. To provide customers with the ability to use the bucket of their choice, adding this optional argument for passing in exact bucket name.  

**How was this change tested:**
Updated unit tests. 

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.