### PR TITLE
added encryption and metadata to artifact upload

### DIFF
--- a/gdk/commands/component/PublishCommand.py
+++ b/gdk/commands/component/PublishCommand.py
@@ -49,6 +49,40 @@ class PublishCommand(Command):
             logging.error("Failed to publish new version of the component '{}'".format(self.project_config["component_name"]))
             raise Exception("{}\n{}".format(error_messages.PUBLISH_FAILED, e))
 
+    def get_bucket_encryption(self, bucket_name):
+        """
+        Identifies the default s3 bucket encryption for artifact upload
+
+        Raises an exception when the request is not successful.
+
+        Parameters
+        ----------
+            bucket_name(string): Name of the s3 bucket to pull default encryption from.
+
+        Returns
+        -------
+            encrypt(dict): encryption argument to use with artifact upload
+        """
+        try:
+            encrypt = {}
+            response = self.service_clients["s3_client"].get_bucket_encryption(
+                Bucket=bucket_name
+            )
+            logging.info(f"Getting default encryption for S3 Bucket {bucket_name}.")
+            sse_default = response['ServerSideEncryptionConfiguration']['Rules'][0][
+                'ApplyServerSideEncryptionByDefault']
+            if sse_default.get("SSEAlgorithm") == "AES256":
+                encrypt = {'ServerSideEncryption': sse_default["SSEAlgorithm"]}
+            elif sse_default.get("KMSMasterKeyID"):
+                encrypt = {
+                    "ServerSideEncryption": sse_default["SSEAlgorithm"],
+                    "SSEKMSKeyId": sse_default['KMSMasterKeyID']
+                }
+            return encrypt
+        except Exception as e:
+            logging.error("Failed to get default encryption key for S3 Bucket {}".format(bucket_name))
+            raise Exception("{}\n{}".format(error_messages.PUBLISH_FAILED, e))
+
     def upload_artifacts_s3(self, component_name, component_version):
         """
         Uploads all the artifacts from component artifacts build folder to s3 bucket.
@@ -67,6 +101,32 @@ class PublishCommand(Command):
         try:
             bucket = self.project_config["bucket"]
             region = self.project_config["region"]
+            encrypt = self.project_config.get("encrypt")
+            metadata = self.project_config.get("metadata")
+
+            # Encryption artifact setup
+            if (type(encrypt) is str) and (encrypt.lower() == 'true'):
+                logging.info("Using default encryption.")
+                extra_args = {'ServerSideEncryption': 'AES256'}
+            elif (type(encrypt) is str) and (encrypt.lower() == 'default'):
+                logging.info("Using default bucket encryption.")
+                kms_key_id = self.get_bucket_encryption(bucket_name=bucket)
+                extra_args = kms_key_id
+            elif (type(encrypt) is dict) and encrypt.get('kms_key_id'):
+                logging.info("Using KMS encryption.")
+                extra_args = {
+                    "ServerSideEncryption": encrypt.get('server_side_encryption'),
+                    "SSEKMSKeyId": encrypt.get('kms_key_id')
+                }
+            else:
+                logging.info("No encryption configuration found.")
+                extra_args = {}
+
+            # Metadata artifact setup
+            if metadata:
+                logging.info("Building metadata for S3 Artifact upload.")
+                extra_args.update({"Metadata": metadata})
+
             logging.info(
                 f"Uploading component artifacts to S3 bucket: {bucket}. If this is your first time using this bucket, add the"
                 " 's3:GetObject' permission to each core device's token exchange role to allow it to download the component"
@@ -80,7 +140,7 @@ class PublishCommand(Command):
             for artifact in build_component_artifacts:
                 s3_file_path = f"{component_name}/{component_version}/{artifact.name}"
                 logging.debug("Uploading artifact '{}' to the bucket '{}'.".format(artifact.resolve(), bucket))
-                self.service_clients["s3_client"].upload_file(str(artifact.resolve()), bucket, s3_file_path)
+                self.service_clients["s3_client"].upload_file(str(artifact.resolve()), bucket, s3_file_path, ExtraArgs=extra_args)
         except Exception as e:
             raise Exception("Error while uploading the artifacts to s3 during publish.\n{}".format(e))
 

--- a/gdk/commands/component/PublishCommand.py
+++ b/gdk/commands/component/PublishCommand.py
@@ -2,13 +2,12 @@ import json
 import logging
 from pathlib import Path
 
-import yaml
-from botocore.exceptions import ClientError
-
 import gdk.commands.component.component as component
 import gdk.commands.component.project_utils as project_utils
 import gdk.common.exceptions.error_messages as error_messages
 import gdk.common.utils as utils
+import yaml
+from botocore.exceptions import ClientError
 from gdk.commands.Command import Command
 
 

--- a/gdk/commands/component/PublishCommand.py
+++ b/gdk/commands/component/PublishCommand.py
@@ -67,8 +67,8 @@ class PublishCommand(Command):
         try:
             bucket = self.project_config["bucket"]
             region = self.project_config["region"]
-            s3_upload_file_args = self.project_config.get("s3_upload_file_args")
-
+            options = self.project_config["options"]
+            s3_upload_file_args = options.get("file_upload_args", dict())
             logging.info(
                 f"Uploading component artifacts to S3 bucket: {bucket}. If this is your first time using this bucket, add the"
                 " 's3:GetObject' permission to each core device's token exchange role to allow it to download the component"

--- a/gdk/commands/component/project_utils.py
+++ b/gdk/commands/component/project_utils.py
@@ -108,6 +108,8 @@ def get_project_config_values():
     component_build_config = component_config["build"]
     bucket = component_config["publish"]["bucket"]
     region = component_config["publish"]["region"]
+    encrypt = component_config["publish"].get("encrypt")
+    metadata = component_config["publish"].get("metadata")
 
     # Build directories
     gg_build_directory = Path(utils.current_directory).joinpath(consts.greengrass_build_dir).resolve()
@@ -129,6 +131,8 @@ def get_project_config_values():
     vars["component_build_config"] = component_build_config
     vars["bucket"] = bucket
     vars["region"] = region
+    vars["encrypt"] = encrypt
+    vars["metadata"] = metadata
     vars["gg_build_directory"] = gg_build_directory
     vars["gg_build_artifacts_dir"] = gg_build_artifacts_dir
     vars["gg_build_recipes_dir"] = gg_build_recipes_dir

--- a/gdk/commands/component/project_utils.py
+++ b/gdk/commands/component/project_utils.py
@@ -108,8 +108,7 @@ def get_project_config_values():
     component_build_config = component_config["build"]
     bucket = component_config["publish"]["bucket"]
     region = component_config["publish"]["region"]
-    encrypt = component_config["publish"].get("encrypt")
-    metadata = component_config["publish"].get("metadata")
+    s3_upload_file_args = component_config["publish"].get("s3_upload_file_args")
 
     # Build directories
     gg_build_directory = Path(utils.current_directory).joinpath(consts.greengrass_build_dir).resolve()
@@ -131,8 +130,7 @@ def get_project_config_values():
     vars["component_build_config"] = component_build_config
     vars["bucket"] = bucket
     vars["region"] = region
-    vars["encrypt"] = encrypt
-    vars["metadata"] = metadata
+    vars["s3_upload_file_args"] = s3_upload_file_args
     vars["gg_build_directory"] = gg_build_directory
     vars["gg_build_artifacts_dir"] = gg_build_artifacts_dir
     vars["gg_build_recipes_dir"] = gg_build_recipes_dir

--- a/gdk/commands/component/project_utils.py
+++ b/gdk/commands/component/project_utils.py
@@ -108,7 +108,7 @@ def get_project_config_values():
     component_build_config = component_config["build"]
     bucket = component_config["publish"]["bucket"]
     region = component_config["publish"]["region"]
-    s3_upload_file_args = component_config["publish"].get("s3_upload_file_args")
+    options = component_config["publish"].get("options", dict())
 
     # Build directories
     gg_build_directory = Path(utils.current_directory).joinpath(consts.greengrass_build_dir).resolve()
@@ -130,7 +130,7 @@ def get_project_config_values():
     vars["component_build_config"] = component_build_config
     vars["bucket"] = bucket
     vars["region"] = region
-    vars["s3_upload_file_args"] = s3_upload_file_args
+    vars["options"] = options
     vars["gg_build_directory"] = gg_build_directory
     vars["gg_build_artifacts_dir"] = gg_build_artifacts_dir
     vars["gg_build_recipes_dir"] = gg_build_recipes_dir

--- a/gdk/static/config_schema.json
+++ b/gdk/static/config_schema.json
@@ -138,6 +138,10 @@
                                         "us-gov-east-1"
                                     ]
                                 }
+                            },                                
+                            "s3_upload_file_args": {
+                                "description": "Extra arguments used by S3 client during file transfer.",
+                                "type": "object"
                             },
                             "required": [
                                 "bucket",

--- a/gdk/static/config_schema.json
+++ b/gdk/static/config_schema.json
@@ -137,11 +137,17 @@
                                         "us-gov-west-1",
                                         "us-gov-east-1"
                                     ]
+                                },
+                                "options": {
+                                    "type": "object",
+                                    "description": "configuration options used during component version creation",
+                                    "properties": {
+                                        "file_upload_args": {
+                                            "type": "object",
+                                            "description": "Extra arguments used by S3 client during file transfer."
+                                        }
+                                    }
                                 }
-                            },                                
-                            "s3_upload_file_args": {
-                                "description": "Extra arguments used by S3 client during file transfer.",
-                                "type": "object"
                             },
                             "required": [
                                 "bucket",

--- a/integration_tests/gdk/components/test_integ_PublishCommand.py
+++ b/integration_tests/gdk/components/test_integ_PublishCommand.py
@@ -386,6 +386,7 @@ def project_config():
         "component_author": "abc",
         "bucket": "default",
         "region": "us-east-1",
+        "options": {},
         "gg_build_directory": Path("/src/GDK-CLI-Internal/greengrass-build"),
         "gg_build_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts"),
         "gg_build_recipes_dir": Path("/src/GDK-CLI-Internal/greengrass-build/recipes"),

--- a/tests/gdk/commands/component/test_PublishCommand.py
+++ b/tests/gdk/commands/component/test_PublishCommand.py
@@ -503,7 +503,7 @@ class PublishCommandTest(TestCase):
         mock_iter_dir = self.mocker.patch("pathlib.Path.iterdir", return_value=[Path("hello.py")])
         mock_create_bucket = self.mocker.patch("boto3.client.create_bucket", return_value=None)
         mock_upload_file = self.mocker.patch("boto3.client.upload_file", return_value=None)
-        self.mock_get_proj_config.return_value["s3_upload_file_args"] = {"Metadata": {"key": "value"}}
+        self.mock_get_proj_config.return_value["options"] = {"file_upload_args": {"Metadata": {"key": "value"}}}
         publish.upload_artifacts_s3("name", "1.0.0")
         assert mock_iter_dir.call_count == 1
         assert mock_create_bucket.call_count == 1
@@ -530,7 +530,7 @@ class PublishCommandTest(TestCase):
         assert mock_upload_file.call_count == 1
         s3_file_path = "name/1.0.0/hello.py"
         mock_upload_file.assert_any_call(
-            str(Path("hello.py").resolve()), self.mock_get_proj_config.return_value["bucket"], s3_file_path, ExtraArgs=None
+            str(Path("hello.py").resolve()), self.mock_get_proj_config.return_value["bucket"], s3_file_path, ExtraArgs={}
         )
 
     def test_upload_artifacts_exception(self):
@@ -552,7 +552,7 @@ class PublishCommandTest(TestCase):
         assert mock_upload_file.call_count == 1
         s3_file_path = "name/1.0.0/hello.py"
         mock_upload_file.assert_any_call(
-            str(Path("hello.py").resolve()), self.mock_get_proj_config.return_value["bucket"], s3_file_path, ExtraArgs=None
+            str(Path("hello.py").resolve()), self.mock_get_proj_config.return_value["bucket"], s3_file_path, ExtraArgs={}
         )
 
     def test_publish_run_not_build(self):
@@ -804,6 +804,7 @@ def project_config():
         "component_author": "abc",
         "bucket": "default",
         "region": "us-east-1",
+        "options": {},
         "gg_build_directory": Path("/src/GDK-CLI-Internal/greengrass-build"),
         "gg_build_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts"),
         "gg_build_recipes_dir": Path("/src/GDK-CLI-Internal/greengrass-build/recipes"),


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This enhancement will allow users to choose an encryption type while uploading the GDK artifact(s) to s3 or if chosen the  code will lookup the default bucket encryption type and use that.  This enhancement also will allow users to add metadata to the artifact(s) that are being uploaded. 

**Supported Encryption Values:** 
_alias_ : Which would use a kms key alias for encrypting the gdk artifact
example 
```
"publish": {
    "bucket": "this-is-a-test",
    "region": "us-east-1",
    "encrypt": {
        "server_side_encryption": "aws:kms",
        "kms_key_id": "alias/gdk-test"
    }
}
```

_kms key arn_ : This option would use a kms key arn for encrypting the gdk artifact
example : 
```
"publish": {
    "bucket": "this-is-a-test",
    "region": "us-east-1",
    "encrypt": {
        "server_side_encryption": "aws:kms",
        "kms_key_id": "arn:aws:kms:us-east-1:###########:key/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
    }
}
```

_kms key id_ : This option would use a kms key id for encrypting the gdk artifact
example : 
```
"publish": {
    "bucket": "this-is-a-test",
    "region": "us-east-1",
    "encrypt": {
        "server_side_encryption": "aws:kms",
        "kms_key_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
    }
}
```

**MetaData usage:** 
Example : 
```
"publish": {
    "bucket": "this-is-a-test",
    "region": "us-east-1",
    "metadata": {
        "key1": "value1",
        "key2": "value2",
        "key3": "value3"
    }
}
```

**Why is this change necessary:**
A number of company's require a bucket policy to which will deny unencrypted object uploads. The metadata enhancement will make it easier deployment solutions like the Connected Device Framework (CDF) to deploy a GreenGrass component to a device. 

**How was this change tested:**
User tested.  I setup a number of scenarios by creating a gdk-config.json file per test.  I also needed to setup S3 bucket default encryption a few different ways for my tests. 

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.