### PR TITLE
chore: add stricter constraints on auto-approve flow

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -3,16 +3,19 @@ name: Auto approve bot
 
 on:
   pull_request_target:
-    types: [ labeled, unlabeled, opened, synchronize, reopened, ready_for_review, review_requested ]
+    types: [ labeled, opened, synchronize, reopened, ready_for_review, review_requested ]
+
+permissions:
+  pull-requests: write
+  contents: write
 
 jobs:
   auto-approve:
-    if: contains(github.event.pull_request.labels.*.name, 'auto-approve')
     runs-on: ubuntu-latest
-
-    permissions:
-      pull-requests: write
-
+    if: contains(github.event.pull_request.labels.*.name, 'auto-approve')
+      && github.actor == 'dependabot[bot]'
+      && github.event.sender.login == 'dependabot[bot]'
+      && github.event.sender.type == 'Bot'
     steps:
       - name: auto approve
         uses: actions/github-script@0.2.0


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Make auto-merge more stricter and only limited to dependabot PRs.

**Why is this change necessary:**
Without strict PR creator check, any other actor can create a PR and put an auto-approve label on it and try to spoof a dependency update PR. This could lead to automatically merging code from unknown actors.

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.