### PR TITLE
fix(publish): warn instead of raising an exception when an artifact i…

### DIFF
--- a/gdk/commands/component/PublishCommand.py
+++ b/gdk/commands/component/PublishCommand.py
@@ -339,7 +339,7 @@ class PublishCommand(Command):
                     logging.debug("Updating artifact URI of '{}' in the recipe file.".format(artifact_file))
                     artifact["URI"] = f"{artifact_uri}/{artifact_file}"
                 else:
-                    raise Exception(
+                    logging.warning(
                         f"Could not find the artifact file specified in the recipe '{artifact_file}' inside the build folder"
                         f" '{gg_build_component_artifacts}'."
                     )

--- a/tests/gdk/commands/component/test_PublishCommand.py
+++ b/tests/gdk/commands/component/test_PublishCommand.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from unittest import TestCase, mock
 
@@ -185,18 +186,14 @@ class PublishCommandTest(TestCase):
         )
         mock_glob = self.mocker.patch("pathlib.Path.glob", return_value=[])
         mock_create_publish_recipe = self.mocker.patch.object(PublishCommand, "create_publish_recipe_file", return_value=None)
-
+        spy_logging_warning = self.mocker.spy(logging, "warning")
         component_name = "com.example.HelloWorld"
         component_version = "1.0.0"
         publish = PublishCommand({})
-        with pytest.raises(Exception) as e:
-            publish.update_and_create_recipe_file(component_name, component_version)
-        assert (
-            "Could not find the artifact file specified in the recipe 'hello_world.py' inside the build folder"
-            in e.value.args[0]
-        )
+        publish.update_and_create_recipe_file(component_name, component_version)
+        assert spy_logging_warning.call_count == 1
         assert mock_glob.call_count == 1
-        assert not mock_create_publish_recipe.called
+        assert mock_create_publish_recipe.called
 
     def test_update_and_create_recipe_file_no_artifacts(self):
         no_artifacts_key = {

--- a/uat/test_uat_publish.py
+++ b/uat/test_uat_publish.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from pathlib import Path
 
 import t_utils
@@ -78,4 +79,39 @@ def test_publish_without_build_template_zip_with_bucket_arg(change_test_dir, gdk
 
     assert artifact_path.exists()
     recipes_path = Path(path_HelloWorld).joinpath("greengrass-build").joinpath("recipes").resolve()
+    t_utils.clean_up_aws_resources(component_name, t_utils.get_version_created(recipes_path, component_name), region)
+
+
+def test_build_template_maven_multi_project_mixed_uris(change_test_dir, gdk_cli):
+    path_multi_mvn_project = Path(change_test_dir).joinpath("maven-publish-test").resolve()
+    zip_file = "maven-mixed-uris-publish-test.zip"
+    component_name = "com.example.Multi.MixUris.Maven"
+    region = "us-east-1"
+    s3_cl = t_utils.create_s3_client(region)
+    account = t_utils.get_acc_num(region)
+    bucket_prefix = "gdk-cli-uat"
+    bucket = f"{bucket_prefix}-{region}-{account}"
+    s3_cl.download_file(
+        f"{bucket}",
+        f"do-not-delete-test-data/{zip_file}",
+        str(Path(change_test_dir).joinpath(zip_file).resolve()),
+    )
+    shutil.unpack_archive(
+        Path(change_test_dir).joinpath(zip_file),
+        path_multi_mvn_project,
+        "zip",
+    )
+    os.remove(Path(change_test_dir).joinpath(zip_file))
+    os.chdir(path_multi_mvn_project)
+    assert Path(path_multi_mvn_project).joinpath("recipe.yaml").resolve().exists()
+    config_file = Path(path_multi_mvn_project).joinpath("gdk-config.json").resolve()
+    assert config_file.exists()
+
+    t_utils.update_config(config_file, component_name, region, bucket=bucket_prefix, author="Me")
+
+    # Check if publish works as expected.
+    check_build_template = gdk_cli.run(["component", "publish"], capture_output=False)
+    assert check_build_template.returncode == 0
+    assert Path(path_multi_mvn_project).joinpath("greengrass-build").resolve().exists()
+    recipes_path = Path(path_multi_mvn_project).joinpath("greengrass-build").joinpath("recipes").resolve()
     t_utils.clean_up_aws_resources(component_name, t_utils.get_version_created(recipes_path, component_name), region)


### PR DESCRIPTION
…s not found

**Issue #, if available:**

**Description of changes:**
When an artifact is not found in the build folder during updating the recipe in`publish`,  instead of raising an exception just log it as a warning. This is because that artifact might actually be available on s3 already.   

**Why is this change necessary:**
For the publish command to work as expected with mixed artifacts (Artifacts created locally with build + artifacts on s3).

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.