### PR TITLE
refactor(cleanup): improve parsing, bucket creation & cleanup

### DIFF
--- a/gdk/commands/component/publish.py
+++ b/gdk/commands/component/publish.py
@@ -67,8 +67,10 @@ def upload_artifacts_s3(component_name, component_version):
             f" artifacts. For more information, see {utils.doc_link_device_role}."
         )
 
-        create_bucket(bucket, region)
         build_component_artifacts = list(project_config["gg_build_component_artifacts_dir"].iterdir())
+        # Create bucket only when there's something to upload.
+        if len(build_component_artifacts) != 0:
+            create_bucket(bucket, region)
         for artifact in build_component_artifacts:
             s3_file_path = f"{component_name}/{component_version}/{artifact.name}"
             logging.debug("Uploading artifact '{}' to the bucket '{}'.".format(artifact.resolve(), bucket))

--- a/gdk/common/parse_args_actions.py
+++ b/gdk/common/parse_args_actions.py
@@ -45,7 +45,9 @@ def call_action_by_name(method_name, d_args):
         logging.debug("Calling '{}'.".format(method_name))
         method_to_call(d_args)
     else:
-        raise Exception("{} does not support the given command.".format(consts.cli_tool_name))
+        gdk.CLIParser.cli_parser.error(
+            f"{consts.cli_tool_name}-v{gdk.CLIParser.utils.cli_version} does not support the given command."
+        )
 
 
 def get_method_from_command(d_args, command, method_name):

--- a/tests/gdk/commands/component/test_init.py
+++ b/tests/gdk/commands/component/test_init.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from unittest.mock import Mock, mock_open, patch
 
 import gdk.commands.component.init as init

--- a/tests/gdk/commands/component/test_publish.py
+++ b/tests/gdk/commands/component/test_publish.py
@@ -429,8 +429,7 @@ def test_get_next_patch_component_version_exception(mocker):
     assert mock_get_next_patch_component_version.call_count == 1
     assert (
         e.value.args[0]
-        == "Error while getting the component versions of 'c_name' in 'region' from the account '1234' during"
-        " publish.\nlisting error"
+        == "Error while getting the component versions of 'c_name' in 'region' from the account '1234' during publish.\nlisting error"
     )
 
 
@@ -500,7 +499,7 @@ def test_upload_artifacts_no_artifacts(mocker):
     mock_upload_file = mocker.patch("boto3.client.upload_file", return_value=response)
     publish.upload_artifacts_s3("name", "version")
     assert mock_iter_dir.call_count == 1
-    assert mock_create_bucket.call_count == 1
+    assert not mock_create_bucket.called
     assert not mock_upload_file.called
 
 

--- a/tests/gdk/common/test_parse_args_actions.py
+++ b/tests/gdk/common/test_parse_args_actions.py
@@ -115,10 +115,8 @@ def test_call_action_by_name_invalid(mocker):
     # Action is not called by its name when the method name doesn't exists in the methods file
     test_d_args = {"gdk": "component", "component": "init", "init": None, "lang": "python", "template": "name"}
     method_name = "invalid_method_name"
-    with pytest.raises(Exception) as e_info:
+    with pytest.raises(SystemExit):
         actions.call_action_by_name(method_name, test_d_args)
-    expected_err_message = "{} does not support the given command.".format(consts.cli_tool_name)
-    assert e_info.value.args[0] == expected_err_message
 
 
 def test_dic_of_conflicting_args():

--- a/uat/test_uat_CLIParser.py
+++ b/uat/test_uat_CLIParser.py
@@ -4,8 +4,6 @@ import subprocess as sp
 import tempfile
 from pathlib import Path
 
-import gdk.common.exceptions.error_messages as error_messages
-
 
 def test_list_template():
     check_list_template = sp.run(["gdk", "component", "list", "--template"], check=True, stdout=sp.PIPE)
@@ -81,5 +79,4 @@ def test_build_template_zip():
         .resolve()
     )
 
-    recipes_path = Path(path_HelloWorld).joinpath("greengrass-build").joinpath("recipes").joinpath("recipe.yaml").resolve()
     assert artifact_path.exists()


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Improve handling of incorrect commands. 
- Create s3 bucket only when there are artifacts to upload. 

**Why is this change necessary:**
Code cleanup

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.