### PR TITLE
refactor(build): use custom exceptions in build

### DIFF
--- a/gdk/commands/component/component.py
+++ b/gdk/commands/component/component.py
@@ -1,3 +1,6 @@
+from gdk.common.exceptions.BuildError import BuildException
+
+
 def init(d_args):
     from gdk.commands.component.InitCommand import InitCommand
 
@@ -13,7 +16,7 @@ def build(d_args):
     try:
         BuildCommand(d_args).run()
     except Exception as e:
-        raise Exception(f"Could not build the project due to the following error.\n{e}")
+        raise BuildException("Could not build the project due to the following error.", e)
 
 
 def publish(d_args):

--- a/gdk/common/exceptions/BuildError.py
+++ b/gdk/common/exceptions/BuildError.py
@@ -1,0 +1,28 @@
+class BuildException(Exception):
+    def __init__(self, reason="", solution="", e=None):
+        err_details = ""
+        if e:
+            err_details = f"Error details: {e}\n"
+        self.message = f"{reason}\n{err_details}{solution}"
+        super().__init__(self.message)
+
+
+class BuildSystemException(BuildException):
+    def __init__(self, build_system, e=None):
+        reason = f"Failed to build the component with the given build system '{build_system}'."
+        solution = "Please fix the component build errors and build the component again."
+        super().__init__(reason, solution, e)
+
+
+class ZipBuildRecursionException(BuildException):
+    def __init__(self, e=None):
+        reason = "Failed to create an archive inside the zip-build folder."
+        solution = "Please remove symlinks in the gdk project directory if any and try again."
+        super().__init__(reason, solution, e)
+
+
+class ArtifactNotFoundException(BuildException):
+    def __init__(self, uri, e=None):
+        reason = f"Could not find the artifact with URI '{uri}' in S3 or inside the build folders."
+        solution = "Please check the artifact URI in the recipe and build the component again."
+        super().__init__(reason, solution, e)

--- a/gdk/common/exceptions/error_messages.py
+++ b/gdk/common/exceptions/error_messages.py
@@ -39,8 +39,6 @@ INIT_DIR_EXISTS_ERROR = (
     "Could not initialize the project as the directory '{}' already exists. Please initialize the project with a new"
     " directory.\nTry `gdk component init --help`"
 )
-# BUILD COMMAND
-BUILD_FAILED = "Failed to build the component with the given project configuration."
 
 # PUBLISH COMMAND
 PUBLISH_FAILED = "Failed to publish new version of component with the given configuration."

--- a/tests/gdk/commands/component/test_BuildCommand.py
+++ b/tests/gdk/commands/component/test_BuildCommand.py
@@ -6,7 +6,7 @@ from unittest.mock import mock_open, patch
 import gdk.common.utils as utils
 import pytest
 from gdk.commands.component.BuildCommand import BuildCommand
-from gdk.common.exceptions import error_messages
+from gdk.common.exceptions.BuildError import ArtifactNotFoundException, BuildSystemException, ZipBuildRecursionException
 
 
 class BuildCommandTest(TestCase):
@@ -28,6 +28,65 @@ class BuildCommandTest(TestCase):
         mock_subprocess_run = self.mocker.patch("subprocess.run")
         BuildCommand({}).run()
 
+        assert self.mock_get_proj_config.assert_called_once
+        assert mock_create_gg_build_directories.assert_called_once
+        assert mock_default_build_component.assert_called_once
+        assert not mock_subprocess_run.called
+        assert mock_get_supported_component_builds.called
+
+    def test_build_run_default_zip_exception(self):
+        mock_create_gg_build_directories = self.mocker.patch.object(BuildCommand, "create_gg_build_directories")
+        mock_default_build_component = self.mocker.patch.object(
+            BuildCommand, "default_build_component", side_effect=ZipBuildRecursionException("error archiving")
+        )
+
+        mock_get_supported_component_builds = self.mocker.patch(
+            "gdk.commands.component.project_utils.get_supported_component_builds", return_value={}
+        )
+        mock_subprocess_run = self.mocker.patch("subprocess.run")
+
+        with pytest.raises(Exception) as e:
+            BuildCommand({}).run()
+        assert "Failed to create an archive inside the zip-build folder." in e.value.args[0]
+        assert self.mock_get_proj_config.assert_called_once
+        assert mock_create_gg_build_directories.assert_called_once
+        assert mock_default_build_component.assert_called_once
+        assert not mock_subprocess_run.called
+        assert mock_get_supported_component_builds.called
+
+    def test_build_run_default_artifact_not_found_exception(self):
+        mock_create_gg_build_directories = self.mocker.patch.object(BuildCommand, "create_gg_build_directories")
+        mock_default_build_component = self.mocker.patch.object(
+            BuildCommand, "default_build_component", side_effect=ArtifactNotFoundException("uri")
+        )
+
+        mock_get_supported_component_builds = self.mocker.patch(
+            "gdk.commands.component.project_utils.get_supported_component_builds", return_value={}
+        )
+        mock_subprocess_run = self.mocker.patch("subprocess.run")
+
+        with pytest.raises(Exception) as e:
+            BuildCommand({}).run()
+        assert "Could not find the artifact with URI" in e.value.args[0]
+        assert self.mock_get_proj_config.assert_called_once
+        assert mock_create_gg_build_directories.assert_called_once
+        assert mock_default_build_component.assert_called_once
+        assert not mock_subprocess_run.called
+        assert mock_get_supported_component_builds.called
+
+    def test_build_run_default_build_system_exception(self):
+        mock_create_gg_build_directories = self.mocker.patch.object(BuildCommand, "create_gg_build_directories")
+        mock_default_build_component = self.mocker.patch.object(
+            BuildCommand, "default_build_component", side_effect=BuildSystemException("error in build")
+        )
+
+        mock_get_supported_component_builds = self.mocker.patch(
+            "gdk.commands.component.project_utils.get_supported_component_builds", return_value={}
+        )
+        mock_subprocess_run = self.mocker.patch("subprocess.run")
+        with pytest.raises(Exception) as e:
+            BuildCommand({}).run()
+        assert "Failed to build the component with the given build system" in e.value.args[0]
         assert self.mock_get_proj_config.assert_called_once
         assert mock_create_gg_build_directories.assert_called_once
         assert mock_default_build_component.assert_called_once
@@ -71,7 +130,7 @@ class BuildCommandTest(TestCase):
     def test_default_build_component_error_find_artifacts_and_update_uri(self):
         mock_run_build_command = self.mocker.patch.object(BuildCommand, "run_build_command")
         mock_find_artifacts_and_update_uri = self.mocker.patch.object(
-            BuildCommand, "find_artifacts_and_update_uri", side_effect=Error("copying")
+            BuildCommand, "find_artifacts_and_update_uri", side_effect=Error("error copying")
         )
 
         mock_get_supported_component_builds = self.mocker.patch(
@@ -83,8 +142,7 @@ class BuildCommandTest(TestCase):
         with pytest.raises(Exception) as e:
             build.default_build_component()
 
-        assert "\ncopy" in e.value.args[0]
-        assert error_messages.BUILD_FAILED in e.value.args[0]
+        assert "error copying" in e.value.args[0]
         assert mock_run_build_command.assert_called_once
         assert mock_find_artifacts_and_update_uri.assert_called_once
         assert not mock_create_build_recipe_file.called
@@ -95,7 +153,7 @@ class BuildCommandTest(TestCase):
         mock_run_build_command = self.mocker.patch.object(BuildCommand, "run_build_command")
         mock_find_artifacts_and_update_uri = self.mocker.patch.object(BuildCommand, "find_artifacts_and_update_uri")
         mock_create_build_recipe_file = self.mocker.patch.object(
-            BuildCommand, "create_build_recipe_file", side_effect=Error("recipe")
+            BuildCommand, "create_build_recipe_file", side_effect=Error("error in recipe")
         )
 
         mock_get_supported_component_builds = self.mocker.patch(
@@ -105,8 +163,7 @@ class BuildCommandTest(TestCase):
         with pytest.raises(Exception) as e:
             build.default_build_component()
 
-        assert "\nrecipe" in e.value.args[0]
-        assert error_messages.BUILD_FAILED in e.value.args[0]
+        assert "error in recipe" in e.value.args[0]
         assert mock_run_build_command.assert_called_once
         assert mock_find_artifacts_and_update_uri.assert_called_once
         assert mock_create_build_recipe_file.assert_called_once
@@ -134,7 +191,7 @@ class BuildCommandTest(TestCase):
 
     def test_run_build_command_with_error_not_zip(self):
         mock_build_system_zip = self.mocker.patch.object(BuildCommand, "_build_system_zip", return_value=None)
-        mock_subprocess_run = self.mocker.patch("subprocess.run", return_value=None, side_effect=Error("some error"))
+        mock_subprocess_run = self.mocker.patch("subprocess.run", return_value=None, side_effect=Error("error in sp"))
         mock_get_cmd_from_platform = self.mocker.patch.object(
             BuildCommand, "get_build_cmd_from_platform", return_value="some-command"
         )
@@ -149,7 +206,7 @@ class BuildCommandTest(TestCase):
             build.run_build_command()
         assert not mock_build_system_zip.called
         assert mock_subprocess_run.called
-        assert "Error building the component with the given build system." in e.value.args[0]
+        assert "error in sp" in e.value.args[0]
 
         assert mock_get_supported_component_builds.called
         assert mock_get_cmd_from_platform.called
@@ -167,9 +224,9 @@ class BuildCommandTest(TestCase):
         )
         build = BuildCommand({})
         build.project_config["component_build_config"]["build_system"] = "zip"
-        with pytest.raises(Exception) as e:
+        with pytest.raises(Error) as e:
             build.run_build_command()
-        assert "Error building the component with the given build system." in e.value.args[0]
+        assert "some error" in e.value.args[0]
         assert mock_build_system_zip.called
         assert mock_get_cmd_from_platform.call_count == 1
         assert mock_get_supported_component_builds.call_count == 1
@@ -324,7 +381,7 @@ class BuildCommandTest(TestCase):
         mock_copytree = self.mocker.patch("shutil.copytree")
         mock_subprocess_run = self.mocker.patch("subprocess.run", return_value=None)
         mock_ignore_files_during_zip = self.mocker.patch.object(BuildCommand, "_ignore_files_during_zip", return_value=[])
-        mock_make_archive = self.mocker.patch("shutil.make_archive", side_effect=Error("some error"))
+        mock_make_archive = self.mocker.patch("shutil.make_archive", side_effect=RecursionError("some error in archive"))
 
         build_sys = {
             "zip": {
@@ -336,10 +393,12 @@ class BuildCommandTest(TestCase):
             "gdk.commands.component.project_utils.get_supported_component_builds", return_value=build_sys
         )
         build = BuildCommand({})
-        with pytest.raises(Exception) as e:
+        with pytest.raises(ZipBuildRecursionException) as e:
             build._build_system_zip()
 
-        assert "Failed to zip the component in default build mode." in e.value.args[0]
+        assert (
+            "Failed to create an archive inside the zip-build folder.\nError details: some error in archive" in e.value.args[0]
+        )
         assert not mock_subprocess_run.called
         mock_build_info.assert_called_with()
         mock_clean_dir.assert_called_with(zip_build_path)
@@ -361,7 +420,7 @@ class BuildCommandTest(TestCase):
             BuildCommand, "_get_build_folder_by_build_system", return_value={zip_build_path}
         )
         mock_clean_dir = self.mocker.patch("gdk.common.utils.clean_dir", return_value=None)
-        mock_copytree = self.mocker.patch("shutil.copytree", side_effect=Error("some error"))
+        mock_copytree = self.mocker.patch("shutil.copytree", side_effect=Error("some error in copytree"))
         mock_subprocess_run = self.mocker.patch("subprocess.run", return_value=None)
         mock_ignore_files_during_zip = self.mocker.patch.object(BuildCommand, "_ignore_files_during_zip", return_value=[])
 
@@ -379,7 +438,7 @@ class BuildCommandTest(TestCase):
         with pytest.raises(Exception) as e:
             build._build_system_zip()
 
-        assert "Failed to zip the component in default build mode." in e.value.args[0]
+        assert "some error in copytree" in e.value.args[0]
         assert not mock_subprocess_run.called
         mock_build_info.assert_called_with()
         mock_clean_dir.assert_called_with(zip_build_path)
@@ -396,7 +455,7 @@ class BuildCommandTest(TestCase):
             BuildCommand,
             "_get_build_folder_by_build_system",
             return_value=zip_build_path,
-            side_effect=Error("some error"),
+            side_effect=Error("error in getting build system"),
         )
         mock_clean_dir = self.mocker.patch("gdk.common.utils.clean_dir", return_value=None)
         mock_copytree = self.mocker.patch("shutil.copytree")
@@ -418,7 +477,7 @@ class BuildCommandTest(TestCase):
         with pytest.raises(Exception) as e:
             build._build_system_zip()
 
-        assert "Failed to zip the component in default build mode." in e.value.args[0]
+        assert "error in getting build system" in e.value.args[0]
         assert not mock_subprocess_run.called
         mock_build_info.assert_called_with()
         assert not mock_clean_dir.called
@@ -432,7 +491,9 @@ class BuildCommandTest(TestCase):
         mock_build_info = self.mocker.patch.object(
             BuildCommand, "_get_build_folder_by_build_system", return_value={zip_build_path}
         )
-        mock_clean_dir = self.mocker.patch("gdk.common.utils.clean_dir", return_value=None, side_effect=Error("some error"))
+        mock_clean_dir = self.mocker.patch(
+            "gdk.common.utils.clean_dir", return_value=None, side_effect=Error("some error cleaning directory")
+        )
         mock_copytree = self.mocker.patch("shutil.copytree")
         mock_subprocess_run = self.mocker.patch("subprocess.run", return_value=None)
         mock_make_archive = self.mocker.patch("shutil.make_archive")
@@ -451,7 +512,7 @@ class BuildCommandTest(TestCase):
         with pytest.raises(Exception) as e:
             build._build_system_zip()
 
-        assert "Failed to zip the component in default build mode." in e.value.args[0]
+        assert "some error cleaning directory" in e.value.args[0]
         assert not mock_subprocess_run.called
         mock_build_info.assert_called_with()
         assert mock_clean_dir.called
@@ -543,14 +604,15 @@ class BuildCommandTest(TestCase):
         build = BuildCommand({})
 
         mock_is_artifact_in_s3 = self.mocker.patch.object(BuildCommand, "is_artifact_in_s3", return_value=False)
-        with pytest.raises(Exception) as e:
+        with pytest.raises(ArtifactNotFoundException) as e:
             build.find_artifacts_and_update_uri()
-
         assert (
-            "Could not find artifact with URI 's3://DOC-EXAMPLE-BUCKET/artifacts/com.example.HelloWorld/1.0.0/hello_world.py'"
-            " on s3 or inside the build folders."
+            "Could not find the artifact with URI"
+            " 's3://DOC-EXAMPLE-BUCKET/artifacts/com.example.HelloWorld/1.0.0/hello_world.py' in S3 or inside the build"
+            " folders."
             in e.value.args[0]
         )
+
         assert not mock_shutil_copy.called
         assert mock_build_info.assert_called_once
         assert mock_glob.assert_called_once
@@ -949,7 +1011,7 @@ class BuildCommandTest(TestCase):
         with patch("builtins.open", mock_open()) as mock_file:
             with pytest.raises(Exception) as e:
                 build.create_build_recipe_file()
-            assert "Failed to create build recipe file at" in e.value.args[0]
+            assert "I mock json error" in e.value.args[0]
             mock_file.assert_called_once_with(file_name, "w")
             mock_json_dump.call_count == 1
             assert not mock_yaml_dump.called
@@ -971,7 +1033,7 @@ class BuildCommandTest(TestCase):
         with patch("builtins.open", mock_open()) as mock_file:
             with pytest.raises(Exception) as e:
                 build.create_build_recipe_file()
-            assert "Failed to create build recipe file at" in e.value.args[0]
+            assert "I mock yaml error" in e.value.args[0]
             mock_file.assert_called_once_with(file_name, "w")
             mock_json_dump.call_count == 1
             assert mock_yaml_dump.called

--- a/uat/test_uat_build.py
+++ b/uat/test_uat_build.py
@@ -69,11 +69,11 @@ def test_build_template_zip_fail_with_no_artifact(change_test_dir):
     assert check_build_template.returncode == 1
     assert Path(dir_path).joinpath("zip-build").resolve().exists()
     assert (
-        "Could not find artifact with URI 's3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/HelloWorld.zip' on s3 or inside"
-        " the build folders."
+        "Could not find the artifact with URI 's3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/HelloWorld.zip' in S3 or"
+        " inside the build folders."
         in output
     )
-    assert "Failed to build the component with the given project configuration." in output
+    assert "Could not build the project due to the following error." in output
 
 
 def test_build_template_maven(change_test_dir):


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add custom build exceptions to catch different kinds of errors with the build command. 

**Why is this change necessary:**
All exceptions are raised the same way with a reason and a solution. These are all caught at the top level keeping the exception message less redundant. 

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.