### PR TITLE
fix(build): fix default build on windows

### DIFF
--- a/gdk/commands/component/build.py
+++ b/gdk/commands/component/build.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import platform
 import shutil
 import subprocess as sp
 from pathlib import Path
@@ -102,6 +103,24 @@ def default_build_component():
         raise Exception("""{}\n{}""".format(error_messages.BUILD_FAILED, e))
 
 
+def get_build_cmd_from_platform(build_system):
+    """
+    Gets build command of the build system specific to the platform on which the command is running.
+
+    Parameters
+    ----------
+        build_system(string): build system specified in the gdk config file
+
+    Returns
+    -------
+        build_command(list): List of build commands of the build system specific to the platform.
+    """
+    platform_sys = platform.system()
+    if platform_sys == "Windows" and "build_command_win" in supported_build_sytems[build_system]:
+        return supported_build_sytems[build_system]["build_command_win"]
+    return supported_build_sytems[build_system]["build_command"]
+
+
 def run_build_command():
     """
     Runs the build command based on the configuration in 'project_build_system.json' file and component project build
@@ -120,12 +139,12 @@ def run_build_command():
     """
     try:
         build_system = project_config["component_build_config"]["build_system"]
-        build_command = supported_build_sytems[build_system]["build_command"]
+        build_command = get_build_cmd_from_platform(build_system)
         logging.warning(
             f"This component is identified as using '{build_system}' build system. If this is incorrect, please exit and"
             f" specify custom build command in the '{consts.cli_project_config_file}'."
         )
-
+        print(build_command)
         if build_system == "zip":
             logging.info("Zipping source code files of the component.")
             _build_system_zip()

--- a/gdk/static/project_build_schema.json
+++ b/gdk/static/project_build_schema.json
@@ -13,7 +13,8 @@
             "type": "object",
             "required": [
                 "build_command",
-                "build_folder"
+                "build_folder",
+                "build_command_win"
             ],
             "properties": {
                 "build_command": {
@@ -28,7 +29,8 @@
             "type": "object",
             "required": [
                 "build_command",
-                "build_folder"
+                "build_folder",
+                "build_command_win"
             ],
             "properties": {
                 "build_command": {
@@ -57,7 +59,18 @@
     },
     "$defs": {
         "build_command": {
-            "description": "An array of strings that forms build command specific to the build system.",
+            "description": "An array of strings that forms build command specific to the build system on non-windows.",
+            "type": "array",
+            "items": {
+                "anyOf": [
+                    {
+                        "type": "string"
+                    }
+                ]
+            }
+        },
+        "build_command_win": {
+            "description": "An array of strings that forms build command specific to the build system on windows.",
             "type": "array",
             "items": {
                 "anyOf": [

--- a/gdk/static/project_build_system.json
+++ b/gdk/static/project_build_system.json
@@ -5,6 +5,11 @@
             "clean",
             "package"
         ],
+        "build_command_win": [
+            "mvn.cmd",
+            "clean",
+            "package"
+        ],
         "build_folder": [
             "target"
         ]
@@ -12,6 +17,10 @@
     "gradle": {
         "build_command": [
             "gradle",
+            "build"
+        ],
+        "build_command_win": [
+            "gradlew",
             "build"
         ],
         "build_folder": [


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
 `gdk component build `command on windows fails as shown below when run with Java HelloWorld template similar to the [UAT failure](https://github.com/aws-greengrass/aws-greengrass-gdk-cli/runs/5071659549?check_suite_focus=true#step:9:37). 
```
C:\Users\ins\gdk-maven>gdk component build
WARNING:root:This component is identified as using 'maven' build system. If this is incorrect, please exit and specify custom build command in the 'gdk-config.json'.

=============================== ERROR ===============================
Failed to build the component with the given project configuration.
Error building the component with the given build system.
[WinError 2] The system cannot find the file specified
-- 
```
This is because we run [`subprocess.run(["mvn","clean","package"])`](https://github.com/aws-greengrass/aws-greengrass-gdk-cli/blob/1ccc050963ba572215c8befc08ab4251ff356ae1/gdk/commands/component/build.py#L134) as part of build command and it is not a valid command on windows.

To fix this, we should make the subprocess command run with `shell=True` so that the command uses `cmd` shell on windows. This is not idea on non-windows system because, by default, this command assumes /bin/sh as the shell unless it is explicitly specified and is very platform-dependent. This is also not secure because of the possible [shell injection](https://en.wikipedia.org/wiki/Shell_injection#Shell_injection)

**Instead, we can use windows specific executables for the build system such as mvn.cmd, gradlew.** 

So, this change
- Add build commands specific to windows platform. 
- Use `platform` module to identify the system. 

**Why is this change necessary:**
To fix a bug on windows platform where default build system maven and gradle don't run as expected.

**How was this change tested:**
- Added unit tests. 
- Tested this manually on a windows instance and the observed same behavior as in the UATs and tested the fix as well. 

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.