### PR TITLE
Added support for Gradle’s Kotlin DSL

### DIFF
--- a/gdk/commands/component/BuildCommand.py
+++ b/gdk/commands/component/BuildCommand.py
@@ -247,7 +247,8 @@ class BuildCommand(Command):
         build_system = self.project_config["component_build_config"]["build_system"]
         build_folder = self.supported_build_sytems[build_system]["build_folder"]
         if build_system == "gradle":
-            return self.get_build_folders(build_folder, "build.gradle")
+            return self.get_build_folders(build_folder, "build.gradle")\
+                .union(self.get_build_folders(build_folder, "build.gradle.kts"))
         elif build_system == "maven":
             return self.get_build_folders(build_folder, "pom.xml")
         return {Path(utils.current_directory).joinpath(*build_folder).resolve()}
@@ -256,7 +257,7 @@ class BuildCommand(Command):
         """
         Recursively identifies build folders in a project.
 
-        This function makes use of build configuration files (such as pom.xml and build.gradle) and build folder
+        This function makes use of build configuration files (such as pom.xml, build.gradle, and build.gradle.kts) and build folder
         directories (such as target, build/libs) to identify the module directory.
 
         Once the module directory is found, its build folder is added to the return list.
@@ -264,13 +265,13 @@ class BuildCommand(Command):
         Parameters
         ----------
             build_folder(string): Build folder of a build system(target, build/libs)
-            build_file(string): Build configuration file of a build system (pom.xml, build.gradle)
+            build_file(string): Build configuration file of a build system (pom.xml, build.gradle, build.gradle.kts)
 
         Returns
         -------
             paths(set): Set of build folder paths in a multi-module project.
         """
-        # Filter module directories which contain pom.xml or build.gradle build files.
+        # Filter module directories which contain pom.xml, build.gradle, build.gradle.kts build files.
         set_dirs_with_build_file = set(f.parent for f in Path(utils.current_directory).rglob(build_file))
         set_of_module_dirs = set()
         for module_dir in set_dirs_with_build_file:

--- a/gdk/commands/component/BuildCommand.py
+++ b/gdk/commands/component/BuildCommand.py
@@ -5,11 +5,12 @@ import shutil
 import subprocess as sp
 from pathlib import Path
 
+import yaml
+
 import gdk.commands.component.project_utils as project_utils
 import gdk.common.consts as consts
 import gdk.common.exceptions.error_messages as error_messages
 import gdk.common.utils as utils
-import yaml
 from gdk.commands.Command import Command
 
 
@@ -247,8 +248,9 @@ class BuildCommand(Command):
         build_system = self.project_config["component_build_config"]["build_system"]
         build_folder = self.supported_build_sytems[build_system]["build_folder"]
         if build_system == "gradle":
-            return self.get_build_folders(build_folder, "build.gradle")\
-                .union(self.get_build_folders(build_folder, "build.gradle.kts"))
+            return self.get_build_folders(build_folder, "build.gradle").union(
+                self.get_build_folders(build_folder, "build.gradle.kts")
+            )
         elif build_system == "maven":
             return self.get_build_folders(build_folder, "pom.xml")
         return {Path(utils.current_directory).joinpath(*build_folder).resolve()}
@@ -257,8 +259,8 @@ class BuildCommand(Command):
         """
         Recursively identifies build folders in a project.
 
-        This function makes use of build configuration files (such as pom.xml, build.gradle, and build.gradle.kts) and build folder
-        directories (such as target, build/libs) to identify the module directory.
+        This function makes use of build configuration files (such as pom.xml, build.gradle, and build.gradle.kts)
+        and build folder directories (such as target, build/libs) to identify the module build directories.
 
         Once the module directory is found, its build folder is added to the return list.
 

--- a/tests/gdk/commands/component/test_BuildCommand.py
+++ b/tests/gdk/commands/component/test_BuildCommand.py
@@ -3,8 +3,9 @@ from shutil import Error
 from unittest import TestCase
 from unittest.mock import mock_open, patch
 
-import gdk.common.utils as utils
 import pytest
+
+import gdk.common.utils as utils
 from gdk.commands.component.BuildCommand import BuildCommand
 from gdk.common.exceptions import error_messages
 
@@ -848,7 +849,7 @@ class BuildCommandTest(TestCase):
         mock_get_build_folders.assert_any_call(["target"], "pom.xml")
 
     def test_get_build_folder_by_build_system_gradle(self):
-        dummy_paths = [Path("/").joinpath("path1"), Path("/").joinpath(*["path1", "path2"])]
+        dummy_paths = {Path("/").joinpath("path1"), Path("/").joinpath(*["path1", "path2"])}
         mock_get_build_folders = self.mocker.patch.object(BuildCommand, "get_build_folders", return_value=dummy_paths)
 
         build = BuildCommand({})
@@ -856,6 +857,7 @@ class BuildCommandTest(TestCase):
         gradle_build_paths = build._get_build_folder_by_build_system()
         assert gradle_build_paths == dummy_paths
         mock_get_build_folders.assert_any_call(["build", "libs"], "build.gradle")
+        mock_get_build_folders.assert_any_call(["build", "libs"], "build.gradle.kts")
 
     def test_get_build_folders_maven(self):
 

--- a/uat/component_build.feature
+++ b/uat/component_build.feature
@@ -91,3 +91,15 @@ Feature: gdk component build works
     When we quietly run gdk component build
     Then command was successful
     And we verify component build files
+
+
+  @version(gt='1.1.0')
+  @change_cwd
+  Scenario: build gradle kotlin multi project
+    Given we have cli installed
+    And we setup gdk project gradle-kotlin-build-test from s3
+    And we verify gdk project files
+    And change component name to com.example.Multi.Gradle.Kotlin
+    When we quietly run gdk component build
+    Then command was successful
+    And we verify component build files


### PR DESCRIPTION
**Description of changes:**
Add support for Gradle's Kotlin DSL by adding "build.gradle.kts" to the list of build files GDK searches for when the build system is set to "gradle"

**Why is this change necessary:**
Without this change anyone using Gradle's Kotlin DSL would receive an error message like the one below when attempting to run `gdk component build`:

```
[2022-03-17 22:00:20] WARNING - Could not find the artifact file 'HelloWorld-1.0.0.jar' in the build folder 'set()'.
```

**How was this change tested:**
I built a Greengrass component that uses Gradle's Kotlin DSL and published it successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.