### PR TITLE
test(publish): uat of publish command using aws-actions 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,9 @@ jobs:
       matrix:
         python-version: [3.6]
         os: [windows-latest, ubuntu-latest, macos-latest]
+    permissions:
+      id-token: write
+      contents: read
     name: Build on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -44,6 +47,11 @@ jobs:
         run: |
           pip install -r test-requirements.txt
           coverage run --source=gdk -m pytest -v -s tests integration_tests && coverage xml --fail-under=90
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{secrets.GDK_WORKFLOW_AWS_ROLE}}
+          aws-region: us-east-1
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/uat/t_utils.py
+++ b/uat/t_utils.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+import boto3
+
+
+def update_config(config_file, component_name, region, bucket, author):
+    # Update gdk-config file mandatory field like region.
+    with open(str(config_file), "r") as f:
+        config = json.loads(f.read())
+        config["component"][component_name]["author"] = author
+        config["component"][component_name]["publish"]["region"] = region
+        config["component"][component_name]["publish"]["bucket"] = bucket
+    with open(str(config_file), "w") as f:
+        f.write(json.dumps(config))
+
+
+def clean_up_aws_resources(component_name, component_version, region):
+    sts_client = boto3.client("sts", region_name=region)
+    caller_identity_response = sts_client.get_caller_identity()
+    account_num = caller_identity_response["Account"]
+    delete_component(component_name, component_version, region, account_num)
+    delete_s3_artifact(region, account_num, component_name, component_version)
+
+
+def delete_s3_artifact(region, account, component_name, component_version):
+    s3_client = boto3.client("s3", region_name=region)
+    try:
+        bucket = f"gdk-cli-uat-{region}-{account}"
+        res = s3_client.list_objects(Bucket=bucket)
+        if "Contents" not in res:
+            return
+        for f in res["Contents"]:
+            if f"{component_name}/{component_version}" in f["Key"]:
+                s3_client.delete_object(Bucket=bucket, Key=f["Key"])
+    except Exception as e:
+        print(f"Failed to delete s3 objects from bucket - {bucket}")
+        print(e)
+
+
+def delete_component(name, version, region, account_num):
+    try:
+        gg_client = boto3.client("greengrassv2", region_name=region)
+        arn = f"arn:aws:greengrass:{region}:{account_num}:components:{name}:versions:{version}"
+        gg_client.delete_component(arn=arn)
+        print(f"Deleted component {name}-{version} in {region}")
+    except Exception as e:
+        print(f"Failed to delete the component {name}-{version} in {region}")
+        print(e)
+
+
+def get_version_created(recipes_path, component_name):
+    for f in Path(recipes_path).iterdir():
+        if component_name in str(f.resolve()):
+            file_name = f.name
+            break
+    split_file_name = file_name.split(f"{component_name}-")
+    split_for_version = split_file_name[1].split(".yaml")[0]
+    return split_for_version

--- a/uat/test_uat_publish.py
+++ b/uat/test_uat_publish.py
@@ -1,0 +1,85 @@
+import os
+import subprocess as sp
+from pathlib import Path
+
+import t_utils
+
+
+def test_publish_template_zip(change_test_dir):
+    # Recipe contains HelloWorld.zip artifact. So, create HelloWorld directory inside temporary directory.
+    path_HelloWorld = Path(change_test_dir).joinpath("HelloWorld")
+    component_name = "com.example.PythonHelloWorld"
+    region = "us-east-1"
+    bucket = "gdk-cli-uat"
+    author = "gdk-cli-uat"
+    # Check if init downloads templates with necessary files.
+    check_init_template = sp.run(
+        ["gdk", "component", "init", "-t", "HelloWorld", "-l", "python", "-n", "HelloWorld"], check=True, stdout=sp.PIPE
+    )
+    assert check_init_template.returncode == 0
+    assert Path(path_HelloWorld).joinpath("recipe.yaml").resolve().exists()
+    config_file = Path(path_HelloWorld).joinpath("gdk-config.json").resolve()
+    assert config_file.exists()
+
+    t_utils.update_config(config_file, component_name, region, bucket, author)
+    os.chdir(path_HelloWorld)
+    # Check if build works as expected.
+    check_build_template = sp.run(["gdk", "component", "build"], check=True, stdout=sp.PIPE)
+    assert check_build_template.returncode == 0
+    assert Path(path_HelloWorld).joinpath("zip-build").resolve().exists()
+    assert Path(path_HelloWorld).joinpath("greengrass-build").resolve().exists()
+    artifact_path = (
+        Path(path_HelloWorld)
+        .joinpath("greengrass-build")
+        .joinpath("artifacts")
+        .joinpath(component_name)
+        .joinpath("NEXT_PATCH")
+        .joinpath("HelloWorld.zip")
+        .resolve()
+    )
+
+    assert artifact_path.exists()
+    check_publish_component = sp.run(["gdk", "component", "publish"], stdout=sp.PIPE)
+    assert check_publish_component.returncode == 0
+    recipes_path = Path(path_HelloWorld).joinpath("greengrass-build").joinpath("recipes").resolve()
+    t_utils.clean_up_aws_resources(component_name, t_utils.get_version_created(recipes_path, component_name), region)
+
+
+def test_publish_without_build_template_zip(change_test_dir):
+    # Recipe contains HelloWorld.zip artifact. So, create HelloWorld directory inside temporary directory.
+    path_HelloWorld = Path(change_test_dir).joinpath("HelloWorld")
+    component_name = "com.example.PythonHelloWorld"
+    region = "us-east-1"
+    bucket = "gdk-cli-uat"
+    author = "gdk-cli-uat"
+    # Check if init downloads templates with necessary files.
+    check_init_template = sp.run(
+        ["gdk", "component", "init", "-t", "HelloWorld", "-l", "python", "-n", "HelloWorld"], check=True, stdout=sp.PIPE
+    )
+    assert check_init_template.returncode == 0
+    assert Path(path_HelloWorld).joinpath("recipe.yaml").resolve().exists()
+    config_file = Path(path_HelloWorld).joinpath("gdk-config.json").resolve()
+    assert config_file.exists()
+
+    # Update gdk-config file mandatory field like region.
+    t_utils.update_config(config_file, component_name, region, bucket, author)
+
+    os.chdir(path_HelloWorld)
+
+    check_publish_component = sp.run(["gdk", "component", "publish"], stdout=sp.PIPE)
+    assert check_publish_component.returncode == 0
+    assert Path(path_HelloWorld).joinpath("zip-build").resolve().exists()
+    assert Path(path_HelloWorld).joinpath("greengrass-build").resolve().exists()
+    artifact_path = (
+        Path(path_HelloWorld)
+        .joinpath("greengrass-build")
+        .joinpath("artifacts")
+        .joinpath(component_name)
+        .joinpath("NEXT_PATCH")
+        .joinpath("HelloWorld.zip")
+        .resolve()
+    )
+
+    assert artifact_path.exists()
+    recipes_path = Path(path_HelloWorld).joinpath("greengrass-build").joinpath("recipes").resolve()
+    t_utils.clean_up_aws_resources(component_name, t_utils.get_version_created(recipes_path, component_name), region)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- UATs for publish command with and without building the component.  
- Use https://github.com/aws-actions/configure-aws-credentials to manage credentials for session. ToDo: Update this to use other account. This PR is only for testing. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [x] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.