### PR TITLE
feat: run auto-approve after CI workflow

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,8 +2,11 @@
 name: Auto approve bot
 
 on:
-  pull_request_target:
-    types: [ labeled, opened, synchronize, reopened, ready_for_review, review_requested ]
+  # Only trigger, when the CI workflow succeeded
+  workflow_run:
+    workflows: [ "CI" ]
+    types:
+      - completed
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Change auto-approve workflow to only run after CI workflow has finished successfully.

**Why is this change necessary:**
As of now, auto-approve workflow executes in parallel to CI workflow. For dependabot pull requests, there is a risk that auto-approve workflow might merge prematurely before CI workflow completes. Making these workflows sequential mitigates that risk.

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.