### PR TITLE
feat(name): pass project directory in init command

### DIFF
--- a/gdk/common/exceptions/error_messages.py
+++ b/gdk/common/exceptions/error_messages.py
@@ -35,7 +35,10 @@ INIT_NON_EMPTY_DIR_ERROR = (
     "Could not initialize the project as the directory is not empty. Please initialize the project in an empty directory.\nTry"
     " `gdk component init --help`"
 )
-
+INIT_DIR_EXISTS_ERROR = (
+    "Could not initialize the project as the directory '{}' already exists. Please initialize the project with a new"
+    " directory.\nTry `gdk component init --help`"
+)
 # BUILD COMMAND
 BUILD_FAILED = "Failed to build the component with the given project configuration."
 

--- a/gdk/static/cli_model.json
+++ b/gdk/static/cli_model.json
@@ -41,6 +41,13 @@
                     "--repository"
                 ],
                 "help": "Name of the repository to be used."
+            },
+            "name": {
+                "name": [
+                    "-n",
+                    "--name"
+                ],
+                "help": "Name of the project directory to create."
             }
         },
         "conflicting_arg_groups": [

--- a/gdk/static/cli_model_schema.json
+++ b/gdk/static/cli_model_schema.json
@@ -50,7 +50,8 @@
                     "required": [
                         "language",
                         "repository",
-                        "template"
+                        "template",
+                        "name"
                     ],
                     "properties": {
                         "language": {
@@ -60,6 +61,9 @@
                             "$ref": "#/$defs/argument"
                         },
                         "template": {
+                            "$ref": "#/$defs/argument"
+                        },
+                        "name": {
                             "$ref": "#/$defs/argument"
                         }
                     }

--- a/tests/gdk/commands/component/test_init.py
+++ b/tests/gdk/commands/component/test_init.py
@@ -9,7 +9,7 @@ from urllib3.exceptions import HTTPError
 
 def test_init_run_with_non_empty_directory(mocker):
     # Test that an exception is raised when init is run in non-empty directory
-    test_d_args = {"language": "python", "template": "name"}
+    test_d_args = {"language": "python", "template": "name", "name": None}
     mock_is_directory_empty = mocker.patch("gdk.common.utils.is_directory_empty", return_value=False)
     mock_init_with_template = mocker.patch("gdk.commands.component.init.init_with_template", return_value=None)
     mock_init_with_repository = mocker.patch("gdk.commands.component.init.init_with_repository", return_value=None)
@@ -27,7 +27,7 @@ def test_init_run_with_non_empty_directory(mocker):
 
 def test_init_run_with_empty_directory(mocker):
     # Test that an exception is not raised when init is run in an empty directory
-    test_d_args = {"template": None, "language": None, "repository": "repository"}
+    test_d_args = {"template": None, "language": None, "repository": "repository", "name": None}
     mock_is_directory_empty = mocker.patch("gdk.common.utils.is_directory_empty", return_value=True)
     mock_init_with_template = mocker.patch("gdk.commands.component.init.init_with_template", return_value=None)
     mock_init_with_repository = mocker.patch("gdk.commands.component.init.init_with_repository", return_value=None)
@@ -42,7 +42,7 @@ def test_init_run_with_empty_directory(mocker):
 
 def test_init_run_with_empty_args_repository(mocker):
     # Test that an exception is not raised when init is run in an empty directory
-    test_d_args = {"template": None, "language": None, "repository": None}
+    test_d_args = {"template": None, "language": None, "repository": None, "name": None}
     mock_is_directory_empty = mocker.patch("gdk.common.utils.is_directory_empty", return_value=True)
     mock_init_with_template = mocker.patch("gdk.commands.component.init.init_with_template", return_value=None)
     mock_init_with_repository = mocker.patch("gdk.commands.component.init.init_with_repository", return_value=None)
@@ -61,7 +61,7 @@ def test_init_run_with_empty_args_repository(mocker):
 
 def test_init_run_with_empty_args_template(mocker):
     # Test that an exception is not raised when init is run in an empty directory
-    test_d_args = {"template": None, "language": "python", "repository": None}
+    test_d_args = {"template": None, "language": "python", "repository": None, "name": None}
     mock_is_directory_empty = mocker.patch("gdk.common.utils.is_directory_empty", return_value=True)
     mock_init_with_template = mocker.patch("gdk.commands.component.init.init_with_template", return_value=None)
     mock_init_with_repository = mocker.patch("gdk.commands.component.init.init_with_repository", return_value=None)
@@ -80,7 +80,7 @@ def test_init_run_with_empty_args_template(mocker):
 
 def test_init_run_with_conflicting_args(mocker):
     # Test that an exception is not raised when init is run in an empty directory
-    test_d_args = {"repository": "repository"}
+    test_d_args = {"repository": "repository", "name": None}
     mock_is_directory_empty = mocker.patch("gdk.common.utils.is_directory_empty", return_value=True)
     mock_init_with_template = mocker.patch("gdk.commands.component.init.init_with_template", return_value=None)
     mock_init_with_repository = mocker.patch("gdk.commands.component.init.init_with_repository", return_value=None)
@@ -99,7 +99,7 @@ def test_init_run_with_conflicting_args(mocker):
 
 def test_init_run_with_valid_args(mocker):
     # Checks if args are used correctly to run correct init method
-    test_d_args = {"language": "python", "template": "name"}
+    test_d_args = {"language": "python", "template": "name", "name": None}
     mock_is_directory_empty = mocker.patch("gdk.common.utils.is_directory_empty", return_value=True)
     mock_init_with_template = mocker.patch("gdk.commands.component.init.init_with_template", return_value=None)
     mock_init_with_repository = mocker.patch("gdk.commands.component.init.init_with_repository", return_value=None)
@@ -111,8 +111,40 @@ def test_init_run_with_valid_args(mocker):
     assert mock_init_with_repository.call_count == 0
 
 
+def test_init_run_with_name_args(mocker):
+    # Checks if args are used correctly to run correct init method
+    test_d_args = {"language": "python", "template": "name", "name": "new-dir"}
+    mock_is_directory_empty = mocker.patch("gdk.common.utils.is_directory_empty", return_value=True)
+    mock_init_with_template = mocker.patch("gdk.commands.component.init.init_with_template", return_value=None)
+    mock_init_with_repository = mocker.patch("gdk.commands.component.init.init_with_repository", return_value=None)
+    mock_mkdir = mocker.patch("pathlib.Path.mkdir", return_value=None)
+    init.run(test_d_args)
+
+    assert mock_is_directory_empty.call_count == 0
+    assert mock_mkdir.call_count == 1
+    assert mock_init_with_template.call_count == 1
+    assert mock_init_with_repository.call_count == 0
+
+
+def test_init_run_with_name_args_invalid(mocker):
+    # Checks if args are used correctly to run correct init method
+    test_d_args = {"language": "python", "template": "name", "name": "new-dir"}
+    mock_is_directory_empty = mocker.patch("gdk.common.utils.is_directory_empty", return_value=True)
+    mock_init_with_template = mocker.patch("gdk.commands.component.init.init_with_template", return_value=None)
+    mock_init_with_repository = mocker.patch("gdk.commands.component.init.init_with_repository", return_value=None)
+    mock_mkdir = mocker.patch("pathlib.Path.mkdir", return_value=None, side_effect=FileExistsError("Some error"))
+    with pytest.raises(Exception) as e:
+        init.run(test_d_args)
+
+    assert e.value.args[0] == error_messages.INIT_DIR_EXISTS_ERROR.format("new-dir")
+    assert mock_is_directory_empty.call_count == 0
+    assert mock_mkdir.call_count == 1
+    assert mock_init_with_template.call_count == 0
+    assert mock_init_with_repository.call_count == 0
+
+
 def test_init_run_with_invalid_args(mocker):
-    test_d_args = {"language": None, "template": None, "repository": None}
+    test_d_args = {"language": None, "template": None, "repository": None, "name": None}
     mock_is_directory_empty = mocker.patch("gdk.common.utils.is_directory_empty", return_value=True)
     mock_init_with_template = mocker.patch("gdk.commands.component.init.init_with_template", return_value=None)
     mock_init_with_repository = mocker.patch("gdk.commands.component.init.init_with_repository", return_value=None)
@@ -129,39 +161,43 @@ def test_init_run_with_invalid_args(mocker):
 def test_init_with_template_valid(mocker):
     template = "template"
     language = "language"
+    project_dir = "dir"
     mock_download_and_clean = mocker.patch("gdk.commands.component.init.download_and_clean", return_value=None)
-    init.init_with_template(template, language)
-    mock_download_and_clean.assert_any_call("template-language", "template")
+    init.init_with_template(template, language, project_dir)
+    mock_download_and_clean.assert_any_call("template-language", "template", project_dir)
 
 
 def test_init_with_template_exception(mocker):
     template = "template"
     language = "language"
+    project_dir = "dir"
     mock_download_and_clean = mocker.patch(
         "gdk.commands.component.init.download_and_clean", side_effect=HTTPError("Some error")
     )
     with pytest.raises(Exception) as e:
-        init.init_with_template(template, language)
+        init.init_with_template(template, language, project_dir)
     assert "Could not initialize the project with component template" in e.value.args[0]
-    mock_download_and_clean.assert_any_call("template-language", "template")
+    mock_download_and_clean.assert_any_call("template-language", "template", project_dir)
 
 
 def test_init_with_repository_valid(mocker):
     repository = "repository_name"
+    project_dir = "dir"
     mock_download_and_clean = mocker.patch("gdk.commands.component.init.download_and_clean", return_value=None)
-    init.init_with_repository(repository)
-    mock_download_and_clean.assert_any_call(repository, "repository")
+    init.init_with_repository(repository, project_dir)
+    mock_download_and_clean.assert_any_call(repository, "repository", project_dir)
 
 
 def test_init_with_repository_exception(mocker):
     repository = "repository_name"
+    project_dir = "dir"
     mock_download_and_clean = mocker.patch(
         "gdk.commands.component.init.download_and_clean", side_effect=HTTPError("Some error")
     )
     with pytest.raises(Exception) as e:
-        init.init_with_repository(repository)
+        init.init_with_repository(repository, project_dir)
     assert "Could not initialize the project with component repository" in e.value.args[0]
-    mock_download_and_clean.assert_any_call(repository, "repository")
+    mock_download_and_clean.assert_any_call(repository, "repository", project_dir)
 
 
 @patch("zipfile.ZipFile")
@@ -178,17 +214,17 @@ def test_download_and_clean_valid(mock_zip, mocker):
     mock_za.return_value.namelist.return_value = ["one"]
     mock_za.return_value.extractall.return_value = None
     mock_zip.return_value.__enter__ = mock_za
-
+    project_dir = "dir"
     # mock_tmp = ""
     # mock_tempdir.return_value.__enter__ = mock_tmp
 
     mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=["dummy-folder1"])
     mock_move = mocker.patch("shutil.move", return_value=None)
 
-    init.download_and_clean("template-language", "template")
+    init.download_and_clean("template-language", "template", project_dir)
     assert mock_iter_dir.call_count == 1
     assert mock_move.call_count == 1
-    mock_move.assert_any_call("dummy-folder1", Path(".").resolve())
+    mock_move.assert_any_call("dummy-folder1", project_dir)
     assert mock_template_download.call_count == 1
     assert mock_get_available_templates.call_count == 1
 
@@ -197,6 +233,7 @@ def test_init_with_template_invalid_url(mocker):
     # Raises an exception when the template url is not valid.
     template = "template"
     language = "language"
+    project_dir = "dir"
     formatted_template_name = f"{template}-{language}"
     mock_get_available_templates = mocker.patch(
         "gdk.commands.component.list.get_component_list_from_github",
@@ -207,7 +244,7 @@ def test_init_with_template_invalid_url(mocker):
 
     with patch("builtins.open", mock_open()) as mock_file:
         with pytest.raises(Exception) as e:
-            init.download_and_clean(formatted_template_name, template)
+            init.download_and_clean(formatted_template_name, template, project_dir)
 
         assert "Failed to download the selected component" in e.value.args[0]
         assert mock_template_download.call_count == 1

--- a/tests/gdk/commands/component/test_publish.py
+++ b/tests/gdk/commands/component/test_publish.py
@@ -429,7 +429,8 @@ def test_get_next_patch_component_version_exception(mocker):
     assert mock_get_next_patch_component_version.call_count == 1
     assert (
         e.value.args[0]
-        == "Error while getting the component versions of 'c_name' in 'region' from the account '1234' during publish.\nlisting error"
+        == "Error while getting the component versions of 'c_name' in 'region' from the account '1234' during"
+        " publish.\nlisting error"
     )
 
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Name argument  passed with the init command is used to create a new directory in which the component template/repository are initialized. This argument is optional. 

If customers dont pass this in, the project is initialized in the current directory only if it is empty. 

**Why is this change necessary:**
Currently, initializing a component project with the greengrass-cli tool can be done only in an empty directory. So customer had to create this directory before using the tool.

With this change, customer can provide the name of the directory as an optional argument to the init command, so that the tool can create a new directory and initialize the project there. 

**How was this change tested:**
Added new unit tests. 

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.