### PR TITLE
chore(workflow): Adding CI step to ensure that gdk is installed successfully

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,19 +28,21 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install CLI and verify
         run: |
           python -m pip install --upgrade pip
+          pip install .
+          gdk --help
+      - name: Testing CLI (Runs both unit and integration tests)
+        run: |
           if ( Test-Path test-requirements.txt ) { pip install -r test-requirements.txt; }
+          coverage run --source=gdk -m pytest -v -s . && coverage report --show-missing --fail-under=70
       - name: Lint with flake8
         run: |
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Testing CLI (Runs both unit and integration tests)
-        run: |
-          pip install .
-          coverage run --source=gdk -m pytest -v -s . && coverage report --show-missing --fail-under=70              
+
   build-on-ubuntu:
     runs-on: ${{ matrix.config.os }}
     strategy:
@@ -57,19 +59,21 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install CLI and verify
         run: |
           python -m pip install --upgrade pip
+          pip install .
+          gdk --help
+      - name: Testing CLI (Runs both unit and integration tests)
+        run: |
           if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
+          coverage run --source=gdk -m pytest -v -s . && coverage report --show-missing --fail-under=70
       - name: Lint with flake8
         run: |
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Testing CLI (Runs both unit and integration tests)
-        run: |
-          pip install .
-          coverage run --source=gdk -m pytest -v -s . && coverage report --show-missing --fail-under=70      
+
   build-on-macos:
     runs-on: ${{ matrix.config.os }}
     strategy:
@@ -85,16 +89,17 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install CLI and verify
         run: |
           python -m pip install --upgrade pip
+          pip install .
+          gdk --help
+      - name: Testing CLI (Runs both unit and integration tests)
+        run: |
           if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
+          coverage run --source=gdk -m pytest -v -s . && coverage report --show-missing --fail-under=70
       - name: Lint with flake8
         run: |
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Testing CLI (Runs both unit and integration tests)
-        run: |
-          pip install .
-          coverage run --source=gdk -m pytest -v -s . && coverage report --show-missing --fail-under=70 


### PR DESCRIPTION
**Issue #, if available:**
Recently there was breaking change which impacted cli installation. This was not caught in CI step of integration because dependencies in `test-requirement.txt` were different than actual cli dependencies in  `requirement.txt`. One option is to ensure that both list of dependencies are same, but that means we install test dependencies during runtime which is unnecessary. 

**Description of changes:**
This fix is alternative approach to ensure that we install GDK as customer would and verify that its installed correctly.

E.g. workflow failure if GDK is not installed correctly: https://github.com/aws-greengrass/aws-greengrass-gdk-cli/actions/runs/1748076300

E.g workflow successful  if GDK is installed correctly: https://github.com/aws-greengrass/aws-greengrass-gdk-cli/actions/runs/1748090819

**Why is this change necessary:**
Its necessary to caught installation issue proactively.

**How was this change tested:**
Tested with setting up workflow in another branch
**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [X] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.