### PR TITLE
fix: exit build when the command fails

### DIFF
--- a/gdk/commands/component/BuildCommand.py
+++ b/gdk/commands/component/BuildCommand.py
@@ -2,17 +2,18 @@ import json
 import logging
 import platform
 import shutil
-import yaml
 import subprocess as sp
 from pathlib import Path
+
+import yaml
 
 import gdk.commands.component.project_utils as project_utils
 import gdk.common.consts as consts
 import gdk.common.exceptions.error_messages as error_messages
 import gdk.common.utils as utils
-from gdk.commands.Command import Command
 from gdk.build_system.BuildSystem import BuildSystem
 from gdk.build_system.Zip import Zip
+from gdk.commands.Command import Command
 
 
 class BuildCommand(Command):
@@ -54,7 +55,7 @@ class BuildCommand(Command):
             custom_build_command = component_build_config["custom_build_command"]
             logging.info("Using custom build configuration to build the component.")
             logging.info("Running the following command\n{}".format(custom_build_command))
-            sp.run(custom_build_command)
+            sp.run(custom_build_command, check=True)
         else:
             logging.info(f"Using '{build_system}' build system to build the component.")
             self.default_build_component()
@@ -156,7 +157,7 @@ class BuildCommand(Command):
                 self._build_system_zip()
             else:
                 logging.info("Running the build command '{}'".format(" ".join(build_command)))
-                sp.run(build_command)
+                sp.run(build_command, check=True)
         except Exception as e:
             raise Exception(f"Error building the component with the given build system.\n{e}")
 

--- a/integration_tests/gdk/components/test_integ_BuildCommand.py
+++ b/integration_tests/gdk/components/test_integ_BuildCommand.py
@@ -181,7 +181,7 @@ def test_build_run_default_maven_yaml(mocker, supported_build_system, rglob_buil
         parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
         mock_file.assert_any_call(file_name, "w")
     assert mock_get_proj_config.assert_called_once
-    mock_subprocess_run.assert_called_with(["mvn", "clean", "package"])  # called maven build command
+    mock_subprocess_run.assert_called_with(["mvn", "clean", "package"], check=True)  # called maven build command
     assert mock_copy_dir.call_count == 0  # No copying directories
     assert supported_build_system.call_count == 1
     assert mock_archive_dir.call_count == 0  # Archvie never called in maven
@@ -217,7 +217,7 @@ def test_build_run_default_maven_yaml_windows(mocker, supported_build_system, rg
         mock_file.assert_any_call(file_name, "w")
         mock_yaml_dump.call_count == 1
     assert mock_get_proj_config.assert_called_once
-    mock_subprocess_run.assert_called_with(["mvn.cmd", "clean", "package"])  # called maven build command
+    mock_subprocess_run.assert_called_with(["mvn.cmd", "clean", "package"], check=True)  # called maven build command
     assert mock_copy_dir.call_count == 0  # No copying directories
     assert supported_build_system.call_count == 1
     assert mock_archive_dir.call_count == 0  # Archvie never called in maven
@@ -251,7 +251,7 @@ def test_build_run_default_maven_yaml_error(mocker, supported_build_system, rglo
         parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build", "-d"]))
     assert "error with maven build cmd" in e.value.args[0]
     assert mock_get_proj_config.assert_called_once
-    mock_subprocess_run.assert_called_with(["mvn.cmd", "clean", "package"])  # called maven build command
+    mock_subprocess_run.assert_called_with(["mvn.cmd", "clean", "package"], check=True)  # called maven build command
     assert mock_copy_dir.call_count == 0  # No copying directories
     assert supported_build_system.call_count == 1
     assert mock_archive_dir.call_count == 0  # Archvie never called in maven
@@ -292,7 +292,7 @@ def test_build_run_default_gradle_yaml_artifact_not_found(mocker, supported_buil
             assert not mock_file.called
             mock_yaml_dump.call_count == 0
     assert mock_get_proj_config.assert_called_once
-    mock_subprocess_run.assert_called_with(gradle_build_command)  # called gradle build command
+    mock_subprocess_run.assert_called_with(gradle_build_command, check=True)  # called gradle build command
     assert mock_copy_dir.call_count == 0  # No copying directories
     assert supported_build_system.call_count == 1
     assert mock_archive_dir.call_count == 0  # Archvie never called in gralde
@@ -376,7 +376,7 @@ def test_build_run_custom(mocker, supported_build_system, rglob_build_file):
         assert not mock_file.called
         mock_yaml_dump.call_count == 0
     assert mock_get_proj_config.assert_called_once
-    mock_subprocess_run.assert_called_with(["some-command"])  # called maven build command
+    mock_subprocess_run.assert_called_with(["some-command"], check=True)  # called maven build command
     assert mock_copy_dir.call_count == 0  # No copying directories
     assert supported_build_system.call_count == 1
     assert mock_is_artifact_in_build.call_count == 0  # only one artifact in project_config. Not vailable in build
@@ -413,7 +413,7 @@ def test_build_run_default_gradle_yaml_artifact_found_build(mocker, supported_bu
         mock_file.assert_any_call(file_name, "w")
         mock_yaml_dump.call_count == 0
     assert mock_get_proj_config.assert_called_once
-    mock_subprocess_run.assert_called_with(gradle_build_command)  # called gradle build command
+    mock_subprocess_run.assert_called_with(gradle_build_command, check=True)  # called gradle build command
     assert mock_copy_dir.call_count == 0  # No copying directories
     assert supported_build_system.call_count == 1
     assert mock_archive_dir.call_count == 0  # Archvie never called in gralde
@@ -451,7 +451,7 @@ def test_build_run_default_gradle_yaml_error_creating_recipe(mocker, supported_b
             mock_yaml_dump.call_count == 1
         assert "Failed to create build recipe file at" in e.value.args[0]
     assert mock_get_proj_config.assert_called_once
-    mock_subprocess_run.assert_called_with(gradle_build_command)  # called gradle build command
+    mock_subprocess_run.assert_called_with(gradle_build_command, check=True)  # called gradle build command
     assert mock_copy_dir.call_count == 0  # No copying directories
     assert supported_build_system.call_count == 1
     assert mock_is_artifact_in_build.call_count == 1


### PR DESCRIPTION
**Issue #, if available:**
A part of #97 to exit when the build fails is covered here. 

**Description of changes:**
Exit build when the build command files. This is a bug if a component is published without build. i.e if `gdk component publish` is run `gdk component build` is also run if the component is not built. In this case, if build fails, we publish command should exit as well. Without this change, even if the build fails, component is published.

We can check for the sub-process return code to see if the build succeeded. we're check=True also does the same thing  along with printing the output of the command. 


**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.