### PR TITLE
fix(gradle): identify build folders properly

### DIFF
--- a/gdk/commands/component/build.py
+++ b/gdk/commands/component/build.py
@@ -262,16 +262,22 @@ def get_build_folders(build_folder, build_file):
 
     Parameters
     ----------
-        build_folder(string): Build foler of a build system(target, build/libs)
+        build_folder(string): Build folder of a build system(target, build/libs)
         build_file(string): Build configuration file of a build system (pom.xml, build.gradle)
 
     Returns
     -------
-        paths(list): List of build folder paths in a multi-module project.
+        paths(set): Set of build folder paths in a multi-module project.
     """
-    set_build_file = set(f.parent for f in Path(utils.current_directory).rglob(build_file))
-    set_build_folder = set(f.parent for f in Path(utils.current_directory).rglob(str(Path().joinpath(*build_folder))))
-    return set(x.joinpath(*build_folder) for x in (set_build_folder & set_build_file))
+    # Filter module directories which contain pom.xml or build.gradle build files.
+    set_dirs_with_build_file = set(f.parent for f in Path(utils.current_directory).rglob(build_file))
+    set_of_module_dirs = set()
+    for module_dir in set_dirs_with_build_file:
+        module_build_folder = Path(module_dir).joinpath(*build_folder).resolve()
+        # Filter module directories that also contain build folders - target/, build/libs/
+        if module_build_folder.exists():
+            set_of_module_dirs.add(module_build_folder)
+    return set_of_module_dirs
 
 
 def find_artifacts_and_update_uri():

--- a/gdk/static/project_build_schema.json
+++ b/gdk/static/project_build_schema.json
@@ -29,8 +29,7 @@
             "type": "object",
             "required": [
                 "build_command",
-                "build_folder",
-                "build_command_win"
+                "build_folder"
             ],
             "properties": {
                 "build_command": {

--- a/gdk/static/project_build_system.json
+++ b/gdk/static/project_build_system.json
@@ -19,10 +19,6 @@
             "gradle",
             "build"
         ],
-        "build_command_win": [
-            "gradlew",
-            "build"
-        ],
         "build_folder": [
             "build",
             "libs"

--- a/uat/t_utils.py
+++ b/uat/t_utils.py
@@ -16,15 +16,13 @@ def update_config(config_file, component_name, region, bucket, author):
 
 
 def clean_up_aws_resources(component_name, component_version, region):
-    sts_client = boto3.client("sts", region_name=region)
-    caller_identity_response = sts_client.get_caller_identity()
-    account_num = caller_identity_response["Account"]
+    account_num = get_acc_num(region)
     delete_component(component_name, component_version, region, account_num)
     delete_s3_artifact(region, account_num, component_name, component_version)
 
 
 def delete_s3_artifact(region, account, component_name, component_version):
-    s3_client = boto3.client("s3", region_name=region)
+    s3_client = create_s3_client(region)
     try:
         bucket = f"gdk-cli-uat-{region}-{account}"
         res = s3_client.list_objects(Bucket=bucket)
@@ -57,3 +55,13 @@ def get_version_created(recipes_path, component_name):
     split_file_name = file_name.split(f"{component_name}-")
     split_for_version = split_file_name[1].split(".yaml")[0]
     return split_for_version
+
+
+def create_s3_client(region):
+    return boto3.client("s3", region_name=region)
+
+
+def get_acc_num(region):
+    sts_client = boto3.client("sts", region_name=region)
+    caller_identity_response = sts_client.get_caller_identity()
+    return caller_identity_response["Account"]


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Correctly identifies the build folders for a specific build system. 
- Updated unit tests as needed. 

Instead of recursively finding the intersection of parents directories of build files and build folders in a given project which fails when there are multi-path build folders (a/b/c), we first identify the list of directories with build files in a project. We then iterate through this list and check if build folders also exist within them. 

**Why is this change necessary:**
This change properly identifies the project directories with build file (pom.xml, build.gradle) and build folders (target/, build/libs) recursively. 

**How was this change tested:**
- Added UAT for gradle build system with multiple projects. 
 - Added UAT for maven build system with multiple projects. 
 
**Any additional information or context required to review the change:**
Test data needed for multi project gradle and multi project maven build systems is downloaded from s3 bucket. 

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [x] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.