### PR TITLE
chore: add pre-commit hooks with flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 127
+max-complexity = 10
+count = True
+show-source = True
+statistics = True

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           pip install flake8
           # The GitHub editor is 127 chars wide
-          flake8 . --count --max-complexity=10 --max-line-length=127 --show-source --statistics
+          flake8 .
       - name: Install test dependencies
         run: |
           pip install -r test-requirements.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: check-added-large-files
+-   repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+        -   id: flake8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,15 @@ To send us a pull request, please:
 
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+3. Ensure your pre-commit hooks are installed, if not then run the following commands.
+   ```shell
+     pip install pre-commit
+     pre-commit install
+   ```
+4. Ensure local tests pass.
+5. Commit to your fork using clear commit messages.
+6. Send us a pull request, answering any default questions in the pull request interface.
+7. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 
 The AWS IoT Greengrass Development Kit Command-Line Interface (GDK CLI) provides features that help you develop custom Greengrass components. You can use the GDK CLI to create, build, and publish custom components. When you create a component repository with the GDK CLI, you can start from a template or a community component from the Greengrass Software Catalog.
 
-Please follow the [GDK CLI public documentation](https://docs.aws.amazon.com/greengrass/v2/developerguide/greengrass-development-kit-cli.html) to learn more about the available commands and configuration that GDK CLI has to offer. 
+Please follow the [GDK CLI public documentation](https://docs.aws.amazon.com/greengrass/v2/developerguide/greengrass-development-kit-cli.html) to learn more about the available commands and configuration that GDK CLI has to offer.
 
 ### Getting Started
 
 #### Prerequisites
  1. [Python3](https://www.python.org/downloads/) and [pip](https://pip.pypa.io/en/latest/installation/): As the GDK CLI tool is written in python, you need to have python3 and pip installed. The most recent version of python includes pip.
 
- 2. [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html): As you'd have to configure your AWS credentials using AWS CLI before running certain gdk commands. 
+ 2. [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html): As you'd have to configure your AWS credentials using AWS CLI before running certain gdk commands.
 
 #### 1. Installing CLI
 
@@ -30,14 +30,14 @@ Configure AWS CLI with your credentials as shown here - https://docs.aws.amazon.
 
 #### 3. Quick start wih HelloWorld component written in python
 
-1. Initializes the project directory with a HelloWorld Greengrassv2 component. 
+1. Initializes the project directory with a HelloWorld Greengrassv2 component.
 
 `gdk component init --template HelloWorld --language python`
 
-2. Build the artifacts and recipes of the component. 
+2. Build the artifacts and recipes of the component.
 
 `gdk component build`
 
-3. Creates new version of the component in your AWS account. 
+3. Creates new version of the component in your AWS account.
 
 `gdk component publish`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-boto3 
-jsonschema 
-PyYAML 
+boto3
+jsonschema
+PyYAML
 requests
 packaging

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,7 @@
+# development dependencies
+pre-commit
+flake8
+# test dependencies
 jsonschema
 requests
 pyyaml
@@ -5,5 +9,4 @@ boto3
 pytest
 mock
 coverage
-flake8
 pytest-mock

--- a/uat/README.md
+++ b/uat/README.md
@@ -63,7 +63,7 @@ pytest -v -s uat --gdk-debug
 
 Pass this flag to in combination with coverage to track code coverage by the test suite.
 ```shell
-coverage run --source=gdk -m pytest -v -s uat --instrumented 
+coverage run --source=gdk -m pytest -v -s uat --instrumented
 ```
 
 Note: The `coverage` is required to instrument the code.
@@ -80,14 +80,14 @@ the tests are running against the most recent commit.
 #### 4. `@pytest.mark.version(...)` constraints
 `@pytest.mark.version(...)` is pytest marker to enforce version constraints for any test.
 
-The marker takes kwargs (key & values) to define constraints. These can be combined to create upper and 
+The marker takes kwargs (key & values) to define constraints. These can be combined to create upper and
 lower bounds. Available key args are:
- * `eq`: equal to gdk cli version (exact version match). 
+ * `eq`: equal to gdk cli version (exact version match).
  * `min` : minimum gdk cli version (lower bound)
- * `ge`: greater than or equal to gdk cli version (lower bound). Alias of `min`. 
- * `gt`: greater than gdk cli version (lower bound). 
+ * `ge`: greater than or equal to gdk cli version (lower bound). Alias of `min`.
+ * `gt`: greater than gdk cli version (lower bound).
  * `max` : maximum gdk cli version (upper bound)
- * `le`: less than or equal to gdk cli version (upper bound). Alias of `max`. 
+ * `le`: less than or equal to gdk cli version (upper bound). Alias of `max`.
  * `lt`: less than gdk cli version (upper bound).
 
 Examples:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Added pre-commit hooks to run flake8 automatically before commits.
Also updated `CONTRIBUTING.md` as the developers would need to run one time command to make `pre-commit` work.

**Why is this change necessary:**
Run flake8 automatically saves developers time, as our CI workflow enforces the same rules.

**How was this change tested:**
By running git commit locally.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.