### PR TITLE
fix(logging): set logging basic config in gdk module __init__

### DIFF
--- a/gdk/CLIParser.py
+++ b/gdk/CLIParser.py
@@ -192,7 +192,6 @@ def main():
 
 
 try:
-    logging.basicConfig(level=logging.INFO, format=utils.log_format, datefmt="%Y-%m-%d %H:%M:%S", force=True)
     cli_tool = CLIParser(consts.cli_tool_name, None)
     cli_parser = cli_tool.create_parser()
 except Exception as e:

--- a/gdk/__init__.py
+++ b/gdk/__init__.py
@@ -1,0 +1,5 @@
+import logging
+
+import gdk.common.consts as consts
+
+logging.basicConfig(level=logging.INFO, format=consts.log_format, datefmt=consts.date_format)

--- a/gdk/common/consts.py
+++ b/gdk/common/consts.py
@@ -29,3 +29,7 @@ repository_list_url = (
     "https://raw.githubusercontent.com/aws-greengrass/aws-greengrass-software-catalog/main/cli-components/"
     + "community-components.json"
 )
+
+# DEFAULT LOGGING
+log_format = "[%(asctime)s] %(levelname)s - %(message)s"
+date_format = "%Y-%m-%d %H:%M:%S"

--- a/gdk/common/utils.py
+++ b/gdk/common/utils.py
@@ -133,7 +133,6 @@ def cli_version_check():
 error_line = "\n=============================== ERROR ===============================\n"
 help_line = "\n=============================== HELP ===============================\n"
 current_directory = Path(".").resolve()
-log_format = "[%(asctime)s] %(levelname)s - %(message)s"
 doc_link_device_role = "https://docs.aws.amazon.com/greengrass/v2/developerguide/device-service-role.html"
 cli_version = version.__version__
 latest_cli_version_file = "https://raw.githubusercontent.com/aws-greengrass/aws-greengrass-gdk-cli/main/gdk/_version.py"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Set basic config of the root logger in gdk `__init__` to make sure that root logger is configured first with the basic config before using it anywhere. This is because root logger ignores any config set on it after its default values are set unless we use force arg (available onlt in py3.8 or above). 

**Why is this change necessary:**
The basic config set in the current GDK doesn't work on versions < py 3.8 as force=True is not available. So, WARNING is set at as default and the log formatter is also not  applied as expected resulting in logs like  https://github.com/aws-greengrass/aws-greengrass-gdk-cli/runs/5150912788?check_suite_focus=true#step:11:23 instead of https://github.com/aws-greengrass/aws-greengrass-gdk-cli/runs/5225356195?check_suite_focus=true#step:11:33


**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.