### PR TITLE
fix(build): find artifact with is_file instead of glob

### DIFF
--- a/gdk/commands/component/build.py
+++ b/gdk/commands/component/build.py
@@ -340,24 +340,26 @@ def is_artifact_in_build(artifact, build_folders):
     """
     artifact_uri = f"{utils.s3_prefix}BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION"
     gg_build_component_artifacts_dir = project_config["gg_build_component_artifacts_dir"]
-    artifact_file = Path(artifact["URI"]).name
+    artifact_file_name = Path(artifact["URI"]).name
     # If the artifact is present in build system specific build folder, copy it to greengrass artifacts build folder
     for build_folder in build_folders:
-        build_files = list(build_folder.glob(artifact_file))
-        if len(build_files) == 1:
+        artifact_file = Path(build_folder).joinpath(artifact_file_name).resolve()
+        if artifact_file.is_file():
             logging.debug(
-                "Copying file '{}' from '{}' to '{}'.".format(artifact_file, build_folder, gg_build_component_artifacts_dir)
+                "Copying file '{}' from '{}' to '{}'.".format(
+                    artifact_file_name, build_folder, gg_build_component_artifacts_dir
+                )
             )
-            shutil.copy(build_files[0], gg_build_component_artifacts_dir)
-            logging.debug("Updating artifact URI of '{}' in the recipe file.".format(artifact_file))
-            artifact["URI"] = f"{artifact_uri}/{artifact_file}"
+            shutil.copy(artifact_file, gg_build_component_artifacts_dir)
+            logging.debug("Updating artifact URI of '{}' in the recipe file.".format(artifact_file_name))
+            artifact["URI"] = f"{artifact_uri}/{artifact_file_name}"
             return True
         else:
             logging.debug(
-                f"Could not find the artifact file specified in the recipe '{artifact_file}' inside the build folder"
+                f"Could not find the artifact file specified in the recipe '{artifact_file_name}' inside the build folder"
                 f" '{build_folder}'."
             )
-    logging.warning(f"Could not find the artifact file '{artifact_file}' in the build folder '{build_folders}'.")
+    logging.warning(f"Could not find the artifact file '{artifact_file_name}' in the build folder '{build_folders}'.")
     return False
 
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Use `is_file()` to check if the artifact exists instead of `glob` to find the file that match the artifact name. 
- Using `glob` resulted in a bug on windows due to its case insensitive file system. 

**Why is this change necessary:**
In the zip-build system, when `HelloWorld.zip` is looked up in folder `zip-build/` using glob, it resulted in a list with file path - `/abs-path-to-the-file/helloworld.zip` on windows (case insensitive). 

This [file path](https://github.com/aws-greengrass/aws-greengrass-gdk-cli/blob/main/gdk/commands/component/build.py#L351) is used to copy the file from `zip-build/` to `greengrass-build/` resulting in a `helloworld.zip` inside the greengras-build folder instead of `HelloWorld.zip`which conflicts with file name in the final recipe. 

Listing file from directory - https://github.com/aws-greengrass/aws-greengrass-gdk-cli/runs/5115582225?check_suite_focus=true#step:10:4955

Unable to find HelloWorld.zip specified in the recipe https://github.com/aws-greengrass/aws-greengrass-gdk-cli/runs/5115582225?check_suite_focus=true#step:10:4950


**How was this change tested:**
Added UATs and unit tests. 

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [x] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.