### PR TITLE
refactor(exceptions): use custom exceptions in init & publish

### DIFF
--- a/gdk/commands/component/PublishCommand.py
+++ b/gdk/commands/component/PublishCommand.py
@@ -4,11 +4,16 @@ from pathlib import Path
 
 import gdk.commands.component.component as component
 import gdk.commands.component.project_utils as project_utils
-import gdk.common.exceptions.error_messages as error_messages
 import gdk.common.utils as utils
 import yaml
 from botocore.exceptions import ClientError
 from gdk.commands.Command import Command
+from gdk.common.exceptions.PublishError import (
+    ArtifactNotFoundDuringPublishException,
+    ComponentCreationException,
+    ComponentNotBuildException,
+    ComponentVersionException,
+)
 
 
 class PublishCommand(Command):
@@ -19,35 +24,31 @@ class PublishCommand(Command):
         self.service_clients = project_utils.get_service_clients(self.project_config["region"])
 
     def run(self):
-        try:
-            self.project_config["account_number"] = self.get_account_number()
-            if self.arguments["bucket"]:
-                self.project_config["bucket"] = self.arguments["bucket"]
-            else:
-                self.project_config["bucket"] = "{}-{}-{}".format(
-                    self.project_config["bucket"], self.project_config["region"], self.project_config["account_number"]
-                )
+        self.project_config["account_number"] = self.get_account_number()
+        if self.arguments["bucket"]:
+            self.project_config["bucket"] = self.arguments["bucket"]
+        else:
+            self.project_config["bucket"] = "{}-{}-{}".format(
+                self.project_config["bucket"], self.project_config["region"], self.project_config["account_number"]
+            )
 
-            component_name = self.project_config["component_name"]
-            component_version = self.get_component_version_from_config()
-            logging.debug(f"Checking if the component '{component_name}' is built.")
-            if not utils.dir_exists(self.project_config["gg_build_component_artifacts_dir"]):
-                logging.warning(
-                    f"The component '{component_name}' is not built.\nSo, building the component before publishing it."
-                )
-                component.build({})
-            logging.info(f"Publishing the component '{component_name}' with the given project configuration.")
-            logging.info("Uploading the component built artifacts to s3 bucket.")
-            self.upload_artifacts_s3(component_name, component_version)
+        component_name = self.project_config["component_name"]
+        component_version = self.get_component_version_from_config()
+        logging.debug(f"Checking if the component '{component_name}' is built.")
+        if not utils.dir_exists(self.project_config["gg_build_component_artifacts_dir"]):
+            logging.warning(
+                f"The component '{component_name}' is not built.\nSo, building the component before publishing it."
+            )
+            component.build({})
+        logging.info(f"Publishing the component '{component_name}' with the given project configuration.")
+        logging.info("Uploading the component built artifacts to s3 bucket.")
+        self.upload_artifacts_s3(component_name, component_version)
 
-            logging.info(f"Updating the component recipe {component_name}-{component_version}.")
-            self.update_and_create_recipe_file(component_name, component_version)
+        logging.info(f"Updating the component recipe {component_name}-{component_version}.")
+        self.update_and_create_recipe_file(component_name, component_version)
 
-            logging.info(f"Creating a new greengrass component {component_name}-{component_version}")
-            self.create_gg_component(component_name, component_version)
-        except Exception as e:
-            logging.error("Failed to publish new version of the component '{}'".format(self.project_config["component_name"]))
-            raise Exception("{}\n{}".format(error_messages.PUBLISH_FAILED, e))
+        logging.info(f"Creating a new greengrass component {component_name}-{component_version}")
+        self.create_gg_component(component_name, component_version)
 
     def upload_artifacts_s3(self, component_name, component_version):
         """
@@ -64,25 +65,22 @@ class PublishCommand(Command):
         -------
             None
         """
-        try:
-            bucket = self.project_config["bucket"]
-            region = self.project_config["region"]
-            logging.info(
-                f"Uploading component artifacts to S3 bucket: {bucket}. If this is your first time using this bucket, add the"
-                " 's3:GetObject' permission to each core device's token exchange role to allow it to download the component"
-                f" artifacts. For more information, see {utils.doc_link_device_role}."
-            )
+        bucket = self.project_config["bucket"]
+        region = self.project_config["region"]
+        logging.info(
+            f"Uploading component artifacts to S3 bucket: {bucket}. If this is your first time using this bucket, add the"
+            " 's3:GetObject' permission to each core device's token exchange role to allow it to download the component"
+            f" artifacts. For more information, see {utils.doc_link_device_role}."
+        )
 
-            build_component_artifacts = list(self.project_config["gg_build_component_artifacts_dir"].iterdir())
-            # Create bucket only when there's something to upload.
-            if len(build_component_artifacts) != 0:
-                self.create_bucket(bucket, region)
-            for artifact in build_component_artifacts:
-                s3_file_path = f"{component_name}/{component_version}/{artifact.name}"
-                logging.debug("Uploading artifact '{}' to the bucket '{}'.".format(artifact.resolve(), bucket))
-                self.service_clients["s3_client"].upload_file(str(artifact.resolve()), bucket, s3_file_path)
-        except Exception as e:
-            raise Exception("Error while uploading the artifacts to s3 during publish.\n{}".format(e))
+        build_component_artifacts = list(self.project_config["gg_build_component_artifacts_dir"].iterdir())
+        # Create bucket only when there's something to upload.
+        if len(build_component_artifacts) != 0:
+            self.create_bucket(bucket, region)
+        for artifact in build_component_artifacts:
+            s3_file_path = f"{component_name}/{component_version}/{artifact.name}"
+            logging.debug("Uploading artifact '{}' to the bucket '{}'.".format(artifact.resolve(), bucket))
+            self.service_clients["s3_client"].upload_file(str(artifact.resolve()), bucket, s3_file_path)
 
     def create_bucket(self, bucket, region):
         """
@@ -133,13 +131,10 @@ class PublishCommand(Command):
         -------
             bool: Returns true if the bucket region is same as the region in check. Else false.
         """
-        try:
-            response = self.service_clients["s3_client"].get_bucket_location(Bucket=bucket)
-            if response["LocationConstraint"] == region:
-                return True
-            return False
-        except Exception as e:
-            raise Exception("Unable to fetch the location of the bucket '{}'.\n{}".format(bucket, e))
+        response = self.service_clients["s3_client"].get_bucket_location(Bucket=bucket)
+        if response["LocationConstraint"] == region:
+            return True
+        return False
 
     def create_gg_component(self, c_name, c_version):
         """
@@ -161,8 +156,7 @@ class PublishCommand(Command):
             try:
                 self.service_clients["greengrass_client"].create_component_version(inlineRecipe=f.read())
             except Exception as e:
-                logging.error("Failed to create the component using the recipe at '{}'.".format(publish_recipe_file))
-                raise Exception("Creating private version '{}' of the component '{}' failed.\n{}".format(c_version, c_name, e))
+                raise ComponentCreationException(c_name, c_version, publish_recipe_file, e)
             logging.info("Created private version '{}' of the component in the account.'{}'.".format(c_version, c_name))
 
     def get_next_version(self):
@@ -180,21 +174,19 @@ class PublishCommand(Command):
         """
         fallback_version = "1.0.0"
         logging.debug("Fetching private components from the account.")
-        try:
-            c_name = self.project_config["component_name"]
-            region = self.project_config["region"]
-            account_num = self.project_config["account_number"]
-            c_next_patch_version = self.get_next_patch_component_version(c_name, region, account_num)
-            if not c_next_patch_version:
-                logging.info(
-                    "No private version of the component '{}' exist in the account. Using '{}' as the next version to create."
-                    .format(c_name, fallback_version)
-                )
-                return fallback_version
-            logging.debug(
-                "Found latest version '{}' of the component '{}' in the account.".format(c_next_patch_version, c_name)
+        c_name = self.project_config["component_name"]
+        region = self.project_config["region"]
+        account_num = self.project_config["account_number"]
+        c_latest_version = self.get_next_patch_component_version(c_name, region, account_num)
+        if not c_latest_version:
+            logging.info(
+                "No private version of the component '{}' exist in the account. Using '{}' as the next version to create."
+                .format(c_name, fallback_version)
             )
-            semver_alphanumeric = c_next_patch_version.split("-")
+            return fallback_version
+        logging.debug("Found latest version '{}' of the component '{}' in the account.".format(c_latest_version, c_name))
+        try:
+            semver_alphanumeric = c_latest_version.split("-")
             semver_numeric = semver_alphanumeric[0].split(".")
             major = semver_numeric[0]
             minor = semver_numeric[1]
@@ -204,7 +196,7 @@ class PublishCommand(Command):
             logging.info("Using '{}' as the next version of the component '{}' to create.".format(next_version, c_name))
             return next_version
         except Exception as e:
-            raise Exception("Failed to calculate the next version of the component during publish.\n{}".format(e))
+            raise ComponentVersionException(c_name, c_latest_version, exception=e)
 
     def get_account_number(self):
         """
@@ -242,20 +234,13 @@ class PublishCommand(Command):
             version(string): Highest version of the component if it exists already. Else returns 1.0.0.
         """
 
-        try:
-            comp_list_response = self.service_clients["greengrass_client"].list_component_versions(
-                arn="arn:aws:greengrass:{}:{}:components:{}".format(region, account_num, component_name)
-            )
-            component_versions = comp_list_response["componentVersions"]
-            if not component_versions:
-                return None
-            return component_versions[0]["componentVersion"]
-        except Exception as e:
-            raise Exception(
-                "Error while getting the component versions of '{}' in '{}' from the account '{}' during publish.\n{}".format(
-                    component_name, region, account_num, e
-                )
-            )
+        comp_list_response = self.service_clients["greengrass_client"].list_component_versions(
+            arn="arn:aws:greengrass:{}:{}:components:{}".format(region, account_num, component_name)
+        )
+        component_versions = comp_list_response["componentVersions"]
+        if not component_versions:
+            return None
+        return component_versions[0]["componentVersion"]
 
     def get_component_version_from_config(self):
         """
@@ -272,21 +257,15 @@ class PublishCommand(Command):
         -------
             None
         """
-        try:
-            component_name = self.project_config["component_name"]
-            if self.project_config["component_version"] == "NEXT_PATCH":
-                logging.debug(
-                    "Component version set to 'NEXT_PATCH' in the config file. Calculating next version of the component '{}'"
-                    .format(self.project_config["component_name"])
-                )
-                return self.get_next_version()
-            logging.info("Using the version set for the component '{}' in the config file.".format(component_name))
-            return self.project_config["component_version"]
-        except Exception as e:
-            logging.error(
-                "Failed to calculate the version of component '{}' based on the configuration.".format(component_name)
+        component_name = self.project_config["component_name"]
+        if self.project_config["component_version"] == "NEXT_PATCH":
+            logging.debug(
+                "Component version set to 'NEXT_PATCH' in the config file. Calculating next version of the component '{}'"
+                .format(component_name)
             )
-            raise (e)
+            return self.get_next_version()
+        logging.info("Using the version set for the component '{}' in the config file.".format(component_name))
+        return self.project_config["component_version"]
 
     def update_and_create_recipe_file(self, component_name, component_version):
         """
@@ -310,10 +289,7 @@ class PublishCommand(Command):
         if "ComponentName" in parsed_component_recipe:
             if parsed_component_recipe["ComponentName"] != component_name:
                 logging.error("Component '{}' is not build.".format(parsed_component_recipe["ComponentName"]))
-                raise Exception(
-                    "Failed to publish the component '{}' as it is not build.\nBuild the component `gdk component"
-                    " build` before publishing it.".format(parsed_component_recipe["ComponentName"])
-                )
+                raise ComponentNotBuildException(parsed_component_recipe["ComponentName"])
         gg_build_component_artifacts = self.project_config["gg_build_component_artifacts_dir"]
         bucket = self.project_config["bucket"]
         artifact_uri = f"{utils.s3_prefix}{bucket}/{component_name}/{component_version}"
@@ -339,10 +315,7 @@ class PublishCommand(Command):
                     logging.debug("Updating artifact URI of '{}' in the recipe file.".format(artifact_file))
                     artifact["URI"] = f"{artifact_uri}/{artifact_file}"
                 else:
-                    raise Exception(
-                        f"Could not find the artifact file specified in the recipe '{artifact_file}' inside the build folder"
-                        f" '{gg_build_component_artifacts}'."
-                    )
+                    raise ArtifactNotFoundDuringPublishException(artifact_file, gg_build_component_artifacts)
 
         # Update the version of the component in the recipe
         parsed_component_recipe["ComponentVersion"] = component_version
@@ -369,15 +342,12 @@ class PublishCommand(Command):
         publish_recipe_file = Path(self.project_config["gg_build_recipes_dir"]).joinpath(publish_recipe_file_name).resolve()
         self.project_config["publish_recipe_file"] = publish_recipe_file
         with open(publish_recipe_file, "w") as prf:
-            try:
-                logging.debug(
-                    "Creating component recipe '{}' in '{}'.".format(
-                        publish_recipe_file_name, self.project_config["gg_build_recipes_dir"]
-                    )
+            logging.debug(
+                "Creating component recipe '{}' in '{}'.".format(
+                    publish_recipe_file_name, self.project_config["gg_build_recipes_dir"]
                 )
-                if publish_recipe_file_name.endswith(".json"):
-                    prf.write(json.dumps(parsed_component_recipe, indent=4))
-                else:
-                    yaml.dump(parsed_component_recipe, prf)
-            except Exception as e:
-                raise Exception("""Failed to create publish recipe file at '{}'.\n{}""".format(publish_recipe_file, e))
+            )
+            if publish_recipe_file_name.endswith(".json"):
+                prf.write(json.dumps(parsed_component_recipe, indent=4))
+            else:
+                yaml.dump(parsed_component_recipe, prf)

--- a/gdk/commands/component/component.py
+++ b/gdk/commands/component/component.py
@@ -1,4 +1,5 @@
 from gdk.common.exceptions.BuildError import BuildException
+from gdk.common.exceptions.InitError import InitException
 
 
 def init(d_args):
@@ -6,8 +7,8 @@ def init(d_args):
 
     try:
         InitCommand(d_args).run()
-    except Exception as e:
-        raise Exception(f"Could not initialze the project due to the following error.\n{e}")
+    except Exception as exp:
+        raise InitException("Could not initialize the project due to the following error.", exception=exp)
 
 
 def build(d_args):

--- a/gdk/commands/component/component.py
+++ b/gdk/commands/component/component.py
@@ -1,5 +1,6 @@
 from gdk.common.exceptions.BuildError import BuildException
 from gdk.common.exceptions.InitError import InitException
+from gdk.common.exceptions.PublishError import PublishException
 
 
 def init(d_args):
@@ -26,7 +27,7 @@ def publish(d_args):
     try:
         PublishCommand(d_args).run()
     except Exception as e:
-        raise Exception(f"Could not publish the component due to the following error.\n{e}")
+        raise PublishException(f"Could not publish the component due to the following error.\n{e}")
 
 
 def list(d_args):

--- a/gdk/common/exceptions/InitError.py
+++ b/gdk/common/exceptions/InitError.py
@@ -1,0 +1,37 @@
+class InitException(Exception):
+    def __init__(self, reason="", solution="", exception=None, help_text=""):
+        err_details = ""
+        if exception:
+            err_details = f"Error details: {exception}\n"
+        self.message = f"{reason}\n{err_details}{solution}{help_text}"
+        super().__init__(self.message)
+
+
+class InvalidInitArgumentsException(InitException):
+    def __init__(self, exception=None):
+        reason = "The arguments passed with the command are invalid."
+        solution = "Please initialize the project with correct arguments."
+        help_text = "\n\nTry `gdk component init --help`"
+        super().__init__(reason, solution, exception, help_text)
+
+
+class DirectoryNotEmptyException(InitException):
+    def __init__(self, exception=None):
+        reason = "The current directory is not empty."
+        solution = "Please initialize the project in an empty directory."
+        super().__init__(reason, solution, exception)
+
+
+class InvalidDirectoryException(InitException):
+    def __init__(self, name, exception=None):
+        reason = f"Directory or a file named '{name}' already exsits in the current directory."
+        solution = "Please initialize the project using a different directory name."
+        super().__init__(reason, solution, exception)
+
+
+class ComponentUnavailableException(InitException):
+    def __init__(self, comp_type, comp_name, exception=None):
+        reason = f"Could not find the component {comp_type} '{comp_name}' in Greengrass Software Catalog."
+        solution = "Please specify a valid component name from the Greengrass Software Catalog."
+        help_text = f"\n\nTry `gdk component list --{comp_type}`"
+        super().__init__(reason, solution, exception, help_text)

--- a/gdk/common/exceptions/PublishError.py
+++ b/gdk/common/exceptions/PublishError.py
@@ -1,0 +1,44 @@
+class PublishException(Exception):
+    def __init__(self, reason="", solution="", exception=None):
+        err_details = ""
+        if exception:
+            err_details = f"Error details: {exception}\n"
+        self.message = f"{reason}\n{err_details}{solution}"
+        super().__init__(self.message)
+
+
+class ArtifactNotFoundDuringPublishException(PublishException):
+    def __init__(self, artifact_file, gg_build_component_artifacts, exception=None):
+        reason = (
+            f"Could not find the artifact file specified in the recipe '{artifact_file}' inside the build folder"
+            f" '{gg_build_component_artifacts}'"
+        )
+        solution = "Please check the artifact URI in the recipe and publish the component again."
+        super().__init__(reason, solution, exception)
+
+
+class ComponentNotBuildException(PublishException):
+    def __init__(self, component_name, exception=None):
+        reason = f"The component '{component_name}' is not built."
+
+        solution = "Please build the component using `gdk component build` before publishing it."
+        super().__init__(reason, solution, exception)
+
+
+class ComponentCreationException(PublishException):
+    def __init__(self, c_name, c_version, publish_recipe_file, exception=None):
+        reason = (
+            f"Failed to create a new version of the component '{c_name}-{c_version}' using the recipe at"
+            f" '{publish_recipe_file}'"
+        )
+
+        solution = "Please fix the errors in the recipe and publish the component again."
+        super().__init__(reason, solution, exception)
+
+
+class ComponentVersionException(PublishException):
+    def __init__(self, c_name, c_latest_version, exception=None):
+        reason = f"Failed to calculate the next version of the component '{c_name}' during publish. "
+
+        solution = f"The component version '{c_latest_version}' must contain a major, minor and patch numbers in it."
+        super().__init__(reason, solution, exception)

--- a/gdk/common/exceptions/error_messages.py
+++ b/gdk/common/exceptions/error_messages.py
@@ -21,24 +21,5 @@ LIST_WITH_INVALID_ARGS = (
     " as an argument to the list command.\nTry `gdk component list --help`"
 )
 
-# INIT COMMAND
-INIT_FAILS_DURING_COMPONENT_DOWNLOAD = "Failed to download the selected component {{}}. Please try again after sometime."
-INIT_WITH_INVALID_ARGS = (
-    "Could not initialize the project as the arguments passed are invalid. Please initialize the project with correct"
-    " arguments.\nTry `gdk component init --help`"
-)
-INIT_WITH_CONFLICTING_ARGS = (
-    "Could not initialize the project as the command arguments are conflicting. Please initialize the project with correct"
-    " arguments.\nTry `gdk component init --help` "
-)
-INIT_NON_EMPTY_DIR_ERROR = (
-    "Could not initialize the project as the directory is not empty. Please initialize the project in an empty directory.\nTry"
-    " `gdk component init --help`"
-)
-INIT_DIR_EXISTS_ERROR = (
-    "Could not initialize the project as the directory '{}' already exists. Please initialize the project with a new"
-    " directory.\nTry `gdk component init --help`"
-)
-
 # PUBLISH COMMAND
 PUBLISH_FAILED = "Failed to publish new version of component with the given configuration."

--- a/integration_tests/gdk/components/test_integ_InitCommand.py
+++ b/integration_tests/gdk/components/test_integ_InitCommand.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock, mock_open, patch
 
 import gdk.CLIParser as CLIParser
 import gdk.common.consts as consts
-import gdk.common.exceptions.error_messages as error_messages
 import gdk.common.parse_args_actions as parse_args_actions
 import gdk.common.utils as utils
 import pytest
@@ -20,7 +19,7 @@ class CommandTest(TestCase):
     def test_init_run_non_empty_dir(self):
         with pytest.raises(Exception) as e:
             parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "init", "-d"]))
-        assert error_messages.INIT_NON_EMPTY_DIR_ERROR in e.value.args[0]
+        assert "The current directory is not empty.\nPlease initialize the project in an empty directory." in e.value.args[0]
 
         mock_non_empty_dir = self.mocker.patch("gdk.common.utils.is_directory_empty", return_value=False)
         mock_init_with_template = self.mocker.patch.object(InitCommand, "init_with_template", return_value=None)
@@ -28,7 +27,7 @@ class CommandTest(TestCase):
         mock_conflicting_args = self.mocker.patch.object(InitCommand, "check_if_arguments_conflict", return_value=None)
         with pytest.raises(Exception) as e:
             parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "init", "-d"]))
-        assert error_messages.INIT_NON_EMPTY_DIR_ERROR in e.value.args[0]
+        assert "The current directory is not empty.\nPlease initialize the project in an empty directory." in e.value.args[0]
         assert mock_non_empty_dir.call_count == 1
         assert not mock_init_with_template.called
         assert not mock_init_with_repository.called
@@ -72,11 +71,7 @@ class CommandTest(TestCase):
             parse_args_actions.run_command(
                 CLIParser.cli_parser.parse_args(["component", "init", "--repository", "dummy", "-n", "new-dir"])
             )
-        assert (
-            "Could not initialize the project as the directory 'new-dir' already exists. Please initialize the project"
-            " with a new directory."
-            in e.value.args[0]
-        )
+        assert "Directory or a file named 'new-dir' already exsits in the current directory." in e.value.args[0]
         assert not mock_non_empty_dir.called
         assert mock_new_dir.call_count == 1
         assert not mock_init_with_template.called
@@ -94,7 +89,7 @@ class CommandTest(TestCase):
         with pytest.raises(Exception) as e:
             parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "init", "--repository", "dummy"]))
 
-        assert "Could not initialze the project due to the following error." in e.value.args[0]
+        assert "Could not initialize the project due to the following error.\nError details: Some exception" in e.value.args[0]
 
         assert mock_is_directory_empty.call_count == 0
         assert mock_init_with_template.call_count == 0
@@ -112,8 +107,7 @@ class CommandTest(TestCase):
                 CLIParser.cli_parser.parse_args(["component", "init", "-t", "dummy", "-n", "new-dir"])
             )
         assert (
-            "Could not initialize the project as the arguments passed are invalid. Please initialize the project with"
-            " correct arguments."
+            "The arguments passed with the command are invalid.\nPlease initialize the project with correct arguments."
             in e.value.args[0]
         )
         assert not mock_non_empty_dir.called
@@ -212,7 +206,7 @@ class CommandTest(TestCase):
                 CLIParser.cli_parser.parse_args(["component", "init", "-t", "template", "-l", "python"])
             )
 
-        assert "Could not initialize the project with component template 'template'." in e.value.args[0]
+        assert "Could not initialize the project due to the following error." in e.value.args[0]
         assert mock_is_directory_empty.call_count == 1
         assert mock_conflicting_args.call_count == 1
         mock_download_and_clean.assert_called_once_with("template-python", "template", utils.current_directory)
@@ -225,7 +219,7 @@ class CommandTest(TestCase):
         with pytest.raises(Exception) as e:
             parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "init", "--repository", "dummy"]))
 
-        assert "Could not initialize the project with component repository 'dummy'." in e.value.args[0]
+        assert "Could not initialize the project due to the following error." in e.value.args[0]
         assert mock_is_directory_empty.call_count == 1
         assert mock_conflicting_args.call_count == 1
         mock_download_and_clean.assert_called_once_with("dummy", "repository", utils.current_directory)

--- a/tests/gdk/commands/component/test_component.py
+++ b/tests/gdk/commands/component/test_component.py
@@ -5,6 +5,7 @@ from gdk.commands.component.InitCommand import InitCommand
 from gdk.commands.component.ListCommand import ListCommand
 from gdk.commands.component.PublishCommand import PublishCommand
 from gdk.common.exceptions.CommandError import ConflictingArgumentsError
+from gdk.common.exceptions.InitError import InvalidInitArgumentsException
 
 
 def test_component_init(mocker):
@@ -26,6 +27,22 @@ def test_component_init_exception(mocker):
     assert "Arguments 'a' and 'b' are conflicting and cannot be used together in a command." in e.value.args[0]
     assert mock_component_init.call_count == 1
     assert mock_component_init_run.call_count == 0
+    mock_component_init.assert_called_with(d_args)
+
+
+def test_component_init_run_exception(mocker):
+    mock_component_init = mocker.patch.object(InitCommand, "__init__", return_value=None)
+    mock_component_init_run = mocker.patch.object(InitCommand, "run", side_effect=InvalidInitArgumentsException())
+    d_args = {"init": None}
+    with pytest.raises(Exception) as e:
+        component.init(d_args)
+    assert (
+        "Could not initialize the project due to the following error.\nError details: The arguments passed with the command"
+        " are invalid."
+        in e.value.args[0]
+    )
+    assert mock_component_init.call_count == 1
+    assert mock_component_init_run.call_count == 1
     mock_component_init.assert_called_with(d_args)
 
 

--- a/uat/test_uat_init.py
+++ b/uat/test_uat_init.py
@@ -4,7 +4,7 @@ from pathlib import Path
 def test_init_template_non_empty_dir(gdk_cli):
     check_init_template = gdk_cli.run(["component", "init", "-t", "HelloWorld", "-l", "python"])
     assert check_init_template.returncode == 1
-    assert "Try `gdk component init --help`" in check_init_template.output
+    assert "Error details: The current directory is not empty." in check_init_template.output
 
 
 def test_init_template(change_test_dir, gdk_cli):
@@ -18,9 +18,7 @@ def test_init_template(change_test_dir, gdk_cli):
 def test_init_template_with_new_directory(change_test_dir, gdk_cli):
     dir = "test-dir"
     dirpath = Path(change_test_dir).joinpath(dir)
-    check_init_template = gdk_cli.run(
-        ["component", "init", "-t", "HelloWorld", "-l", "python", "-n", dir]
-    )
+    check_init_template = gdk_cli.run(["component", "init", "-t", "HelloWorld", "-l", "python", "-n", dir])
     assert check_init_template.returncode == 0
     assert Path(dirpath).joinpath("recipe.yaml").resolve().exists()
     assert Path(dirpath).joinpath("gdk-config.json").resolve().exists()
@@ -28,9 +26,7 @@ def test_init_template_with_new_directory(change_test_dir, gdk_cli):
 
 def test_init_repository(change_test_dir, gdk_cli):
     dirpath = Path(change_test_dir)
-    check_init_repo = gdk_cli.run(
-        ["component", "init", "-r", "aws-greengrass-labs-database-influxdb"]
-    )
+    check_init_repo = gdk_cli.run(["component", "init", "-r", "aws-greengrass-labs-database-influxdb"])
     assert check_init_repo.returncode == 0
     assert Path(dirpath).joinpath("recipe.yaml").exists()
     assert Path(dirpath).joinpath("gdk-config.json").exists()
@@ -39,9 +35,7 @@ def test_init_repository(change_test_dir, gdk_cli):
 def test_init_repository_with_new_dir(change_test_dir, gdk_cli):
     dir = "test-dir"
     dirpath = Path(change_test_dir).joinpath(dir)
-    check_init_repo = gdk_cli.run(
-        ["component", "init", "-r", "aws-greengrass-labs-database-influxdb", "-n", dir]
-    )
+    check_init_repo = gdk_cli.run(["component", "init", "-r", "aws-greengrass-labs-database-influxdb", "-n", dir])
     assert check_init_repo.returncode == 0
     assert Path(dirpath).joinpath("recipe.yaml").exists()
     assert Path(dirpath).joinpath("gdk-config.json").exists()


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add custom exceptions in `init` command. Remove error_messages. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [x] Updated or added new integration tests
- [x] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.