### PR TITLE
refactor(init): check conflicting args before directory

### DIFF
--- a/gdk/commands/component/init.py
+++ b/gdk/commands/component/init.py
@@ -31,6 +31,9 @@ def run(command_args):
     -------
         None
     """
+    # Check if the command args are conflicting
+    if parse_args_actions.conflicting_arg_groups(command_args, "init"):
+        raise Exception(error_messages.INIT_WITH_CONFLICTING_ARGS)
     project_dir = utils.current_directory
     if not command_args["name"]:
         # Check if directory is not empty
@@ -44,10 +47,6 @@ def run(command_args):
             Path(project_dir).mkdir(exist_ok=False)
         except FileExistsError:
             raise Exception(error_messages.INIT_DIR_EXISTS_ERROR.format(project_dir.name))
-
-    # Check if the command args are conflicting
-    if parse_args_actions.conflicting_arg_groups(command_args, "init"):
-        raise Exception(error_messages.INIT_WITH_CONFLICTING_ARGS)
 
     # Choose appropriate action based on commands
     if command_args["template"] and command_args["language"]:

--- a/tests/gdk/commands/component/test_init.py
+++ b/tests/gdk/commands/component/test_init.py
@@ -19,7 +19,7 @@ def test_init_run_with_non_empty_directory(mocker):
     assert e.value.args[0] == error_messages.INIT_NON_EMPTY_DIR_ERROR
 
     assert mock_is_directory_empty.call_count == 1
-    assert mock_conflicting_args.call_count == 0
+    assert mock_conflicting_args.call_count == 1
     assert mock_init_with_template.call_count == 0
     assert mock_init_with_repository.call_count == 0
 
@@ -90,7 +90,7 @@ def test_init_run_with_conflicting_args(mocker):
 
     assert e.value.args[0] == error_messages.INIT_WITH_CONFLICTING_ARGS
 
-    assert mock_is_directory_empty.call_count == 1
+    assert mock_is_directory_empty.call_count == 0
     assert mock_init_with_template.call_count == 0
     assert mock_init_with_repository.call_count == 0
     assert mock_conflicting_args.call_count == 1


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Checks for conflicting arguments in the `init` command before performing directory operations such as checking if the current directory is empty or creating a new directory based on `name` arg. 

**Why is this change necessary:**
- In the cases where `init` command is run with both `name` and other conflicting arguments, new directory with `name` is created first before the command is exited with conflicting arguments exception.
If the customer corrects the  arguments in the command and runs again, now the command exists with directory exception and it is not customer friendly. 

With this change, the command exists with an exception first even before creating an empty directory. 

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.