### PR TITLE
feat: exclude files specified by user

### DIFF
--- a/gdk/build_system/BuildSystem.py
+++ b/gdk/build_system/BuildSystem.py
@@ -13,7 +13,6 @@ class BuildSystem:
 
     def register(self, system):
         self.systems[system.__str__()] = system
-        print(self.systems)
 
     def build(self, system_type):
         system = self.systems.get(system_type)

--- a/gdk/build_system/BuildSystem.py
+++ b/gdk/build_system/BuildSystem.py
@@ -13,6 +13,7 @@ class BuildSystem:
 
     def register(self, system):
         self.systems[system.__str__()] = system
+        print(self.systems)
 
     def build(self, system_type):
         system = self.systems.get(system_type)

--- a/gdk/build_system/Zip.py
+++ b/gdk/build_system/Zip.py
@@ -27,7 +27,7 @@ class Zip:
 
     def _build_system_zip(self):
         try:
-            zip_build = next(iter(self.build_folder))  # Only one zip-build folder in the set
+            zip_build = next(iter(self._get_build_folder_by_build_system()))  # Only one zip-build folder in the set
             artifacts_zip_build = Path(zip_build).joinpath(utils.current_directory.name).resolve()
             utils.clean_dir(zip_build)
             logging.debug("Copying over component files to the '{}' folder.".format(artifacts_zip_build.name))

--- a/gdk/build_system/Zip.py
+++ b/gdk/build_system/Zip.py
@@ -15,6 +15,7 @@ class Zip:
     This build folder is zipped completely as a component zip artifact.
     Raises an exception if there's an error in the process of zippings.
     """
+
     def __init__(self, project_config, build_folders):
         self.build_folders = build_folders
         self.project_config = project_config
@@ -27,11 +28,15 @@ class Zip:
 
     def build(self):
         try:
-            zip_build = next(iter(self.build_folders))  # Only one zip-build folder in the set
-            artifacts_zip_build = Path(zip_build).joinpath(utils.current_directory.name).resolve()
+            # Only one zip-build folder in the set
+            zip_build = next(iter(self.build_folders))
+            artifacts_zip_build = Path(zip_build).joinpath(
+                utils.current_directory.name).resolve()
             utils.clean_dir(zip_build)
-            logging.debug("Copying over component files to the '{}' folder.".format(artifacts_zip_build.name))
-            shutil.copytree(utils.current_directory, artifacts_zip_build, ignore=shutil.ignore_patterns(*self.ignore_list()))
+            logging.debug("Copying over component files to the '{}' folder.".format(
+                artifacts_zip_build.name))
+            shutil.copytree(utils.current_directory, artifacts_zip_build,
+                            ignore=shutil.ignore_patterns(*self.get_ignored_file_patterns()))
 
             # Get build file name without extension. This will be used as name of the archive.
             archive_file = utils.current_directory.name
@@ -40,18 +45,21 @@ class Zip:
                     archive_file, zip_build.name, artifacts_zip_build.name
                 )
             )
-            archive_file_name = Path(zip_build).joinpath(archive_file).resolve()
-            shutil.make_archive(archive_file_name, "zip", root_dir=artifacts_zip_build)
+            archive_file_name = Path(zip_build).joinpath(
+                archive_file).resolve()
+            shutil.make_archive(archive_file_name, "zip",
+                                root_dir=artifacts_zip_build)
             logging.debug("Archive complete.")
 
         except Exception as e:
-            raise Exception("""Failed to zip the component in default build mode.\n{}""".format(e))
+            raise Exception(
+                """Failed to zip the component in default build mode.\n{}""".format(e))
 
-    def ignore_list(self) -> list:
+    def get_ignored_file_patterns(self) -> list:
         """
-        Creates a list of files or directories to ignore while copying a directory.
+        Creates a list of files or directory patterns to ignore while copying a directory.
 
-        Helper function to create custom list of files/directories to ignore. Here, we exclude,
+        When no `exclude` option is present on the build configuration, it excludes:
         1. project config file -> gdk-config.json
         2. greengrass-build directory
         3. recipe file
@@ -59,13 +67,11 @@ class Zip:
         5. node_modules
         6. hidden files
 
-        Parameters
-        ----------
-            path,names
-
-        Returns
-        -------
-            ignore_list(list): List of files or directories to ignore during zip.
+        Otherwise it exclues:
+        1. project config file -> gdk-config.json
+        2. greengrass-build directory
+        3. recipe file
+        4. Any pattern defined on the exclude pattern array
         """
         options = self._get_build_options()
 
@@ -76,12 +82,12 @@ class Zip:
         ]
 
         if not options:
-            ignore_list.append(*[
+            ignore_list.extend([
                 "test*",
                 ".*",
                 "node_modules",
             ])
         else:
-            ignore_list.append(*options.get("excludes", []))
+            ignore_list.extend(options.get("excludes", []))
 
         return ignore_list

--- a/gdk/build_system/Zip.py
+++ b/gdk/build_system/Zip.py
@@ -27,7 +27,7 @@ class Zip:
 
     def _build_system_zip(self):
         try:
-            zip_build = next(iter(self._get_build_folder_by_build_system()))  # Only one zip-build folder in the set
+            zip_build = next(iter(self.build_folder))  # Only one zip-build folder in the set
             artifacts_zip_build = Path(zip_build).joinpath(utils.current_directory.name).resolve()
             utils.clean_dir(zip_build)
             logging.debug("Copying over component files to the '{}' folder.".format(artifacts_zip_build.name))

--- a/gdk/commands/component/BuildCommand.py
+++ b/gdk/commands/component/BuildCommand.py
@@ -166,39 +166,6 @@ class BuildCommand(Command):
         build_system.register(Zip(self.project_config, self._get_build_folder_by_build_system()))
         build_system.build("zip")
 
-    def _ignore_files_during_zip(self, path, names):
-        """
-        Creates a list of files or directories to ignore while copying a directory.
-
-        Helper function to create custom list of files/directories to ignore. Here, we exclude,
-        1. project config file -> gdk-config.json
-        2. greengrass-build directory
-        3. recipe file
-        4. tests folder
-        5. node_modules
-        6. hidden files
-
-        Parameters
-        ----------
-            path,names
-
-        Returns
-        -------
-            ignore_list(list): List of files or directories to ignore during zip.
-        """
-        # TODO: Nuke this - improve test that is testing this private method
-        # TODO: Identify individual files in recipe that are not same as zip and exclude them during zip.
-
-        ignore_list = [
-            consts.cli_project_config_file,
-            consts.greengrass_build_dir,
-            self.project_config["component_recipe_file"].name,
-            "test*",
-            ".*",
-            "node_modules",
-        ]
-        return ignore_list
-
     def _get_build_folder_by_build_system(self):
         """
         Returns build folder name specific to the build system. This folder contains component artifacts after the build

--- a/tests/gdk/build_system/test_BuildSystem.py
+++ b/tests/gdk/build_system/test_BuildSystem.py
@@ -19,7 +19,7 @@ class BuildSystemTests(TestCase):
                 pass
 
             def __str__(self):
-                return "fake"
+                return "fake_sys"
 
             def build(self):
                 return True
@@ -27,7 +27,7 @@ class BuildSystemTests(TestCase):
         build_system = BuildSystem()
         build_system.register(FakeSystem())
 
-        assert build_system.build("fake") is True
+        assert build_system.build("fake_sys") is True
 
     def test_build_system_unregistered_module(self):
 

--- a/tests/gdk/build_system/test_BuildSystem.py
+++ b/tests/gdk/build_system/test_BuildSystem.py
@@ -19,7 +19,7 @@ class BuildSystemTests(TestCase):
                 pass
 
             def __str__(self):
-                return "fake_sys"
+                return "fake"
 
             def build(self):
                 return True
@@ -27,7 +27,7 @@ class BuildSystemTests(TestCase):
         build_system = BuildSystem()
         build_system.register(FakeSystem())
 
-        assert build_system.build("fake_sys") is True
+        assert True == build_system.build("fake")
 
     def test_build_system_unregistered_module(self):
 

--- a/tests/gdk/build_system/test_BuildSystem.py
+++ b/tests/gdk/build_system/test_BuildSystem.py
@@ -27,7 +27,7 @@ class BuildSystemTests(TestCase):
         build_system = BuildSystem()
         build_system.register(FakeSystem())
 
-        assert True == build_system.build("fake")
+        assert build_system.build("fake") is True
 
     def test_build_system_unregistered_module(self):
 

--- a/tests/gdk/build_system/test_Zip.py
+++ b/tests/gdk/build_system/test_Zip.py
@@ -1,0 +1,33 @@
+import pytest
+from pathlib import Path
+from unittest import TestCase
+
+from gdk.build_system.Zip import Zip
+from tests.helpers.project_config import arrange_project_config
+
+
+class ZipTests(TestCase):
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker):
+        self.mocker = mocker
+
+    def project_config(self, build_options: dict):
+        return arrange_project_config({
+            "component_build_config": {
+                "build_system": "zip",
+                "options": build_options
+            }
+        })
+
+    def test_zip_build_with_excludes_option_only(self):
+        # Given
+        config = self.project_config({"excludes": [".env"]})
+        build_folder = Path(Path(".").resolve()).joinpath('zip-build')
+
+        # When
+        zip = Zip(config, {build_folder})
+
+        # Then
+        ignore_list = zip.ignore_list(None, None)
+        assert len(ignore_list) > 0
+        assert ".env" in ignore_list

--- a/tests/gdk/commands/component/test_BuildCommand.py
+++ b/tests/gdk/commands/component/test_BuildCommand.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from shutil import Error
 from unittest import TestCase
-from unittest.mock import mock_open, patch
+from unittest.mock import mock_open, patch, ANY
 
 import pytest
 
@@ -267,7 +267,6 @@ class BuildCommandTest(TestCase):
         mock_clean_dir = self.mocker.patch("gdk.common.utils.clean_dir", return_value=None)
         mock_copytree = self.mocker.patch("shutil.copytree")
         mock_subprocess_run = self.mocker.patch("subprocess.run", return_value=None)
-        mock_ignore_files_during_zip = self.mocker.patch.object(Zip, "_ignore_files_during_zip", return_value=[])
         mock_make_archive = self.mocker.patch("shutil.make_archive")
 
         build_sys = {
@@ -289,29 +288,10 @@ class BuildCommandTest(TestCase):
 
         curr_dir = Path(".").resolve()
 
-        mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, ignore=mock_ignore_files_during_zip)
+        mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, ignore=ANY)
         assert mock_make_archive.called
         zip_build_file = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
         mock_make_archive.assert_called_with(zip_build_file, "zip", root_dir=zip_artifacts_path)
-        assert mock_get_supported_component_builds.call_count == 1
-
-    def test_ignore_files_during_zip(self):
-
-        build_sys = {
-            "zip": {
-                "build_command": ["zip"],
-                "build_folder": ["zip-build"],
-            }
-        }
-        mock_get_supported_component_builds = self.mocker.patch(
-            "gdk.commands.component.project_utils.get_supported_component_builds", return_value=build_sys
-        )
-
-        path = Path(".")
-        names = ["1", "2"]
-        build = BuildCommand({})
-        li = build._ignore_files_during_zip(path, names)
-        assert type(li) == list
         assert mock_get_supported_component_builds.call_count == 1
 
     def test_build_system_zip_error_archive(self):
@@ -325,7 +305,6 @@ class BuildCommandTest(TestCase):
         mock_clean_dir = self.mocker.patch("gdk.common.utils.clean_dir", return_value=None)
         mock_copytree = self.mocker.patch("shutil.copytree")
         mock_subprocess_run = self.mocker.patch("subprocess.run", return_value=None)
-        mock_ignore_files_during_zip = self.mocker.patch.object(Zip, "_ignore_files_during_zip", return_value=[])
         mock_make_archive = self.mocker.patch("shutil.make_archive", side_effect=Error("some error"))
 
         build_sys = {
@@ -348,7 +327,7 @@ class BuildCommandTest(TestCase):
 
         curr_dir = Path(".").resolve()
 
-        mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, ignore=mock_ignore_files_during_zip)
+        mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, ignore=ANY)
         assert mock_make_archive.called
         zip_build_file = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
         mock_make_archive.assert_called_with(zip_build_file, "zip", root_dir=zip_artifacts_path)
@@ -365,7 +344,6 @@ class BuildCommandTest(TestCase):
         mock_clean_dir = self.mocker.patch("gdk.common.utils.clean_dir", return_value=None)
         mock_copytree = self.mocker.patch("shutil.copytree", side_effect=Error("some error"))
         mock_subprocess_run = self.mocker.patch("subprocess.run", return_value=None)
-        mock_ignore_files_during_zip = self.mocker.patch.object(Zip, "_ignore_files_during_zip", return_value=[])
 
         build_sys = {
             "zip": {
@@ -388,7 +366,7 @@ class BuildCommandTest(TestCase):
 
         curr_dir = Path(".").resolve()
 
-        mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, ignore=mock_ignore_files_during_zip)
+        mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, ignore=ANY)
         assert not mock_make_archive.called
         assert mock_get_supported_component_builds.call_count == 1
 
@@ -402,7 +380,7 @@ class BuildCommandTest(TestCase):
         mock_clean_dir = self.mocker.patch("gdk.common.utils.clean_dir", return_value=None)
         mock_copytree = self.mocker.patch("shutil.copytree")
         mock_subprocess_run = self.mocker.patch("subprocess.run", return_value=None)
-        mock_ignore_files_during_zip = self.mocker.patch.object(Zip, "_ignore_files_during_zip", return_value=[])
+        mock_ignore_files_during_zip = self.mocker.patch.object(Zip, "get_ignored_file_patterns", return_value=[])
         mock_make_archive = self.mocker.patch("shutil.make_archive")
 
         build_sys = {

--- a/tests/helpers/project_config.py
+++ b/tests/helpers/project_config.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+
+def arrange_project_config(overrides: dict):
+    base = {
+        "component_name": "component_name",
+        "component_build_config": {
+            "build_system": "zip"
+        },
+        "component_version": "1.0.0",
+        "component_author": "Testhoven",
+        "bucket": "default",
+        "region": "us-east-1",
+        "gg_build_directory": Path("/src/GDK-CLI-Internal/greengrass-build"),
+        "gg_build_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts"),
+        "gg_build_recipes_dir": Path("/src/GDK-CLI-Internal/greengrass-build/recipes"),
+        "gg_build_component_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts/component_name/1.0.0"),
+        "component_recipe_file": Path("/src/GDK-CLI-Internal/tests/gdk/static/build_command/valid_component_recipe.json"),
+        "parsed_component_recipe": {
+            "RecipeFormatVersion": "2020-01-25",
+            "ComponentName": "com.example.HelloWorld",
+            "ComponentVersion": "1.0.0",
+            "ComponentDescription": "My first Greengrass component.",
+            "ComponentPublisher": "Amazon",
+            "ComponentConfiguration": {"DefaultConfiguration": {"Message": "world"}},
+            "Manifests": [
+                {
+                    "Platform": {"os": "linux"},
+                    "Lifecycle": {"Run": "python3 -u {artifacts:path}/hello_world.py '{configuration:/Message}'"},
+                    "Artifacts": [{
+                        "URI": "s3://DOC-EXAMPLE-BUCKET/artifacts/com.example.HelloWorld/1.0.0/hello_world.py"
+                    }],
+                }
+            ],
+        },
+    }
+
+    base.update(overrides or {})
+    return base


### PR DESCRIPTION
**Issue #, if available:**
Solves https://github.com/aws-greengrass/aws-greengrass-gdk-cli/issues/109 as well.

**Description of changes:**
Reads the `exclude` configuration from the zip build options and if present it will exclude the files defined + the gdk exclusive files and build folders.

**Why is this change necessary:**
Allow users to have more control over the files they would like to get zipped.

**How was this change tested:**
unit test  + uats