### PR TITLE
chore(version): update gdk version and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please follow the [GDK CLI public documentation](https://docs.aws.amazon.com/gre
 
 To install the latest version of CLI using this git repository and pip, run the following command
 
-`pip3 install git+https://github.com/aws-greengrass/aws-greengrass-gdk-cli.git`
+`pip3 install git+https://github.com/aws-greengrass/aws-greengrass-gdk-cli.git@v1.0.0`
 
 Run `gdk --help` to check if the cli tool is successfully installed.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3
 jsonschema 
 PyYAML 
 requests
+packaging


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Update readme to download 1.0.0 version of gdk using the tag instead of pulling the version on the main.
- Update requirements file to include packaging library as dependency. 

**Why is this change necessary:**
Without this change, customers cannot download 1.0.0 stable version of GDK-CLI. Even if they want to try the version on main, required dependency is missing. So this change fixes it. 

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [x] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.