### PR TITLE
chore(regression): regression test old gdk version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,12 +44,14 @@ jobs:
           python -m pip install --upgrade pip
       - name: Lint with flake8
         run: |
-          pip3 install flake8
+          pip install flake8
           # The GitHub editor is 127 chars wide
           flake8 . --count --max-complexity=10 --max-line-length=127 --show-source --statistics
-      - name: Unit Testing CLI
+      - name: Install test dependencies
         run: |
           pip install -r test-requirements.txt
+      - name: Unit Testing CLI
+        run: |
           coverage run --source=gdk -m pytest -v -s tests && coverage xml --fail-under=98
       - name: Upload tests coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -57,7 +59,6 @@ jobs:
           flags: unit
       - name: Integration Testing CLI
         run: |
-          pip install -r test-requirements.txt
           coverage run --source=gdk -m pytest -v -s integration_tests && coverage xml --fail-under=90
       - name: Upload integration tests coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -74,29 +75,30 @@ jobs:
           java-version: 1.8
       - name: Run UATs with code coverage
         run: |
-          pip install -r test-requirements.txt
           coverage run --source=gdk -m pytest -v -s uat --instrumented && coverage xml --fail-under=77
       - name: Upload UAT coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
           flags: uat
 
-  # Regression job performs installation of gdk as our customers would and runs our UAT suite for
+  # Regression job performs installation of gdk as our customers would. Runs our UAT suite for
   # each matrix permutation to detect regression failures.
   regression:
     strategy:
-      max-parallel: 3
+      max-parallel: 6
       matrix:
+        gdk-version: [ HEAD, v1.0.0, v1.1.0 ]
         python-version: [3.6, 3.7, 3.8, 3.x]
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write
       contents: read
-    name: Regression on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+    name: Regression of GDK ${{ matrix.gdk-version == 'HEAD' && '' || matrix.gdk-version }} on ${{ matrix.os }} with Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
         with:
+          ref: ${{ matrix.gdk-version == 'HEAD' && github.ref || matrix.gdk-version }}
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -119,7 +121,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Get Latest UATs
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
       - name: Run UATs
         run: |
           pip install -r test-requirements.txt
-          pytest -v -s uat
+          pytest -v -s uat --target-version ${{ matrix.gdk-version }} --gdk-debug

--- a/uat/README.md
+++ b/uat/README.md
@@ -1,0 +1,103 @@
+# End-to-end tests for Greengrass Development Kit (GDK) - Command Line Interface (CLI)
+
+### *Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.*
+
+End-to-end setup uses `pytest` and expects test dependencies to be installed.
+
+### Getting Started
+
+#### Prerequisites
+1. [Python3](https://www.python.org/downloads/) and [pip](https://pip.pypa.io/en/latest/installation/): As the GDK CLI tool is written in python, you need to have python3 and pip installed. The most recent version of python includes pip.
+
+2. [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html): As you'd have to configure your AWS credentials using AWS CLI before running certain gdk commands.
+
+#### 1. Cloning CLI repository
+
+To install the latest version of CLI using this git repository and pip, run the following command
+
+```shell
+git clone https://github.com/aws-greengrass/aws-greengrass-gdk-cli.git@v1.1.0
+cd aws-greengrass-gdk-cli
+```
+
+#### 2. Install CLI from code
+
+```shell
+python3 -m pip install pip
+pip install .
+```
+
+#### 3. Configure AWS credentials
+
+Configure AWS CLI with your credentials as shown here - https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html.
+
+#### 4. Installing test dependencies
+
+```
+pip install -r test-requirements.txt
+```
+
+#### 5. Running end-to-end test suite
+
+```shell
+pytest -v -s uat
+```
+
+### Built-in options
+
+#### `--gdk-debug` option
+
+Pass this flag to emit debug logs from gdk cli during all test runs. Example:
+```shell
+pytest -v -s uat --gdk-debug
+```
+
+#### 1. `--gdk-debug` option
+
+Pass this flag to emit debug logs from gdk cli during all test runs. Example:
+```shell
+pytest -v -s uat --gdk-debug
+```
+
+#### 2. `--instrumented` option
+
+Pass this flag to in combination with coverage to track code coverage by the test suite.
+```shell
+coverage run --source=gdk -m pytest -v -s uat --instrumented 
+```
+
+Note: The `coverage` is required to instrument the code.
+
+#### 3. `--target-version` option
+Pass this flag to run test suite considering a specific gdk version.
+```shell
+pytest -v -s uat --target-version 1.1.0
+```
+
+If not provided than target version defaults to `HEAD`, which makes version constraint evaluation to assume
+the tests are running against the most recent commit.
+
+#### 4. `@pytest.mark.version(...)` constraints
+`@pytest.mark.version(...)` is pytest marker to enforce version constraints for any test.
+
+The marker takes kwargs (key & values) to define constraints. These can be combined to create upper and 
+lower bounds. Available key args are:
+ * `eq`: equal to gdk cli version (exact version match). 
+ * `min` : minimum gdk cli version (lower bound)
+ * `ge`: greater than or equal to gdk cli version (lower bound). Alias of `min`. 
+ * `gt`: greater than gdk cli version (lower bound). 
+ * `max` : maximum gdk cli version (upper bound)
+ * `le`: less than or equal to gdk cli version (upper bound). Alias of `max`. 
+ * `lt`: less than gdk cli version (upper bound).
+
+Examples:
+```python
+    @pytest.mark.version(eq='1.1.0')
+    @pytest.mark.version(min='1.1.0') or @pytest.mark.version(ge='1.1.0')
+    @pytest.mark.version(max='1.1.0') or @pytest.mark.version(le='1.1.0')
+    @pytest.mark.version(gt='1.1.0')
+    @pytest.mark.version(lt='1.1.0')
+    @pytest.mark.version(min='1.0.0', max='1.1.0')
+```
+
+

--- a/uat/conftest.py
+++ b/uat/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from packaging.version import parse as version_parser
 from t_setup import GdkProcess, GdkInstrumentedProcess
 
 
@@ -9,6 +10,9 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--gdk-debug", action="store_true", default=False, help="run gdk commands with debug flag"
+    )
+    parser.addoption(
+        "--target-version", action="store", default='HEAD', help="run tests for specific target version"
     )
 
 
@@ -21,8 +25,61 @@ def change_test_dir(tmpdir, monkeypatch):
 @pytest.fixture()
 def gdk_cli(request):
     debug = request.config.getoption("--gdk-debug")
-    print(f"Initializing GDK client with debug mode {debug}")
+    print(f"Initializing GDK client {'in debug mode' if debug else ''}.")
     if request.config.getoption("--instrumented"):
         return GdkInstrumentedProcess(debug)
     else:
         return GdkProcess(debug)
+
+
+@pytest.fixture(autouse=True)
+def version_check(request):
+    version_option = request.config.getoption('--target-version')
+    if version_option is None:
+        return
+
+    latest_mode = version_option == 'HEAD'
+    print(f"\nTarget gdk-cli version {version_option}")
+
+    # request.node is the current test item
+    # query the marker "version" of current test item
+    version_marker = request.node.get_closest_marker('version')
+
+    # if test item was not marked, there's no version restriction
+    if version_marker is None:
+        return
+
+    # parse target version from options
+    target_version = version_parser(version_option) if not latest_mode else version_option
+
+    # if used as @pytest.mark.version(eq=1.0.0)
+    eq_version = version_marker.kwargs.get('eq')
+    eq_version = version_parser(eq_version) if eq_version else None
+    if eq_version and (latest_mode or target_version == eq_version):
+        pytest.skip(f'Target version {target_version} is not equal to the required version {eq_version}.')
+
+    # if used as @pytest.mark.version(lt=1.0.0)
+    lt_version = version_marker.kwargs.get('lt')
+    lt_version = version_parser(lt_version) if lt_version else None
+    if lt_version and (latest_mode or target_version >= lt_version):
+        pytest.skip(f'Target version {target_version} is not lower than required version {lt_version}.')
+
+    # if used as @pytest.mark.version(min=1.0.0) or as @pytest.mark.version(le=1.0.0)
+    le_version = version_marker.kwargs.get('le')
+    max_version = le_version if le_version else version_marker.kwargs.get('max')
+    max_version = version_parser(max_version) if max_version is not None else None
+    if max_version and (latest_mode or target_version > max_version):
+        pytest.skip(f'Target version {target_version} is higher than required version {max_version}.')
+
+    # if used as @pytest.mark.version(gt=1.0.0)
+    gt_version = version_marker.kwargs.get('gt')
+    gt_version = version_parser(gt_version) if gt_version else None
+    if not latest_mode and gt_version and target_version <= gt_version:
+        pytest.skip(f'Target version {target_version} is not greater than required version {gt_version}.')
+
+    # if used as @pytest.mark.version(min=1.0.0) or as @pytest.mark.version(ge=1.0.0)
+    ge_version = version_marker.kwargs.get('ge')
+    min_version = ge_version if ge_version else version_marker.kwargs.get('min', '1.0.0')
+    min_version = version_parser(min_version) if min_version else None
+    if not latest_mode and min_version and target_version < min_version:
+        pytest.skip(f'Target version {target_version} is lower than required version {min_version}.')

--- a/uat/pytest.ini
+++ b/uat/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts=--verbose
+markers =
+    version: marks tests to work with specific gdk versions

--- a/uat/t_utils.py
+++ b/uat/t_utils.py
@@ -1,4 +1,5 @@
 import json
+import yaml
 import random
 import string
 from pathlib import Path
@@ -18,6 +19,18 @@ def update_config(config_file, component_name, region, bucket, author, version="
         config["component"][component_name]["version"] = version
     with open(str(config_file), "w") as f:
         f.write(json.dumps(config, indent=4))
+
+
+def replace_uri_in_recipe(recipe_file, os_type, uri_search, uri_replace):
+    with open(str(recipe_file), "r") as f:
+        recipe = yaml.safe_load(f.read())
+        for i in range(0, len(recipe["Manifests"])):
+            if recipe["Manifests"][i]["Platform"]["os"] == os_type:
+                for j in range(0, len(recipe["Manifests"][i]["Artifacts"])):
+                    uri = recipe["Manifests"][i]["Artifacts"][j]["URI"]
+                    recipe["Manifests"][i]["Artifacts"][j]["URI"] = uri.replace(uri_search, uri_replace, 1)
+    with open(str(recipe_file), "w") as f:
+        f.write(yaml.dump(recipe))
 
 
 def clean_up_aws_resources(component_name, component_version, region):

--- a/uat/test_uat_init.py
+++ b/uat/test_uat_init.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pathlib import Path
 
 
@@ -15,6 +17,7 @@ def test_init_template(change_test_dir, gdk_cli):
     assert Path(dirpath).joinpath("gdk-config.json").resolve().exists()
 
 
+@pytest.mark.version(min='1.1.0')
 def test_init_template_with_new_directory(change_test_dir, gdk_cli):
     dir = "test-dir"
     dirpath = Path(change_test_dir).joinpath(dir)
@@ -32,6 +35,7 @@ def test_init_repository(change_test_dir, gdk_cli):
     assert Path(dirpath).joinpath("gdk-config.json").exists()
 
 
+@pytest.mark.version(min='1.1.0')
 def test_init_repository_with_new_dir(change_test_dir, gdk_cli):
     dir = "test-dir"
     dirpath = Path(change_test_dir).joinpath(dir)

--- a/uat/test_uat_publish.py
+++ b/uat/test_uat_publish.py
@@ -1,11 +1,61 @@
 import os
 import shutil
+import pytest
+
 from pathlib import Path
 
 import t_utils
 
 
+@pytest.mark.version(min='1.0.0')
 def test_publish_template_zip(change_test_dir, gdk_cli):
+    # Recipe contains HelloWorld.zip artifact. So, create HelloWorld directory inside temporary directory.
+    path_HelloWorld = Path(change_test_dir).joinpath("helloworld")
+    path_HelloWorld.mkdir(parents=True, exist_ok=True)
+    os.chdir(str(path_HelloWorld))
+
+    simple_component_name = "com.example.PythonHelloWorld"
+    component_name = simple_component_name + "." + t_utils.random_id()
+    region = "us-east-1"
+    bucket = "gdk-cli-uat"
+    author = "gdk-cli-uat"
+    # Check if init downloads templates with necessary files.
+    check_init_template = gdk_cli.run(["component", "init", "-t", "HelloWorld", "-l", "python"])
+    assert check_init_template.returncode == 0
+    recipe_file = Path(path_HelloWorld).joinpath("recipe.yaml").resolve()
+    assert recipe_file.exists()
+    config_file = Path(path_HelloWorld).joinpath("gdk-config.json").resolve()
+    assert config_file.exists()
+
+    t_utils.replace_uri_in_recipe(recipe_file, "all", "HelloWorld", "helloworld")
+    t_utils.update_config(
+        config_file, component_name, region, bucket, author, old_component_name=simple_component_name
+    )
+    os.chdir(path_HelloWorld)
+    # Check if build works as expected.
+    check_build_template = gdk_cli.run(["component", "build"])
+    assert check_build_template.returncode == 0
+    assert Path(path_HelloWorld).joinpath("zip-build").resolve().exists()
+    assert Path(path_HelloWorld).joinpath("greengrass-build").resolve().exists()
+    artifact_path = (
+        Path(path_HelloWorld)
+        .joinpath("greengrass-build")
+        .joinpath("artifacts")
+        .joinpath(component_name)
+        .joinpath("NEXT_PATCH")
+        .joinpath("helloworld.zip")
+        .resolve()
+    )
+
+    assert artifact_path.exists()
+    check_publish_component = gdk_cli.run(["component", "publish"])
+    assert check_publish_component.returncode == 0
+    recipes_path = Path(path_HelloWorld).joinpath("greengrass-build").joinpath("recipes").resolve()
+    t_utils.clean_up_aws_resources(component_name, t_utils.get_version_created(recipes_path, component_name), region)
+
+
+@pytest.mark.version(min='1.1.0')
+def test_publish_template_zip_with_directory_name(change_test_dir, gdk_cli):
     # Recipe contains HelloWorld.zip artifact. So, create HelloWorld directory inside temporary directory.
     path_HelloWorld = Path(change_test_dir).joinpath("HelloWorld")
     simple_component_name = "com.example.PythonHelloWorld"
@@ -46,6 +96,7 @@ def test_publish_template_zip(change_test_dir, gdk_cli):
     t_utils.clean_up_aws_resources(component_name, t_utils.get_version_created(recipes_path, component_name), region)
 
 
+@pytest.mark.version(min='1.1.0')
 def test_publish_without_build_template_zip_with_bucket_arg(change_test_dir, gdk_cli):
     # Recipe contains HelloWorld.zip artifact. So, create HelloWorld directory inside temporary directory.
     path_HelloWorld = Path(change_test_dir).joinpath("HelloWorld")
@@ -88,10 +139,13 @@ def test_publish_without_build_template_zip_with_bucket_arg(change_test_dir, gdk
     t_utils.clean_up_aws_resources(component_name, t_utils.get_version_created(recipes_path, component_name), region)
 
 
+@pytest.mark.version(gt='1.1.0')
 def test_build_template_maven_multi_project_mixed_uris(change_test_dir, gdk_cli):
     path_multi_mvn_project = Path(change_test_dir).joinpath("maven-publish-test").resolve()
-    zip_file = "maven-mixed-uris-publish-test.zip"
-    component_name = "com.example.Multi.MixUris.Maven"
+    simple_zip_file = "maven-mixed-uris-publish-test.zip"
+    zip_file = "maven-mixed-uris-publish-test-" + t_utils.random_id() + ".zip"
+    simple_component_name = "com.example.Multi.MixUris.Maven"
+    component_name = simple_component_name + "." + t_utils.random_id()
     region = "us-east-1"
     s3_cl = t_utils.create_s3_client(region)
     account = t_utils.get_acc_num(region)
@@ -99,7 +153,7 @@ def test_build_template_maven_multi_project_mixed_uris(change_test_dir, gdk_cli)
     bucket = f"{bucket_prefix}-{region}-{account}"
     s3_cl.download_file(
         f"{bucket}",
-        f"do-not-delete-test-data/{zip_file}",
+        f"do-not-delete-test-data/{simple_zip_file}",
         str(Path(change_test_dir).joinpath(zip_file).resolve()),
     )
     shutil.unpack_archive(
@@ -113,7 +167,9 @@ def test_build_template_maven_multi_project_mixed_uris(change_test_dir, gdk_cli)
     config_file = Path(path_multi_mvn_project).joinpath("gdk-config.json").resolve()
     assert config_file.exists()
 
-    t_utils.update_config(config_file, component_name, region, bucket=bucket_prefix, author="Me")
+    t_utils.update_config(
+        config_file, component_name, region, bucket=bucket_prefix, author="Me", old_component_name=simple_component_name
+    )
 
     # Check if publish works as expected.
     check_build_template = gdk_cli.run(["component", "publish"], capture_output=False)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add multiple gdk versions to verify regression between latest and old gdk versions.

1. Add new option --target-version to pass the expected the gdk-cli versions to UATs.
   * Example:
      *  `pytest -v -s uat --target-version 1.0.0`
      *  `pytest -v -s uat --target-version 1.1.0`
      *  `pytest -v -s uat --target-version HEAD`
   * If not provided then target version defaults to `HEAD`, which translates to the code at the most recent commit against which the regression workflow is running.
2. Add `@pytest.mark.version(...)` test marker to provide version constraints for any UAT test.
   * The marker takes `kwargs` (key & values) to define constraints. These can be combined to create upper and lower bounds. Available key args are:
      * `eq`: equal to gdk cli version (exact version match).
      * `min` : minimum gdk cli version (lower bound)
      * `ge`: greater than or equal to gdk cli version (lower bound). Alias of `min`.
      * `gt`: greater than gdk cli version (lower bound).
      * `max` : maximum gdk cli version (upper bound)
      * `le`: less than or equal to gdk cli version (upper bound). Alias of `max`.
      * `lt`: less than gdk cli version (upper bound).
   * Examples:
       * `@pytest.mark.version(eq='1.1.0')`
       * `@pytest.mark.version(min='1.1.0')` or `@pytest.mark.version(ge='1.1.0')`
       * `@pytest.mark.version(max='1.1.0')` or `@pytest.mark.version(le='1.1.0')`
       * `@pytest.mark.version(gt='1.1.0')`
       * `@pytest.mark.version(lt='1.1.0')`
       * `@pytest.mark.version(min='1.0.0', max='1.1.0')`
 3. Applied version constraints based on feature changes between versions.

**Why is this change necessary:**
To ensure new changes are not breaking older versions.

**How was this change tested:**
With workflows runs as part of this pull request.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [x] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.