### PR TITLE
test(integ): add integ tests for build & publish

### DIFF
--- a/integration_tests/gdk/components/test_integ_BuildCommand.py
+++ b/integration_tests/gdk/components/test_integ_BuildCommand.py
@@ -1,0 +1,491 @@
+import json
+from pathlib import Path
+from shutil import Error
+from unittest.mock import mock_open, patch
+
+import gdk.CLIParser as CLIParser
+import gdk.common.consts as consts
+import gdk.common.exceptions.error_messages as error_messages
+import gdk.common.parse_args_actions as parse_args_actions
+import gdk.common.utils as utils
+import pytest
+from gdk.commands.component.BuildCommand import BuildCommand
+
+
+@pytest.fixture()
+def supported_build_system(mocker):
+    builds_file = utils.get_static_file_path(consts.project_build_system_file)
+    with open(builds_file, "r") as f:
+        data = json.loads(f.read())
+    mock_get_supported_component_builds = mocker.patch(
+        "gdk.commands.component.project_utils.get_supported_component_builds", return_value=data
+    )
+    return mock_get_supported_component_builds
+
+
+@pytest.fixture()
+def rglob_build_file(mocker):
+    def search(*args, **kwargs):
+        if "build.gradle" in args[0] or "pom.xml" in args[0]:
+            return [Path(utils.current_directory).joinpath("build_file")]
+        return []
+
+    mock_rglob = mocker.patch("pathlib.Path.rglob", side_effect=search)
+    return mock_rglob
+
+
+def test_build_command_instantiation(mocker):
+    mock_get_supported_component_builds = mocker.patch(
+        "gdk.commands.component.project_utils.get_supported_component_builds", return_value={}
+    )
+    mock_check_if_arguments_conflict = mocker.patch.object(BuildCommand, "check_if_arguments_conflict", return_value=None)
+    mock_run = mocker.patch.object(BuildCommand, "run", return_value=None)
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        return_value={},
+    )
+    parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
+
+    assert mock_get_proj_config.call_count == 1
+    assert mock_get_supported_component_builds.call_count == 1
+    assert mock_check_if_arguments_conflict.call_count == 1
+    assert mock_run.call_count == 1
+
+
+def test_build_command_instantiation_failed_fetching_config(mocker):
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        side_effect=Exception("exception fetching proj values"),
+    )
+    mock_get_supported_component_builds = mocker.patch(
+        "gdk.commands.component.project_utils.get_supported_component_builds", return_value={}
+    )
+    mock_check_if_arguments_conflict = mocker.patch.object(BuildCommand, "check_if_arguments_conflict", return_value=None)
+    mock_run = mocker.patch.object(BuildCommand, "run", return_value=None)
+    with pytest.raises(Exception) as e:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
+    assert "exception fetching proj values" in e.value.args[0]
+    assert mock_get_proj_config.call_count == 1
+    assert mock_get_supported_component_builds.call_count == 0
+    assert mock_check_if_arguments_conflict.call_count == 1
+    assert mock_run.call_count == 0
+
+
+def test_build_command_instantiation_failed_fetching_build_config(mocker):
+
+    mock_get_supported_component_builds = mocker.patch(
+        "gdk.commands.component.project_utils.get_supported_component_builds",
+        side_effect=Exception("exception fetching build"),
+    )
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        return_value={},
+    )
+    mock_check_if_arguments_conflict = mocker.patch.object(BuildCommand, "check_if_arguments_conflict", return_value=None)
+    mock_run = mocker.patch.object(BuildCommand, "run", return_value=None)
+    with pytest.raises(Exception) as e:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
+    assert "exception fetching build" in e.value.args[0]
+    assert mock_get_proj_config.call_count == 1
+    assert mock_get_supported_component_builds.call_count == 1
+    assert mock_check_if_arguments_conflict.call_count == 1
+    assert mock_run.call_count == 0
+
+
+def test_build_command_instantiation_failed_conflicting_args(mocker):
+
+    mock_get_supported_component_builds = mocker.patch(
+        "gdk.commands.component.project_utils.get_supported_component_builds", return_value={}
+    )
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        side_effect=Exception("exception fetching proj values"),
+    )
+    mock_check_if_arguments_conflict = mocker.patch.object(
+        BuildCommand,
+        "check_if_arguments_conflict",
+        side_effect=Exception("exception due to conflictins args"),
+    )
+    mock_run = mocker.patch.object(BuildCommand, "run", return_value=None)
+    with pytest.raises(Exception) as e:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
+    assert "exception due to conflictins args" in e.value.args[0]
+    assert mock_get_proj_config.call_count == 0
+    assert mock_get_supported_component_builds.call_count == 0
+    assert mock_check_if_arguments_conflict.call_count == 1
+    assert mock_run.call_count == 0
+
+
+def test_build_run():
+    with pytest.raises(Exception) as e:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
+    assert "Could not build the project due to the following error." in e.value.args[0]
+
+
+def test_build_run_default_zip_json(mocker, supported_build_system, rglob_build_file):
+    mock_clean_dir = mocker.patch("gdk.common.utils.clean_dir", return_value=None)
+    mock_create_dir = mocker.patch("pathlib.Path.mkdir", return_value=None)
+    mock_copy_dir = mocker.patch("shutil.copytree", return_value=None)
+    mock_archive_dir = mocker.patch("shutil.make_archive", return_value=None)
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        return_value=project_config(),
+    )
+
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        return_value=project_config(),
+    )
+    mock_is_artifact_in_build = mocker.patch.object(BuildCommand, "is_artifact_in_build", return_value=True)
+
+    mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_json_dump = mocker.patch("json.dumps")
+    pc = mock_get_proj_config.return_value
+    file_name = Path(pc["gg_build_recipes_dir"]).joinpath(pc["component_recipe_file"].name).resolve()
+    with patch("builtins.open", mock_open()) as mock_file:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
+        mock_file.assert_any_call(file_name, "w")
+        mock_json_dump.call_count == 1
+
+    assert mock_get_proj_config.assert_called_once
+    assert not mock_subprocess_run.called
+    assert mock_copy_dir.call_count == 1  # copy files to zip-build to create a zip
+    assert mock_archive_dir.call_count == 1  # archiving directory
+    assert mock_is_artifact_in_build.call_count == 1  # only one artifact in project_config. Available in build
+    assert mock_clean_dir.call_count == 2  # clean zip-build, clean greengrass-build
+    assert mock_create_dir.call_count == 2  # create gg directories
+
+
+def test_build_run_default_maven_yaml(mocker, supported_build_system, rglob_build_file):
+
+    mock_clean_dir = mocker.patch("gdk.common.utils.clean_dir", return_value=None)
+    mock_create_dir = mocker.patch("pathlib.Path.mkdir", return_value=None)
+    mock_copy_dir = mocker.patch("shutil.copytree", return_value=None)
+    mock_archive_dir = mocker.patch("shutil.make_archive", return_value=None)
+    pc = project_config()
+    pc["component_build_config"] = {"build_system": "maven"}
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        return_value=pc,
+    )
+    mock_platform = mocker.patch("platform.system", return_value="not-windows")
+    pc["component_recipe_file"] = Path("/src/GDK-CLI-Internal/tests/gdk/static/build_command/recipe.yaml")
+    mock_is_artifact_in_build = mocker.patch.object(BuildCommand, "is_artifact_in_build", return_value=True)
+
+    mock_subprocess_run = mocker.patch("subprocess.run")
+    pc = mock_get_proj_config.return_value
+    file_name = Path(pc["gg_build_recipes_dir"]).joinpath(pc["component_recipe_file"].name).resolve()
+
+    with patch("builtins.open", mock_open()) as mock_file:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
+        mock_file.assert_any_call(file_name, "w")
+    assert mock_get_proj_config.assert_called_once
+    mock_subprocess_run.assert_called_with(["mvn", "clean", "package"])  # called maven build command
+    assert mock_copy_dir.call_count == 0  # No copying directories
+    assert supported_build_system.call_count == 1
+    assert mock_archive_dir.call_count == 0  # Archvie never called in maven
+    assert mock_is_artifact_in_build.call_count == 1  # only one artifact in project_config. Available in build
+    assert mock_clean_dir.call_count == 1  # clean greengrass-build
+    assert mock_create_dir.call_count == 2  # create gg directories
+    assert mock_platform.call_count == 1
+
+
+def test_build_run_default_maven_yaml_windows(mocker, supported_build_system, rglob_build_file):
+
+    mock_clean_dir = mocker.patch("gdk.common.utils.clean_dir", return_value=None)
+    mock_create_dir = mocker.patch("pathlib.Path.mkdir", return_value=None)
+    mock_copy_dir = mocker.patch("shutil.copytree", return_value=None)
+    mock_archive_dir = mocker.patch("shutil.make_archive", return_value=None)
+    mock_platform = mocker.patch("platform.system", return_value="Windows")
+    pc = project_config()
+    pc["component_build_config"] = {"build_system": "maven"}
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        return_value=pc,
+    )
+
+    mock_is_artifact_in_build = mocker.patch.object(BuildCommand, "is_artifact_in_build", return_value=True)
+
+    mock_subprocess_run = mocker.patch("subprocess.run", side_effect="error with maven build cmd")
+    mock_yaml_dump = mocker.patch("yaml.dump")
+    pc = mock_get_proj_config.return_value
+    file_name = Path(pc["gg_build_recipes_dir"]).joinpath(pc["component_recipe_file"].name).resolve()
+
+    with patch("builtins.open", mock_open()) as mock_file:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
+        mock_file.assert_any_call(file_name, "w")
+        mock_yaml_dump.call_count == 1
+    assert mock_get_proj_config.assert_called_once
+    mock_subprocess_run.assert_called_with(["mvn.cmd", "clean", "package"])  # called maven build command
+    assert mock_copy_dir.call_count == 0  # No copying directories
+    assert supported_build_system.call_count == 1
+    assert mock_archive_dir.call_count == 0  # Archvie never called in maven
+    assert mock_is_artifact_in_build.call_count == 1  # only one artifact in project_config. Available in build
+    assert mock_clean_dir.call_count == 1  # clean greengrass-build
+    assert mock_create_dir.call_count == 2  # create gg directories
+    assert mock_platform.call_count == 1
+
+
+def test_build_run_default_maven_yaml_error(mocker, supported_build_system, rglob_build_file):
+
+    mock_clean_dir = mocker.patch("gdk.common.utils.clean_dir", return_value=None)
+    mock_create_dir = mocker.patch("pathlib.Path.mkdir", return_value=None)
+    mock_copy_dir = mocker.patch("shutil.copytree", return_value=None)
+    mock_archive_dir = mocker.patch("shutil.make_archive", return_value=None)
+    mock_platform = mocker.patch("platform.system", return_value="Windows")
+    pc = project_config()
+    pc["component_build_config"] = {"build_system": "maven"}
+    pc["component_recipe_file"] = Path("/src/GDK-CLI-Internal/tests/gdk/static/build_command/recipe.yaml")
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        return_value=pc,
+    )
+
+    mock_is_artifact_in_build = mocker.patch.object(BuildCommand, "is_artifact_in_build", return_value=True)
+
+    mock_subprocess_run = mocker.patch("subprocess.run", side_effect=Exception("error with maven build cmd"))
+    pc = mock_get_proj_config.return_value
+
+    with pytest.raises(Exception) as e:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build", "-d"]))
+    assert "error with maven build cmd" in e.value.args[0]
+    assert mock_get_proj_config.assert_called_once
+    mock_subprocess_run.assert_called_with(["mvn.cmd", "clean", "package"])  # called maven build command
+    assert mock_copy_dir.call_count == 0  # No copying directories
+    assert supported_build_system.call_count == 1
+    assert mock_archive_dir.call_count == 0  # Archvie never called in maven
+    assert mock_is_artifact_in_build.call_count == 0  # only one artifact in project_config. Available in build
+    assert mock_clean_dir.call_count == 1  # clean greengrass-build
+    assert mock_create_dir.call_count == 2  # create gg directories
+    assert mock_platform.called
+
+
+def test_build_run_default_gradle_yaml_artifact_not_found(mocker, supported_build_system, rglob_build_file):
+
+    mock_clean_dir = mocker.patch("gdk.common.utils.clean_dir", return_value=None)
+    mock_create_dir = mocker.patch("pathlib.Path.mkdir", return_value=None)
+    mock_copy_dir = mocker.patch("shutil.copytree", return_value=None)
+    mock_archive_dir = mocker.patch("shutil.make_archive", return_value=None)
+    pc = project_config()
+    pc["component_build_config"] = {"build_system": "gradle"}
+    pc["component_recipe_file"] = Path("/src/GDK-CLI-Internal/tests/gdk/static/build_command/recipe.yaml")
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        return_value=pc,
+    )
+
+    mock_boto3_client = mocker.patch("boto3.client")
+    mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_yaml_dump = mocker.patch("yaml.dump")
+    pc = mock_get_proj_config.return_value
+
+    with patch("builtins.open", mock_open()) as mock_file:
+        with pytest.raises(Exception) as e:
+            parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
+            assert (
+                "Could not find artifact with URI"
+                " 's3://DOC-EXAMPLE-BUCKET/artifacts/com.example.HelloWorld/1.0.0/hello_world.py' on s3 or inside"
+                " the build folders."
+                in e.value.args[0]
+            )
+            assert not mock_file.called
+            mock_yaml_dump.call_count == 0
+    assert mock_get_proj_config.assert_called_once
+    mock_subprocess_run.assert_called_with(["gradle", "build"])  # called gradle build command
+    assert mock_copy_dir.call_count == 0  # No copying directories
+    assert supported_build_system.call_count == 1
+    assert mock_archive_dir.call_count == 0  # Archvie never called in gralde
+    assert mock_boto3_client.call_count == 1
+    assert mock_clean_dir.call_count == 1  # clean greengrass-build
+    assert mock_create_dir.call_count == 2  # create gg directories
+
+
+def test_build_run_default_exception(mocker, rglob_build_file):
+    mock_create_gg_build_directories = mocker.patch.object(BuildCommand, "create_gg_build_directories")
+    mock_default_build_component = mocker.patch.object(
+        BuildCommand, "default_build_component", side_effect=Exception("error in default_build_component")
+    )
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        return_value=project_config(),
+    )
+
+    mock_get_supported_component_builds = mocker.patch(
+        "gdk.commands.component.project_utils.get_supported_component_builds", return_value={}
+    )
+    mock_subprocess_run = mocker.patch("subprocess.run")
+    with pytest.raises(Exception) as e:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
+    assert "error in default_build_component" in e.value.args[0]
+    assert mock_get_proj_config.called
+    assert mock_get_supported_component_builds.called
+    assert mock_create_gg_build_directories.assert_called_once
+    assert mock_default_build_component.assert_called_once
+    assert not mock_subprocess_run.called
+
+
+def test_default_build_component_error_run_build_command(mocker, rglob_build_file):
+    mock_clean_dir = mocker.patch("gdk.common.utils.clean_dir", return_value=None)
+    mock_create_dir = mocker.patch("pathlib.Path.mkdir", return_value=None)
+    mock_run_build_command = mocker.patch.object(
+        BuildCommand, "run_build_command", side_effect=Error("err in run_build_command")
+    )
+    mock_find_artifacts_and_update_uri = mocker.patch.object(BuildCommand, "find_artifacts_and_update_uri")
+    mock_create_build_recipe_file = mocker.patch.object(BuildCommand, "create_build_recipe_file")
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        return_value=project_config(),
+    )
+    mock_get_supported_component_builds = mocker.patch(
+        "gdk.commands.component.project_utils.get_supported_component_builds", return_value={}
+    )
+    with pytest.raises(Exception) as e:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
+    assert error_messages.BUILD_FAILED in e.value.args[0]
+    assert mock_run_build_command.assert_called_once
+    assert not mock_find_artifacts_and_update_uri.called
+    assert not mock_create_build_recipe_file.called
+
+    assert mock_get_supported_component_builds.called
+    assert mock_clean_dir.call_count == 1
+    assert mock_create_dir.call_count == 2
+    assert mock_get_proj_config.call_count == 1
+
+
+def test_build_run_custom(mocker, supported_build_system, rglob_build_file):
+    mock_clean_dir = mocker.patch("gdk.common.utils.clean_dir", return_value=None)
+    mock_create_dir = mocker.patch("pathlib.Path.mkdir", return_value=None)
+    mock_copy_dir = mocker.patch("shutil.copytree", return_value=None)
+    pc = project_config()
+    pc["component_build_config"] = {"build_system": "custom", "custom_build_command": ["some-command"]}
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        return_value=pc,
+    )
+
+    mock_is_artifact_in_build = mocker.patch.object(BuildCommand, "is_artifact_in_build", return_value=False)
+    mock_is_artifact_in_s3 = mocker.patch.object(BuildCommand, "is_artifact_in_s3", return_value=True)
+    mock_boto3_client = mocker.patch("boto3.client")
+    mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_yaml_dump = mocker.patch("yaml.dump")
+    pc = mock_get_proj_config.return_value
+
+    with patch("builtins.open", mock_open()) as mock_file:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
+        assert not mock_file.called
+        mock_yaml_dump.call_count == 0
+    assert mock_get_proj_config.assert_called_once
+    mock_subprocess_run.assert_called_with(["some-command"])  # called maven build command
+    assert mock_copy_dir.call_count == 0  # No copying directories
+    assert supported_build_system.call_count == 1
+    assert mock_is_artifact_in_build.call_count == 0  # only one artifact in project_config. Not vailable in build
+    assert mock_is_artifact_in_s3.call_count == 0  # only one artifact in project_config. Not available in s3
+    assert mock_boto3_client.call_count == 0
+    assert mock_clean_dir.call_count == 1  # clean greengrass-build
+    assert mock_create_dir.call_count == 2  # create gg directories
+
+
+def test_build_run_default_gradle_yaml_artifact_found_build(mocker, supported_build_system, rglob_build_file):
+
+    mock_clean_dir = mocker.patch("gdk.common.utils.clean_dir", return_value=None)
+    mock_create_dir = mocker.patch("pathlib.Path.mkdir", return_value=None)
+    mock_copy_dir = mocker.patch("shutil.copytree", return_value=None)
+    mock_archive_dir = mocker.patch("shutil.make_archive", return_value=None)
+    pc = project_config()
+    pc["component_build_config"] = {"build_system": "gradle"}
+    pc["component_recipe_file"] = Path("/src/GDK-CLI-Internal/tests/gdk/static/build_command/recipe.yaml")
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        return_value=pc,
+    )
+
+    mock_boto3_client = mocker.patch("boto3.client")
+    mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_yaml_dump = mocker.patch("yaml.dump")
+    pc = mock_get_proj_config.return_value
+    mocker.patch("pathlib.Path.is_file", return_value=True)
+    mock_copy_file = mocker.patch("shutil.copy", return_value=None)
+    mock_exists = mocker.patch("pathlib.Path.exists", return_value=True)
+    file_name = Path(pc["gg_build_recipes_dir"]).joinpath(pc["component_recipe_file"].name).resolve()
+    with patch("builtins.open", mock_open()) as mock_file:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
+        mock_file.assert_any_call(file_name, "w")
+        mock_yaml_dump.call_count == 0
+    assert mock_get_proj_config.assert_called_once
+    mock_subprocess_run.assert_called_with(["gradle", "build"])  # called gradle build command
+    assert mock_copy_dir.call_count == 0  # No copying directories
+    assert supported_build_system.call_count == 1
+    assert mock_archive_dir.call_count == 0  # Archvie never called in gralde
+    assert mock_boto3_client.call_count == 0  # artifacts found in s3
+    assert mock_clean_dir.call_count == 1  # clean greengrass-build
+    assert mock_create_dir.call_count == 2  # create gg directories
+    assert mock_copy_file.call_count == 1
+    assert mock_exists.called
+
+
+def test_build_run_default_gradle_yaml_error_creating_recipe(mocker, supported_build_system, rglob_build_file):
+
+    mock_clean_dir = mocker.patch("gdk.common.utils.clean_dir", return_value=None)
+    mock_create_dir = mocker.patch("pathlib.Path.mkdir", return_value=None)
+    mock_copy_dir = mocker.patch("shutil.copytree", return_value=None)
+    mock_archive_dir = mocker.patch("shutil.make_archive", return_value=None)
+    pc = project_config()
+    pc["component_build_config"] = {"build_system": "gradle"}
+    pc["component_recipe_file"] = Path("/src/GDK-CLI-Internal/tests/gdk/static/build_command/recipe.yaml")
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        return_value=pc,
+    )
+
+    mock_boto3_client = mocker.patch("boto3.client")
+    mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_yaml_dump = mocker.patch("yaml.dump", side_effect=Exception("writing failed"))
+    pc = mock_get_proj_config.return_value
+    mock_is_artifact_in_build = mocker.patch.object(BuildCommand, "is_artifact_in_build", return_value=True)
+    file_name = Path(pc["gg_build_recipes_dir"]).joinpath(pc["component_recipe_file"].name).resolve()
+    with patch("builtins.open", mock_open()) as mock_file:
+        with pytest.raises(Exception) as e:
+            parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
+            mock_file.assert_any_call(file_name, "w")
+            mock_yaml_dump.call_count == 1
+        assert "Failed to create build recipe file at" in e.value.args[0]
+    assert mock_get_proj_config.assert_called_once
+    mock_subprocess_run.assert_called_with(["gradle", "build"])  # called gradle build command
+    assert mock_copy_dir.call_count == 0  # No copying directories
+    assert supported_build_system.call_count == 1
+    assert mock_is_artifact_in_build.call_count == 1
+    assert mock_archive_dir.call_count == 0  # Archvie never called in gralde
+    assert mock_boto3_client.call_count == 0  # artifacts found in s3
+    assert mock_clean_dir.call_count == 1  # clean greengrass-build
+    assert mock_create_dir.call_count == 2  # create gg directories
+
+
+def project_config():
+    return {
+        "component_name": "component_name",
+        "component_build_config": {"build_system": "zip"},
+        "component_version": "1.0.0",
+        "component_author": "abc",
+        "bucket": "default",
+        "region": "us-east-1",
+        "gg_build_directory": Path("/src/GDK-CLI-Internal/greengrass-build"),
+        "gg_build_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts"),
+        "gg_build_recipes_dir": Path("/src/GDK-CLI-Internal/greengrass-build/recipes"),
+        "gg_build_component_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts/component_name/1.0.0"),
+        "component_recipe_file": Path("/src/GDK-CLI-Internal/tests/gdk/static/build_command/valid_component_recipe.json"),
+        "parsed_component_recipe": {
+            "RecipeFormatVersion": "2020-01-25",
+            "ComponentName": "com.example.HelloWorld",
+            "ComponentVersion": "1.0.0",
+            "ComponentDescription": "My first Greengrass component.",
+            "ComponentPublisher": "Amazon",
+            "ComponentConfiguration": {"DefaultConfiguration": {"Message": "world"}},
+            "Manifests": [
+                {
+                    "Platform": {"os": "linux"},
+                    "Lifecycle": {"Run": "python3 -u {artifacts:path}/hello_world.py '{configuration:/Message}'"},
+                    "Artifacts": [{"URI": "s3://DOC-EXAMPLE-BUCKET/artifacts/com.example.HelloWorld/1.0.0/hello_world.py"}],
+                }
+            ],
+        },
+    }

--- a/integration_tests/gdk/components/test_integ_PublishCommand.py
+++ b/integration_tests/gdk/components/test_integ_PublishCommand.py
@@ -1,0 +1,409 @@
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import boto3
+import gdk.CLIParser as CLIParser
+import gdk.common.parse_args_actions as parse_args_actions
+import pytest
+from gdk.commands.component.PublishCommand import PublishCommand
+
+
+@pytest.fixture()
+def mock_project_config(mocker):
+    mock_get_proj_config = mocker.patch(
+        "gdk.commands.component.project_utils.get_project_config_values",
+        return_value=project_config(),
+    )
+    mocker.patch(
+        "gdk.commands.component.project_utils.parse_recipe_file",
+        return_value=mock_get_proj_config.return_value["parsed_component_recipe"],
+    )
+    return mock_get_proj_config
+
+
+@pytest.fixture()
+def get_service_clients(mocker):
+    region = project_config()["region"]
+    service_clients = {}
+    service_clients["sts_client"] = boto3.client("sts", region_name=region)
+    service_clients["s3_client"] = boto3.client("s3", region_name=region)
+    service_clients["greengrass_client"] = boto3.client("greengrassv2", region_name=region)
+    mocker.patch("gdk.commands.component.project_utils.get_service_clients", return_value=service_clients)
+    mocker.patch.object(service_clients["sts_client"], "get_caller_identity", return_value={"Account": 1234})
+    mocker.patch.object(service_clients["s3_client"], "create_bucket", return_value=None)
+    mocker.patch.object(service_clients["s3_client"], "upload_file", return_value=None)
+    mocker.patch.object(service_clients["greengrass_client"], "create_component_version", return_value=None)
+    mocker.patch.object(
+        service_clients["greengrass_client"],
+        "list_component_versions",
+        return_value={"componentVersions": [{"componentVersion": "1.0.4"}, {"componentVersion": "1.0.1"}]},
+    )
+    return service_clients
+
+
+def test_publish_command_instantiation(mocker, mock_project_config):
+    mock_check_if_arguments_conflict = mocker.patch.object(PublishCommand, "check_if_arguments_conflict", return_value=None)
+    mock_run = mocker.patch.object(PublishCommand, "run", return_value=None)
+    mock_get_service_clients = mocker.patch(
+        "gdk.commands.component.project_utils.get_service_clients",
+        return_value={},
+    )
+    parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "publish"]))
+
+    assert mock_project_config.call_count == 1
+    assert mock_check_if_arguments_conflict.call_count == 1
+    assert mock_run.call_count == 1
+    assert mock_get_service_clients.call_count == 1
+
+
+def test_publish_run_already_built(mocker, get_service_clients, mock_project_config):
+    mock_build_dir_exists = mocker.patch(
+        "gdk.common.utils.dir_exists",
+        return_value=True,
+    )
+    pc = mock_project_config.return_value
+    mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=[Path("hello_world.py")])
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=[Path("hello_world.py")])
+    file_name = (
+        Path(pc["gg_build_recipes_dir"]).joinpath("{}-{}.json".format(pc["component_name"], pc["component_version"])).resolve()
+    )
+
+    spy_get_caller_identity = mocker.spy(get_service_clients["sts_client"], "get_caller_identity")
+    spy_create_bucket = mocker.patch.object(get_service_clients["s3_client"], "create_bucket")
+    spy_upload_file = mocker.patch.object(get_service_clients["s3_client"], "upload_file")
+    spy_create_component = mocker.patch.object(get_service_clients["greengrass_client"], "create_component_version")
+    with patch("builtins.open", mock_open()) as mock_file:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "publish"]))
+        mock_file.assert_any_call(file_name, "w")
+    assert mock_build_dir_exists.call_count == 1  # Checks if build directory exists
+    assert mock_iter_dir.call_count == 1  # Checks if there is at least one artifact to upload
+    assert mock_glob.call_count == 1  # Checks if artifact in the recipe exist in the build directory
+
+    # Assert cloud calls
+    assert spy_create_bucket.call_count == 1  # Tries to create a bucket if at least one artifact needs to be uploaded
+    spy_create_bucket.assert_called_with(Bucket="default-us-east-1-1234")
+    assert spy_upload_file.call_count == 1  # Only one file to upload
+    assert spy_create_component.call_count == 1  # Create gg private component
+    assert spy_get_caller_identity.call_count == 1  # Get account number
+
+
+def test_publish_run_with_bucket_argument(mocker, get_service_clients, mock_project_config):
+    mock_build_dir_exists = mocker.patch(
+        "gdk.common.utils.dir_exists",
+        return_value=True,
+    )
+    pc = mock_project_config.return_value
+    mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=[Path("hello_world.py")])
+
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=[Path("hello_world.py")])
+    file_name = (
+        Path(pc["gg_build_recipes_dir"]).joinpath("{}-{}.json".format(pc["component_name"], pc["component_version"])).resolve()
+    )
+
+    spy_get_caller_identity = mocker.spy(get_service_clients["sts_client"], "get_caller_identity")
+    spy_create_bucket = mocker.patch.object(get_service_clients["s3_client"], "create_bucket")
+    spy_upload_file = mocker.patch.object(get_service_clients["s3_client"], "upload_file")
+    spy_create_component = mocker.patch.object(get_service_clients["greengrass_client"], "create_component_version")
+    with patch("builtins.open", mock_open()) as mock_file:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "publish", "-b", "new-bucket-arg"]))
+        mock_file.assert_any_call(file_name, "w")
+    assert mock_build_dir_exists.call_count == 1  # Checks if build directory exists
+    assert mock_iter_dir.call_count == 1  # Checks if there is at least one artifact to upload
+    assert mock_glob.call_count == 1  # Checks if artifact in the recipe exist in the build directory
+
+    # Assert cloud calls
+    assert spy_create_bucket.call_count == 1  # Tries to create a bucket if at least one artifact needs to be uploaded
+    spy_create_bucket.assert_called_with(Bucket="new-bucket-arg")  # Use exact bucket arg
+    assert spy_upload_file.call_count == 1  # Only one file to upload
+    assert spy_create_component.call_count == 1  # Create gg private component
+    assert spy_get_caller_identity.call_count == 1  # Get account number
+
+
+def test_publish_run_next_patch(mocker, get_service_clients, mock_project_config):
+    mock_build_dir_exists = mocker.patch(
+        "gdk.common.utils.dir_exists",
+        return_value=True,
+    )
+    pc = mock_project_config.return_value
+    pc["component_version"] = "NEXT_PATCH"
+    mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=[Path("hello_world.py")])
+
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=[Path("hello_world.py")])
+    # Next patch version based on test data
+    file_name = Path(pc["gg_build_recipes_dir"]).joinpath("{}-{}.json".format(pc["component_name"], "1.0.5")).resolve()
+
+    spy_get_caller_identity = mocker.spy(get_service_clients["sts_client"], "get_caller_identity")
+    spy_create_bucket = mocker.patch.object(get_service_clients["s3_client"], "create_bucket")
+    spy_upload_file = mocker.patch.object(get_service_clients["s3_client"], "upload_file")
+    spy_create_component = mocker.patch.object(get_service_clients["greengrass_client"], "create_component_version")
+    with patch("builtins.open", mock_open()) as mock_file:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "publish"]))
+        mock_file.assert_any_call(file_name, "w")
+    assert mock_build_dir_exists.call_count == 1  # Checks if build directory exists
+    assert mock_iter_dir.call_count == 1  # Checks if there is at least one artifact to upload
+    assert mock_glob.call_count == 1  # Checks if artifact in the recipe exist in the build directory
+
+    # Assert cloud calls
+    assert spy_create_bucket.call_count == 1  # Tries to create a bucket if at least one artifact needs to be uploaded
+    spy_create_bucket.assert_called_with(Bucket="default-us-east-1-1234")
+    assert spy_upload_file.call_count == 1  # Only one file to upload
+    assert spy_create_component.call_count == 1  # Create gg private component
+    assert spy_get_caller_identity.call_count == 1  # Get account number
+
+
+def test_publish_run_next_patch_doesnt_exist(mocker, get_service_clients, mock_project_config):
+    mock_build_dir_exists = mocker.patch(
+        "gdk.common.utils.dir_exists",
+        return_value=True,
+    )
+    pc = mock_project_config.return_value
+    pc["component_version"] = "NEXT_PATCH"
+    mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=[Path("hello_world.py")])
+
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=[Path("hello_world.py")])
+    # Next patch version based on test data
+    file_name = Path(pc["gg_build_recipes_dir"]).joinpath("{}-{}.json".format(pc["component_name"], "1.0.0")).resolve()
+    mocker.patch.object(
+        get_service_clients["greengrass_client"],
+        "list_component_versions",
+        return_value={"componentVersions": []},
+    )
+    spy_get_caller_identity = mocker.spy(get_service_clients["sts_client"], "get_caller_identity")
+    spy_create_bucket = mocker.patch.object(get_service_clients["s3_client"], "create_bucket")
+    spy_upload_file = mocker.patch.object(get_service_clients["s3_client"], "upload_file")
+    spy_create_component = mocker.patch.object(get_service_clients["greengrass_client"], "create_component_version")
+    with patch("builtins.open", mock_open()) as mock_file:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "publish"]))
+        mock_file.assert_any_call(file_name, "w")
+    assert mock_build_dir_exists.call_count == 1  # Checks if build directory exists
+    assert mock_iter_dir.call_count == 1  # Checks if there is at least one artifact to upload
+    assert mock_glob.call_count == 1  # Checks if artifact in the recipe exist in the build directory
+
+    # Assert cloud calls
+    assert spy_create_bucket.call_count == 1  # Tries to create a bucket if at least one artifact needs to be uploaded
+    spy_create_bucket.assert_called_with(Bucket="default-us-east-1-1234")
+    assert spy_upload_file.call_count == 1  # Only one file to upload
+    assert spy_create_component.call_count == 1  # Create gg private component
+    assert spy_get_caller_identity.call_count == 1  # Get account number
+
+
+def test_publish_run_not_built(mocker, get_service_clients, mock_project_config):
+    mock_build_dir_exists = mocker.patch(
+        "gdk.common.utils.dir_exists",
+        return_value=False,
+    )
+    mock_build = mocker.patch("gdk.commands.component.component.build", return_value=None)
+
+    pc = mock_project_config.return_value
+    mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=[Path("hello_world.py")])
+
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=[Path("hello_world.py")])
+    file_name = (
+        Path(pc["gg_build_recipes_dir"]).joinpath("{}-{}.json".format(pc["component_name"], pc["component_version"])).resolve()
+    )
+
+    spy_get_caller_identity = mocker.spy(get_service_clients["sts_client"], "get_caller_identity")
+    spy_create_bucket = mocker.patch.object(get_service_clients["s3_client"], "create_bucket")
+    spy_upload_file = mocker.patch.object(get_service_clients["s3_client"], "upload_file")
+    spy_create_component = mocker.patch.object(get_service_clients["greengrass_client"], "create_component_version")
+    with patch("builtins.open", mock_open()) as mock_file:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "publish"]))
+        mock_file.assert_any_call(file_name, "w")
+    assert mock_build_dir_exists.call_count == 1  # Checks if build directory exists
+    assert mock_build.call_count == 1  # build the component first
+    assert mock_iter_dir.call_count == 1  # Checks if there is at least one artifact to upload
+    assert mock_glob.call_count == 1  # Checks if artifact in the recipe exist in the build directory
+
+    # Assert cloud calls
+    assert spy_create_bucket.call_count == 1  # Tries to create a bucket if at least one artifact needs to be uploaded
+    assert spy_upload_file.call_count == 1  # Only one file to upload
+    assert spy_create_component.call_count == 1  # Create gg private component
+    assert spy_get_caller_identity.call_count == 1  # Get account number
+
+
+def test_publish_run_error_during_upload(mocker, get_service_clients, mock_project_config):
+    mock_build_dir_exists = mocker.patch(
+        "gdk.common.utils.dir_exists",
+        return_value=True,
+    )
+    pc = mock_project_config.return_value
+    mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=[Path("hello_world.py")])
+
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=[Path("hello_world.py")])
+    file_name = Path(pc["gg_build_recipes_dir"]).joinpath("{}-{}.json".format(pc["component_name"], "1.0.0")).resolve()
+
+    spy_get_caller_identity = mocker.spy(get_service_clients["sts_client"], "get_caller_identity")
+    spy_create_bucket = mocker.patch.object(get_service_clients["s3_client"], "create_bucket")
+
+    spy_create_component = mocker.patch.object(get_service_clients["greengrass_client"], "create_component_version")
+
+    mocker.patch.object(get_service_clients["s3_client"], "upload_file", side_effect=Exception("Error in upload"))
+    with pytest.raises(Exception) as e:
+        with patch("builtins.open", mock_open()) as mock_file:
+            parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "publish"]))
+            mock_file.assert_any_call(file_name, "w")
+        assert "Error in upload" in e.args.value[0]
+    assert mock_build_dir_exists.call_count == 1  # Checks if build directory exists
+    assert mock_iter_dir.call_count == 1  # Checks if there is at least one artifact to upload
+    assert mock_glob.call_count == 0  # Recipe is not updated
+
+    # Assert cloud calls
+    assert spy_create_bucket.call_count == 1  # Tries to create a bucket if at least one artifact needs to be uploaded
+    spy_create_bucket.assert_called_with(Bucket="default-us-east-1-1234")
+    assert spy_create_component.call_count == 0  # GG component is not created
+    assert spy_get_caller_identity.call_count == 1  # Get account number
+
+
+def test_publish_run_bucket_exists(mocker, get_service_clients, mock_project_config):
+    mock_build_dir_exists = mocker.patch(
+        "gdk.common.utils.dir_exists",
+        return_value=True,
+    )
+    pc = mock_project_config.return_value
+    mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=[Path("hello_world.py")])
+
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=[Path("hello_world.py")])
+    # Next patch version based on test data
+    file_name = Path(pc["gg_build_recipes_dir"]).joinpath("{}-{}.json".format(pc["component_name"], "1.0.0")).resolve()
+
+    spy_get_caller_identity = mocker.spy(get_service_clients["sts_client"], "get_caller_identity")
+
+    def throw_err(*args, **kwargs):
+        ex = boto3.client("s3").exceptions.BucketAlreadyExists(
+            {"Error": {"Code": "BucketAlreadyExists", "Message": "fake message"}}, "CreateBucket"
+        )
+        raise ex
+
+    mock_create_bucket_err = mocker.patch.object(get_service_clients["s3_client"], "create_bucket", side_effect=throw_err)
+    spy_create_component = mocker.patch.object(get_service_clients["greengrass_client"], "create_component_version")
+    mocker.patch.object(get_service_clients["s3_client"], "upload_file", return_value=None)
+    with pytest.raises(Exception) as e:
+        with patch("builtins.open", mock_open()) as mock_file:
+            parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "publish"]))
+            mock_file.assert_any_call(file_name, "w")
+        assert (
+            "An error occurred (BucketAlreadyExists) when calling the CreateBucket operation: fake message" in e.value.args[0]
+        )
+    assert mock_build_dir_exists.call_count == 1  # Checks if build directory exists
+    assert mock_iter_dir.call_count == 1  # Checks if there is at least one artifact to upload
+    assert mock_glob.call_count == 0  # Recipe is not updated
+
+    # Assert cloud calls
+    assert mock_create_bucket_err.call_count == 1  # Tries to create a bucket if at least one artifact needs to be uploaded
+    mock_create_bucket_err.assert_called_with(Bucket="default-us-east-1-1234")
+    assert spy_create_component.call_count == 0  # GG component is not created
+    assert spy_get_caller_identity.call_count == 1  # Get account number
+
+
+def test_publish_run_bucket_already_owned_in_same_region(mocker, get_service_clients, mock_project_config):
+    mock_build_dir_exists = mocker.patch(
+        "gdk.common.utils.dir_exists",
+        return_value=True,
+    )
+    pc = mock_project_config.return_value
+    mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=[Path("hello_world.py")])
+
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=[Path("hello_world.py")])
+    file_name = Path(pc["gg_build_recipes_dir"]).joinpath("{}-{}.json".format(pc["component_name"], "1.0.0")).resolve()
+
+    spy_get_caller_identity = mocker.spy(get_service_clients["sts_client"], "get_caller_identity")
+
+    def throw_err(*args, **kwargs):
+        ex = boto3.client("s3").exceptions.BucketAlreadyOwnedByYou(
+            {"Error": {"Code": "BucketAlreadyOwnedByYou", "Message": "fake message"}}, "CreateBucket"
+        )
+        raise ex
+
+    mock_create_bucket_err = mocker.patch.object(get_service_clients["s3_client"], "create_bucket", side_effect=throw_err)
+    spy_create_component = mocker.patch.object(get_service_clients["greengrass_client"], "create_component_version")
+    mock_get_bucket_location = mocker.patch.object(
+        get_service_clients["s3_client"], "get_bucket_location", return_value={"LocationConstraint": "us-east-1"}
+    )
+    with patch("builtins.open", mock_open()) as mock_file:
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "publish", "-d"]))
+        mock_file.assert_any_call(file_name, "w")
+    assert mock_build_dir_exists.call_count == 1  # Checks if build directory exists
+    assert mock_iter_dir.call_count == 1  # Checks if there is at least one artifact to upload
+    assert mock_glob.call_count == 1  # Recipe is not updated
+
+    # Assert cloud calls
+    assert mock_create_bucket_err.call_count == 1  # Tries to create a bucket if at least one artifact needs to be uploaded
+    mock_create_bucket_err.assert_called_with(Bucket="default-us-east-1-1234")
+    assert spy_create_component.call_count == 1  # GG component is not created
+    assert spy_get_caller_identity.call_count == 1  # Get account number
+    assert mock_get_bucket_location.call_count == 1
+
+
+def test_publish_run_bucket_already_owned_in_diff_region(mocker, get_service_clients, mock_project_config):
+    mock_build_dir_exists = mocker.patch(
+        "gdk.common.utils.dir_exists",
+        return_value=True,
+    )
+    pc = mock_project_config.return_value
+    pc["region"] = "us-west-2"
+    mock_iter_dir = mocker.patch("pathlib.Path.iterdir", return_value=[Path("hello_world.py")])
+
+    mock_glob = mocker.patch("pathlib.Path.glob", return_value=[Path("hello_world.py")])
+    file_name = Path(pc["gg_build_recipes_dir"]).joinpath("{}-{}.json".format(pc["component_name"], "1.0.0")).resolve()
+
+    spy_get_caller_identity = mocker.spy(get_service_clients["sts_client"], "get_caller_identity")
+
+    def throw_err(*args, **kwargs):
+        ex = boto3.client("s3").exceptions.BucketAlreadyOwnedByYou(
+            {"Error": {"Code": "BucketAlreadyOwnedByYou", "Message": "fake message"}}, "CreateBucket"
+        )
+        raise ex
+
+    mock_create_bucket_err = mocker.patch.object(get_service_clients["s3_client"], "create_bucket", side_effect=throw_err)
+    mock_get_bucket_location = mocker.patch.object(
+        get_service_clients["s3_client"], "get_bucket_location", return_value={"LocationConstraint": "us-east-1"}
+    )
+    spy_create_component = mocker.patch.object(get_service_clients["greengrass_client"], "create_component_version")
+    with pytest.raises(Exception) as e:
+        with patch("builtins.open", mock_open()) as mock_file:
+            parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "publish", "-d"]))
+            mock_file.assert_any_call(file_name, "w")
+        assert "BucketAlreadyOwnedByYou" in e
+    assert mock_build_dir_exists.call_count == 1  # Checks if build directory exists
+    assert mock_iter_dir.call_count == 1  # Checks if there is at least one artifact to upload
+    assert mock_glob.call_count == 0  # Recipe is not updated
+
+    # Assert cloud calls
+    assert mock_create_bucket_err.call_count == 1  # Tries to create a bucket if at least one artifact needs to be uploaded
+    mock_create_bucket_err.assert_called_with(
+        Bucket="default-us-west-2-1234", CreateBucketConfiguration={"LocationConstraint": "us-west-2"}
+    )
+    assert spy_create_component.call_count == 0  # GG component is not created
+    assert spy_get_caller_identity.call_count == 1  # Get account number
+    assert mock_get_bucket_location.call_count == 1
+
+
+def project_config():
+    return {
+        "component_name": "component_name",
+        "component_build_config": {"build_system": "zip"},
+        "component_version": "1.0.0",
+        "component_author": "abc",
+        "bucket": "default",
+        "region": "us-east-1",
+        "gg_build_directory": Path("/src/GDK-CLI-Internal/greengrass-build"),
+        "gg_build_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts"),
+        "gg_build_recipes_dir": Path("/src/GDK-CLI-Internal/greengrass-build/recipes"),
+        "gg_build_component_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts/component_name/1.0.0"),
+        "component_recipe_file": Path("/src/GDK-CLI-Internal/tests/gdk/static/build_command/valid_component_recipe.json"),
+        "parsed_component_recipe": {
+            "RecipeFormatVersion": "2020-01-25",
+            "ComponentName": "component_name",
+            "ComponentVersion": "component_version",
+            "ComponentDescription": "My first Greengrass component.",
+            "ComponentPublisher": "Amazon",
+            "ComponentConfiguration": {"DefaultConfiguration": {"Message": "world"}},
+            "Manifests": [
+                {
+                    "Platform": {"os": "linux"},
+                    "Lifecycle": {"Run": "python3 -u {artifacts:path}/hello_world.py '{configuration:/Message}'"},
+                    "Artifacts": [{"URI": "s3://DOC-EXAMPLE-BUCKET/artifacts/component_name/1.0.0/hello_world.py"}],
+                }
+            ],
+        },
+    }

--- a/tests/gdk/commands/component/test_BuildCommand.py
+++ b/tests/gdk/commands/component/test_BuildCommand.py
@@ -18,78 +18,6 @@ class BuildCommandTest(TestCase):
             return_value=project_config(),
         )
 
-    def test_build_command_instantiation(self):
-        mock_get_supported_component_builds = self.mocker.patch(
-            "gdk.commands.component.project_utils.get_supported_component_builds", return_value={}
-        )
-        mock_check_if_arguments_conflict = self.mocker.patch.object(
-            BuildCommand, "check_if_arguments_conflict", return_value=None
-        )
-        mock_run = self.mocker.patch.object(BuildCommand, "run", return_value=None)
-        BuildCommand({})
-
-        assert self.mock_get_proj_config.call_count == 1
-        assert mock_get_supported_component_builds.call_count == 1
-        assert mock_check_if_arguments_conflict.call_count == 1
-        assert mock_run.call_count == 0
-
-    def test_build_command_instantiation_failed_fetching_config(self):
-        mock_get_proj_config = self.mocker.patch(
-            "gdk.commands.component.project_utils.get_project_config_values",
-            side_effect=Exception("exception fetching proj values"),
-        )
-        mock_get_supported_component_builds = self.mocker.patch(
-            "gdk.commands.component.project_utils.get_supported_component_builds", return_value={}
-        )
-        mock_check_if_arguments_conflict = self.mocker.patch.object(
-            BuildCommand, "check_if_arguments_conflict", return_value=None
-        )
-        mock_run = self.mocker.patch.object(BuildCommand, "run", return_value=None)
-        with pytest.raises(Exception) as e:
-            BuildCommand({})
-        assert "exception fetching proj values" in e.value.args[0]
-        assert mock_get_proj_config.call_count == 1
-        assert mock_get_supported_component_builds.call_count == 0
-        assert mock_check_if_arguments_conflict.call_count == 1
-        assert mock_run.call_count == 0
-
-    def test_build_command_instantiation_failed_fetching_build_config(self):
-
-        mock_get_supported_component_builds = self.mocker.patch(
-            "gdk.commands.component.project_utils.get_supported_component_builds",
-            side_effect=Exception("exception fetching build"),
-        )
-        mock_check_if_arguments_conflict = self.mocker.patch.object(
-            BuildCommand, "check_if_arguments_conflict", return_value=None
-        )
-        mock_run = self.mocker.patch.object(BuildCommand, "run", return_value=None)
-        with pytest.raises(Exception) as e:
-            BuildCommand({})
-        assert "exception fetching build" in e.value.args[0]
-        assert self.mock_get_proj_config.call_count == 1
-        assert mock_get_supported_component_builds.call_count == 1
-        assert mock_check_if_arguments_conflict.call_count == 1
-        assert mock_run.call_count == 0
-
-    def test_build_command_instantiation_failed_conflicting_args(self):
-
-        mock_get_supported_component_builds = self.mocker.patch(
-            "gdk.commands.component.project_utils.get_supported_component_builds", return_value={}
-        )
-        mock_check_if_arguments_conflict = self.mocker.patch.object(
-            BuildCommand,
-            "check_if_arguments_conflict",
-            side_effect=Exception("exception due to conflictins args"),
-        )
-        mock_run = self.mocker.patch.object(BuildCommand, "run", return_value=None)
-        with pytest.raises(Exception) as e:
-            BuildCommand({})
-        assert "exception due to conflictins args" in e.value.args[0]
-        assert self.mock_get_proj_config.call_count == 0
-        assert mock_get_supported_component_builds.call_count == 0
-        assert mock_check_if_arguments_conflict.call_count == 1
-        assert mock_run.call_count == 0
-
     def test_build_run_default(self):
         mock_create_gg_build_directories = self.mocker.patch.object(BuildCommand, "create_gg_build_directories")
         mock_default_build_component = self.mocker.patch.object(BuildCommand, "default_build_component")
@@ -137,26 +65,6 @@ class BuildCommandTest(TestCase):
         assert mock_run_build_command.assert_called_once
         assert mock_find_artifacts_and_update_uri.assert_called_once
         assert mock_create_build_recipe_file.assert_called_once
-
-        assert mock_get_supported_component_builds.called
-
-    def test_default_build_component_error_run_build_command(self):
-
-        mock_run_build_command = self.mocker.patch.object(BuildCommand, "run_build_command", side_effect=Error("command"))
-        mock_find_artifacts_and_update_uri = self.mocker.patch.object(BuildCommand, "find_artifacts_and_update_uri")
-        mock_create_build_recipe_file = self.mocker.patch.object(BuildCommand, "create_build_recipe_file")
-
-        mock_get_supported_component_builds = self.mocker.patch(
-            "gdk.commands.component.project_utils.get_supported_component_builds", return_value={}
-        )
-        build = BuildCommand({})
-        with pytest.raises(Exception) as e:
-            build.default_build_component()
-        assert "\ncommand" in e.value.args[0]
-        assert error_messages.BUILD_FAILED in e.value.args[0]
-        assert mock_run_build_command.assert_called_once
-        assert not mock_find_artifacts_and_update_uri.called
-        assert not mock_create_build_recipe_file.called
 
         assert mock_get_supported_component_builds.called
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adding integration tests for build and publish commands with 90% coverage. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [x] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.