### PR TITLE
feat: add support for using Gradle wrapper scripts

### DIFF
--- a/gdk/commands/component/BuildCommand.py
+++ b/gdk/commands/component/BuildCommand.py
@@ -247,7 +247,7 @@ class BuildCommand(Command):
         """
         build_system = self.project_config["component_build_config"]["build_system"]
         build_folder = self.supported_build_sytems[build_system]["build_folder"]
-        if build_system == "gradle":
+        if build_system == "gradle" or build_system == "gradlew":
             return self.get_build_folders(build_folder, "build.gradle").union(
                 self.get_build_folders(build_folder, "build.gradle.kts")
             )

--- a/gdk/static/config_schema.json
+++ b/gdk/static/config_schema.json
@@ -52,6 +52,7 @@
                                         "zip",
                                         "maven",
                                         "gradle",
+                                        "gradlew",
                                         "custom"
                                     ]
                                 }

--- a/gdk/static/project_build_schema.json
+++ b/gdk/static/project_build_schema.json
@@ -6,6 +6,7 @@
     "required": [
         "maven",
         "gradle",
+        "gradlew",
         "zip"
     ],
     "properties": {
@@ -26,6 +27,21 @@
             }
         },
         "gradle": {
+            "type": "object",
+            "required": [
+                "build_command",
+                "build_folder"
+            ],
+            "properties": {
+                "build_command": {
+                    "$ref": "#/$defs/build_command"
+                },
+                "build_folder": {
+                    "$ref": "#/$defs/build_folder"
+                }
+            }
+        },
+        "gradlew": {
             "type": "object",
             "required": [
                 "build_command",

--- a/gdk/static/project_build_system.json
+++ b/gdk/static/project_build_system.json
@@ -17,6 +17,7 @@
     "gradle": {
         "build_command": [
             "gradle",
+            "clean",
             "build"
         ],
         "build_folder": [
@@ -27,6 +28,7 @@
     "gradlew": {
         "build_command": [
             "./gradlew",
+            "clean",
             "build"
         ],
         "build_folder": [

--- a/gdk/static/project_build_system.json
+++ b/gdk/static/project_build_system.json
@@ -24,6 +24,16 @@
             "libs"
         ]
     },
+    "gradlew": {
+        "build_command": [
+            "./gradlew",
+            "build"
+        ],
+        "build_folder": [
+            "build",
+            "libs"
+        ]
+    },
     "zip": {
         "build_command": [
             "zip"

--- a/integration_tests/gdk/components/test_integ_BuildCommand.py
+++ b/integration_tests/gdk/components/test_integ_BuildCommand.py
@@ -3,13 +3,16 @@ from pathlib import Path
 from shutil import Error
 from unittest.mock import mock_open, patch
 
+import pytest
+
 import gdk.CLIParser as CLIParser
 import gdk.common.consts as consts
 import gdk.common.exceptions.error_messages as error_messages
 import gdk.common.parse_args_actions as parse_args_actions
 import gdk.common.utils as utils
-import pytest
 from gdk.commands.component.BuildCommand import BuildCommand
+
+gradle_build_command = ["gradle", "clean", "build"]
 
 
 @pytest.fixture()
@@ -289,7 +292,7 @@ def test_build_run_default_gradle_yaml_artifact_not_found(mocker, supported_buil
             assert not mock_file.called
             mock_yaml_dump.call_count == 0
     assert mock_get_proj_config.assert_called_once
-    mock_subprocess_run.assert_called_with(["gradle", "build"])  # called gradle build command
+    mock_subprocess_run.assert_called_with(gradle_build_command)  # called gradle build command
     assert mock_copy_dir.call_count == 0  # No copying directories
     assert supported_build_system.call_count == 1
     assert mock_archive_dir.call_count == 0  # Archvie never called in gralde
@@ -410,7 +413,7 @@ def test_build_run_default_gradle_yaml_artifact_found_build(mocker, supported_bu
         mock_file.assert_any_call(file_name, "w")
         mock_yaml_dump.call_count == 0
     assert mock_get_proj_config.assert_called_once
-    mock_subprocess_run.assert_called_with(["gradle", "build"])  # called gradle build command
+    mock_subprocess_run.assert_called_with(gradle_build_command)  # called gradle build command
     assert mock_copy_dir.call_count == 0  # No copying directories
     assert supported_build_system.call_count == 1
     assert mock_archive_dir.call_count == 0  # Archvie never called in gralde
@@ -448,7 +451,7 @@ def test_build_run_default_gradle_yaml_error_creating_recipe(mocker, supported_b
             mock_yaml_dump.call_count == 1
         assert "Failed to create build recipe file at" in e.value.args[0]
     assert mock_get_proj_config.assert_called_once
-    mock_subprocess_run.assert_called_with(["gradle", "build"])  # called gradle build command
+    mock_subprocess_run.assert_called_with(gradle_build_command)  # called gradle build command
     assert mock_copy_dir.call_count == 0  # No copying directories
     assert supported_build_system.call_count == 1
     assert mock_is_artifact_in_build.call_count == 1

--- a/tests/gdk/commands/component/test_BuildCommand.py
+++ b/tests/gdk/commands/component/test_BuildCommand.py
@@ -469,7 +469,7 @@ class BuildCommandTest(TestCase):
         assert build_command == ["mvn", "clean", "package"]
 
         build_command = build.get_build_cmd_from_platform("gradle")
-        assert build_command == ["gradle", "build"]
+        assert build_command == ["gradle", "clean", "build"]
 
         build_command = build.get_build_cmd_from_platform("zip")
         assert build_command == ["zip"]
@@ -485,7 +485,7 @@ class BuildCommandTest(TestCase):
         assert build_command == ["mvn.cmd", "clean", "package"]
 
         build_command = build.get_build_cmd_from_platform("gradle")
-        assert build_command == ["gradle", "build"]
+        assert build_command == ["gradle", "clean", "build"]
 
         build_command = build.get_build_cmd_from_platform("zip")
         assert build_command == ["zip"]

--- a/uat/component_build.feature
+++ b/uat/component_build.feature
@@ -103,3 +103,15 @@ Feature: gdk component build works
     When we quietly run gdk component build
     Then command was successful
     And we verify component build files
+
+  @version(gt='1.1.0')
+  @change_cwd
+  Scenario: build gradle kotlin multi project using gradle wrapper
+    Given we have cli installed
+    And we setup gdk project gradle-kotlin-build-test from s3
+    And we verify gdk project files
+    And change component name to com.example.Multi.Gradle.Kotlin
+    And change build system to gradlew
+    When we quietly run gdk component build
+    Then command was successful
+    And we verify component build files

--- a/uat/steps/component.py
+++ b/uat/steps/component.py
@@ -61,6 +61,14 @@ def update_component_config(context, component_name):
     context.last_component = unique_component_name
 
 
+@step('change build system to {build_system}')
+def update_component_config_build_system(context, build_system):
+    cwd = context.cwd if "cwd" in context else os.getcwd()
+    config_file = Path(cwd).joinpath(GG_CONFIG_JSON).resolve()
+    assert config_file.exists(), f"{GG_CONFIG_JSON} does not exist"
+    t_utils.update_config_build_sytem(config_file, context.last_component, build_system)
+
+
 @step('change artifact uri for {platform_type} platform from {search} to {replace}')
 def update_artifact_uri(context, platform_type, search, replace):
     cwd = context.cwd if "cwd" in context else os.getcwd()

--- a/uat/t_utils.py
+++ b/uat/t_utils.py
@@ -1,10 +1,10 @@
 import json
-import yaml
 import random
 import string
 from pathlib import Path
 
 import boto3
+import yaml
 
 
 def update_config(config_file, component_name, region, bucket, author, version="NEXT_PATCH", old_component_name=None):
@@ -17,6 +17,15 @@ def update_config(config_file, component_name, region, bucket, author, version="
         config["component"][component_name]["publish"]["region"] = region
         config["component"][component_name]["publish"]["bucket"] = bucket
         config["component"][component_name]["version"] = version
+    with open(str(config_file), "w") as f:
+        f.write(json.dumps(config, indent=4))
+
+
+def update_config_build_sytem(config_file, component_name, build_system):
+    # Update gdk-config file mandatory field like region.
+    with open(str(config_file), "r") as f:
+        config = json.loads(f.read())
+        config["component"][component_name]["build"]["build_sytem"] = build_system
     with open(str(config_file), "w") as f:
         f.write(json.dumps(config, indent=4))
 
@@ -87,4 +96,4 @@ def get_acc_num(region):
 def random_id():
     size = 6
     chars = string.ascii_uppercase + string.digits
-    return ''.join(random.choice(chars) for _ in range(size))
+    return "".join(random.choice(chars) for _ in range(size))


### PR DESCRIPTION
**Issue:**
https://github.com/aws-greengrass/aws-greengrass-gdk-cli/issues/84

**Description of changes:**
Added support for using Gradle wrapper scripts AKA "./gradlew"

**Why is this change necessary:**
Gradle wrappers enforce that a build uses the proper version of Gradle. Without this change components will be built with the system's Gradle command which may be the wrong version.

**How was this change tested:**
I built a component locally with it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.