### PR TITLE
feat(version-check): check if cli version is up to date

### DIFF
--- a/gdk/CLIParser.py
+++ b/gdk/CLIParser.py
@@ -6,8 +6,6 @@ import gdk.common.model_actions as model_actions
 import gdk.common.parse_args_actions as parse_args_actions
 import gdk.common.utils as utils
 
-from . import _version
-
 
 class ArgumentParser(argparse.ArgumentParser):
     def error(self, message):
@@ -178,12 +176,14 @@ class CLIParser:
         """
         self.parser.add_argument("-d", "--debug", help="Increase command output to debug level", action="store_true")
         self.parser.add_argument(
-            "-v", "--version", action="version", version="{} {}".format(consts.cli_tool_name, _version.__version__)
+            "-v", "--version", action="version", version="{} {}".format(consts.cli_tool_name, utils.cli_version)
         )
 
 
 def main():
     try:
+        # Check the version of the cli before command parsing.
+        utils.cli_version_check()
         args_namespace = cli_parser.parse_args()
         parse_args_actions.run_command(args_namespace)
     except Exception as e:

--- a/integration_tests/gdk/common/test_integ_utils.py
+++ b/integration_tests/gdk/common/test_integ_utils.py
@@ -1,0 +1,6 @@
+import gdk.common.utils as utils
+from packaging.version import Version
+
+
+def test_valid_cli_latest_version():
+    assert Version(utils.get_latest_cli_version()) >= Version(utils.cli_version)

--- a/tests/gdk/commands/component/test_publish.py
+++ b/tests/gdk/commands/component/test_publish.py
@@ -429,7 +429,8 @@ def test_get_next_patch_component_version_exception(mocker):
     assert mock_get_next_patch_component_version.call_count == 1
     assert (
         e.value.args[0]
-        == "Error while getting the component versions of 'c_name' in 'region' from the account '1234' during publish.\nlisting error"
+        == "Error while getting the component versions of 'c_name' in 'region' from the account '1234' during"
+        " publish.\nlisting error"
     )
 
 

--- a/tests/gdk/static/invalid_gdk_version.json
+++ b/tests/gdk/static/invalid_gdk_version.json
@@ -1,0 +1,16 @@
+{
+    "component": {
+        "1": {
+            "author": "abc",
+            "version": "1.0.0",
+            "build": {
+                "build_system": "zip"
+            },
+            "publish": {
+                "bucket": "default",
+                "region": "us-east-1"
+            }
+        }
+    },
+    "gdk_version": "1000.0.0"
+}

--- a/tests/test_CLIParser.py
+++ b/tests/test_CLIParser.py
@@ -117,9 +117,11 @@ def test_main(mocker):
     args_namespace = argparse.Namespace(component="init", init=None, lang="python", template="name", **{"gdk": "component"})
     mock_cli_parser = mocker.patch("gdk.CLIParser.cli_parser.parse_args", return_value=args_namespace)
     mock_run_command = mocker.patch("gdk.common.parse_args_actions.run_command", return_value=None)
+    mock_validate_cli_version = mocker.patch("gdk.common.utils.cli_version_check", return_value=None)
     cli_parser.main()
     mock_cli_parser.assert_any_call()
     mock_run_command.assert_any_call(args_namespace)
+    assert mock_validate_cli_version.called
 
 
 def test_main_exception(mocker):
@@ -128,7 +130,9 @@ def test_main_exception(mocker):
     mock_run_command = mocker.patch(
         "gdk.common.parse_args_actions.run_command", return_value=None, side_effect=HTTPError("some")
     )
+    mock_validate_cli_version = mocker.patch("gdk.common.utils.cli_version_check", return_value=None)
     with pytest.raises(SystemExit):
         cli_parser.main()
     mock_cli_parser.assert_any_call()
     mock_run_command.assert_any_call(args_namespace)
+    assert mock_validate_cli_version.called


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
GDK CLI releases are maintained on GitHub using tags. This code change assumes that the latest version of the cli tool is maintained at [gdk/_version.py](https://github.com/aws-greengrass/aws-greengrass-gdk-cli/blob/main/gdk/_version.py). This is considered at the latest version of the tool at any given time.

- At the beginning of parsing every cli command, same file but in the locally installed version of the cli tool library is compared with the latest version file on GitHub repo.  If the installed gdk version is smaller than the latest, INFO log is displayed. If for some reason, the tool is not able to fetch the latest version or if the installed gdk version is same as the latest one, we proceed executing the command. Either way, this check here doesn't affect the flow of the command provided by customer.
- The version of the gdk project (`gdk_version` in `gdk-config.json`) is compared with the installed gdk version. If the gdk project version is greater than the installed gdk, the command is failed and exited with an error. `gdk-config.json` is expected to contain minimum gdk version that supports the config file.

**Why is this change necessary:**
- Lets customer know about the latest cli version if available by logging and recommends upgrading.
- Forces customer to upgrade the cli version when the gdk project in which the command is running  is incompatible with the customer's installed cli version.

**How was this change tested:**
Tested manually and also added unittests.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.