### PR TITLE
feat(s3-uri): support s3 artifacts during build

### DIFF
--- a/gdk/commands/component/publish.py
+++ b/gdk/commands/component/publish.py
@@ -312,7 +312,7 @@ def update_and_create_recipe_file(component_name, component_version):
             )
     gg_build_component_artifacts = project_config["gg_build_component_artifacts_dir"]
     bucket = project_config["bucket"]
-    artifact_uri = f"s3://{bucket}/{component_name}/{component_version}"
+    artifact_uri = f"{utils.s3_prefix}{bucket}/{component_name}/{component_version}"
 
     if "Manifests" not in parsed_component_recipe:
         logging.debug("No 'Manifests' key in the recipe.")

--- a/gdk/common/utils.py
+++ b/gdk/common/utils.py
@@ -137,3 +137,4 @@ log_format = "[%(asctime)s] %(levelname)s - %(message)s"
 doc_link_device_role = "https://docs.aws.amazon.com/greengrass/v2/developerguide/device-service-role.html"
 cli_version = version.__version__
 latest_cli_version_file = "https://raw.githubusercontent.com/aws-greengrass/aws-greengrass-gdk-cli/main/gdk/_version.py"
+s3_prefix = "s3://"

--- a/tests/gdk/commands/component/test_publish.py
+++ b/tests/gdk/commands/component/test_publish.py
@@ -429,7 +429,8 @@ def test_get_next_patch_component_version_exception(mocker):
     assert mock_get_next_patch_component_version.call_count == 1
     assert (
         e.value.args[0]
-        == "Error while getting the component versions of 'c_name' in 'region' from the account '1234' during publish.\nlisting error"
+        == "Error while getting the component versions of 'c_name' in 'region' from the account '1234' during"
+        " publish.\nlisting error"
     )
 
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change allows gdk to create recipes with artifacts that exist in either s3 or local build folders of gdk.

*Current behavior:* 
We parse artifact URIs in the recipe and check for only those artifacts that have s3:// prefix to avoid uris that are docker images. For the ones with s3:// prefix, we check if the files exist in the build folder. If not, the tool exits with an error. 

To support remote s3 uris,
*New behavior:* With this change, we don't exit immediately but check for the artifact in s3 as well. Thus, supporting both local build artifacts and s3 uris in the recipe. 


**Why is this change necessary:**
Currently, we only support local artifacts that are built using gdk build system. There may be cases where some artifacts already exist in customer's s3 buckets and recipes point to them. Eg. It saves more time to refer big ML models that exist on s3 than downloading them locally, and then uploading them back to s3 only for it to be compatible with gdk.

**How was this change tested:**
Added unittests

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.