### PR TITLE
feat: add region and options args in publish command

### DIFF
--- a/gdk/commands/component/PublishCommand.py
+++ b/gdk/commands/component/PublishCommand.py
@@ -84,11 +84,10 @@ class PublishCommand(Command):
                 )
 
     def _read_options(self, options):
-        if options.endswith(".json"):
-            logging.debug("Reading options from the json file provided in the publish command")
-            options = self._read_from_file(options)
         try:
-            return json.loads(options)
+            if not options.endswith(".json"):
+                return json.loads(options)
+            return self._read_from_file(options)
         except json.decoder.JSONDecodeError as err:
             raise InvalidArgumentsError(
                 options,
@@ -96,6 +95,7 @@ class PublishCommand(Command):
             )
 
     def _read_from_file(self, options):
+        logging.debug("Reading options from the json file provided in the publish command")
         file_path = Path(options).resolve()
         if not utils.file_exists(file_path):
             raise InvalidArgumentsError(
@@ -103,7 +103,7 @@ class PublishCommand(Command):
                 "The json file path provided in the command does not exist",
             )
         with open(file_path, "r") as o_file:
-            return o_file.read()
+            return json.loads(o_file.read())
 
     def _update_region(self):
         if self.arguments["region"]:

--- a/gdk/commands/component/PublishCommand.py
+++ b/gdk/commands/component/PublishCommand.py
@@ -53,11 +53,16 @@ class PublishCommand(Command):
             None
         """
         self._update_account_number()
-        self._update_bucket()
+        self._override_config_with_command_args()
         self._update_component_version()
 
     def _update_account_number(self):
         self.project_config["account_number"] = self.get_account_number()
+
+    def _override_config_with_command_args(self):
+        self._update_region()
+        self._update_bucket()
+        self._update_options()
 
     def _update_bucket(self):
         if self.arguments["bucket"]:
@@ -66,6 +71,15 @@ class PublishCommand(Command):
             self.project_config["bucket"] = "{}-{}-{}".format(
                 self.project_config["bucket"], self.project_config["region"], self.project_config["account_number"]
             )
+
+    def _update_options(self):
+        if self.arguments["options"]:
+            opts = json.loads(self.arguments["options"])
+            self.project_config["options"] = opts
+
+    def _update_region(self):
+        if self.arguments["region"]:
+            self.project_config["region"] = self.arguments["region"]
 
     def _update_component_version(self):
         self.project_config["component_version"] = self.get_component_version_from_config()

--- a/gdk/common/exceptions/CommandError.py
+++ b/gdk/common/exceptions/CommandError.py
@@ -10,3 +10,10 @@ class ConflictingArgumentsError(CommandError):
         message = f"Arguments '{arg1}' and '{arg2}' are conflicting and cannot be used together in a command."
         self.message = message
         super().__init__(self.message)
+
+
+class InvalidArgumentsError(CommandError):
+    def __init__(self, arg1, message):
+        message = f"Argument '{arg1}' provided in the command is invalid. " + message
+        self.message = message
+        super().__init__(self.message)

--- a/gdk/static/cli_model.json
+++ b/gdk/static/cli_model.json
@@ -103,7 +103,7 @@
                     "-o",
                     "--options"
                 ],
-                "help": "Extra configuration options used during component version creation. This argument needs to be a json string containing publish options"
+                "help": "Extra configuration options used during component version creation. This argument needs to be a valid json string or a json file path containing publish options."
             }
         }
     },

--- a/gdk/static/cli_model.json
+++ b/gdk/static/cli_model.json
@@ -103,7 +103,7 @@
                     "-o",
                     "--options"
                 ],
-                "help": "Extra configuration options used during component version creation. This argument needs to be a valid json string or file path to a JSON file containing... containing publish options."
+                "help": "Extra configuration options used during component version creation. This argument needs to be a valid json string or file path to a JSON file containing the publish options."
             }
         }
     },

--- a/gdk/static/cli_model.json
+++ b/gdk/static/cli_model.json
@@ -103,7 +103,7 @@
                     "-o",
                     "--options"
                 ],
-                "help": "Extra configuration options used during component version creation. This argument needs to be a valid json string or a json file path containing publish options."
+                "help": "Extra configuration options used during component version creation. This argument needs to be a valid json string or file path to a JSON file containing... containing publish options."
             }
         }
     },

--- a/gdk/static/cli_model.json
+++ b/gdk/static/cli_model.json
@@ -90,6 +90,20 @@
                     "--bucket"
                 ],
                 "help": "Name of the s3 bucket to use for uploading component artifacts."
+            },
+            "region": {
+                "name": [
+                    "-r",
+                    "--region"
+                ],
+                "help": "Name of the AWS region to use component creation."
+            },
+            "options": {
+                "name": [
+                    "-o",
+                    "--options"
+                ],
+                "help": "Extra configuration options used during component version creation."
             }
         }
     },

--- a/gdk/static/cli_model.json
+++ b/gdk/static/cli_model.json
@@ -103,7 +103,7 @@
                     "-o",
                     "--options"
                 ],
-                "help": "Extra configuration options used during component version creation."
+                "help": "Extra configuration options used during component version creation. This argument needs to be a json string containing publish options"
             }
         }
     },

--- a/gdk/static/cli_model.json
+++ b/gdk/static/cli_model.json
@@ -89,21 +89,21 @@
                     "-b",
                     "--bucket"
                 ],
-                "help": "Name of the s3 bucket to use for uploading component artifacts."
+                "help": "Name of the s3 bucket to use for uploading component artifacts. This argument overrides the bucket name provided in the gdk configuration."
             },
             "region": {
                 "name": [
                     "-r",
                     "--region"
                 ],
-                "help": "Name of the AWS region to use component creation."
+                "help": "Name of the AWS region to use during component creation. This argument overrides the region name provided in the gdk configuration."
             },
             "options": {
                 "name": [
                     "-o",
                     "--options"
                 ],
-                "help": "Extra configuration options used during component version creation. This argument needs to be a valid json string or file path to a JSON file containing the publish options."
+                "help": "Extra configuration options used during component version creation. This argument needs to be a valid json string or file path to a JSON file containing the publish options. This argument overrides the options provided in the gdk configuration."
             }
         }
     },

--- a/integration_tests/gdk/components/test_integ_PublishCommand.py
+++ b/integration_tests/gdk/components/test_integ_PublishCommand.py
@@ -205,8 +205,17 @@ def test_publish_with_invalid_options_file(mocker, options_arg_file_contents, ge
         with patch("builtins.open", mock_open(read_data=options_arg_file_contents)):
             parse_args_actions.run_command(
                 CLIParser.cli_parser.parse_args(
-                    ["component", "publish", "-d", "-b", "new-bucket-arg", "-r", "us-west-2", "-o", 
-                    "options_arg_file_contents.json"]
+                    [
+                        "component",
+                        "publish",
+                        "-d",
+                        "-b",
+                        "new-bucket-arg",
+                        "-r",
+                        "us-west-2",
+                        "-o",
+                        "options_arg_file_contents.json",
+                    ]
                 )
             )
     assert "Please provide a valid json file path or a json string as the options argument" in e.value.args[0]

--- a/integration_tests/gdk/components/test_integ_PublishCommand.py
+++ b/integration_tests/gdk/components/test_integ_PublishCommand.py
@@ -119,7 +119,7 @@ def test_publish_run_with_bucket_argument(mocker, get_service_clients, mock_proj
     assert spy_get_caller_identity.call_count == 1  # Get account number
 
 
-def test_publish_run_with_region_and_options_argument(mocker, get_service_clients, mock_project_config):
+def test_publish_run_with_all_argument(mocker, get_service_clients, mock_project_config):
     mock_build_dir_exists = mocker.patch(
         "gdk.common.utils.dir_exists",
         return_value=True,
@@ -133,9 +133,9 @@ def test_publish_run_with_region_and_options_argument(mocker, get_service_client
     )
 
     spy_get_caller_identity = mocker.spy(get_service_clients["sts_client"], "get_caller_identity")
-    spy_create_bucket = mocker.patch.object(get_service_clients["s3_client"], "create_bucket")
-    spy_upload_file = mocker.patch.object(get_service_clients["s3_client"], "upload_file")
-    spy_create_component = mocker.patch.object(get_service_clients["greengrass_client"], "create_component_version")
+    spy_create_bucket = mocker.spy(get_service_clients["s3_client"], "create_bucket")
+    spy_upload_file = mocker.spy(get_service_clients["s3_client"], "upload_file")
+    spy_create_component = mocker.spy(get_service_clients["greengrass_client"], "create_component_version")
     with patch("builtins.open", mock_open()) as mock_file:
         parse_args_actions.run_command(
             CLIParser.cli_parser.parse_args(

--- a/integration_tests/gdk/components/test_integ_PublishCommand.py
+++ b/integration_tests/gdk/components/test_integ_PublishCommand.py
@@ -2,9 +2,10 @@ from pathlib import Path
 from unittest.mock import ANY, mock_open, patch
 
 import boto3
+import pytest
+
 import gdk.CLIParser as CLIParser
 import gdk.common.parse_args_actions as parse_args_actions
-import pytest
 from gdk.commands.component.PublishCommand import PublishCommand
 
 
@@ -119,7 +120,7 @@ def test_publish_run_with_bucket_argument(mocker, get_service_clients, mock_proj
     assert spy_get_caller_identity.call_count == 1  # Get account number
 
 
-def test_publish_run_with_all_argument(mocker, get_service_clients, mock_project_config):
+def test_publish_run_with_all_arguments(mocker, get_service_clients, mock_project_config):
     mock_build_dir_exists = mocker.patch(
         "gdk.common.utils.dir_exists",
         return_value=True,

--- a/tests/gdk/commands/component/test_PublishCommand.py
+++ b/tests/gdk/commands/component/test_PublishCommand.py
@@ -567,10 +567,13 @@ class PublishCommandTest(TestCase):
         mock_dir_exists = self.mocker.patch("gdk.common.utils.dir_exists", return_value=False)
         mock_build = self.mocker.patch("gdk.commands.component.component.build", return_value=None)
         mock_create_gg_component = self.mocker.patch.object(PublishCommand, "create_gg_component", return_value=None)
-        publish = PublishCommand({"bucket": None})
+        publish = PublishCommand(
+            {"bucket": None, "region": "us-west-2", "options": '{"file_upload_args":{"Metadata": {"key": "value"}}}'}
+        )
         publish.run()
         assert publish.project_config["account_number"] == "1234"
-        assert publish.project_config["bucket"] == "default-us-east-1-1234"
+        assert publish.project_config["bucket"] == "default-us-west-2-1234"
+        assert publish.project_config["options"] == {"file_upload_args": {"Metadata": {"key": "value"}}}
         assert mock_dir_exists.call_count == 1
         assert mock_build.call_count == 1
         assert mock_get_account_num.call_count == 1
@@ -591,7 +594,7 @@ class PublishCommandTest(TestCase):
         mock_dir_exists = self.mocker.patch("gdk.common.utils.dir_exists", return_value=False)
         mock_build = self.mocker.patch("gdk.commands.component.component.build", return_value=None)
         mock_create_gg_component = self.mocker.patch.object(PublishCommand, "create_gg_component", return_value=None)
-        publish = PublishCommand({"bucket": "exact-bucket"})
+        publish = PublishCommand({"bucket": "exact-bucket", "region": None, "options": None})
         publish.run()
         assert publish.project_config["account_number"] == "1234"
         assert publish.project_config["bucket"] == "exact-bucket"
@@ -614,7 +617,7 @@ class PublishCommandTest(TestCase):
         )
         mock_dir_exists = self.mocker.patch("gdk.common.utils.dir_exists", return_value=True)
         mock_build = self.mocker.patch("gdk.commands.component.component.build", return_value=None)
-        publish = PublishCommand({"bucket": None})
+        publish = PublishCommand({"bucket": None, "region": None, "options": None})
         publish.project_config["bucket"] = "default"
         mock_create_gg_component = self.mocker.patch.object(PublishCommand, "create_gg_component", return_value=None)
         publish.run()
@@ -637,7 +640,7 @@ class PublishCommandTest(TestCase):
             side_effect=HTTPError("some error"),
         )
         mock_project_built = self.mocker.patch.object(PublishCommand, "try_build", return_value=None)
-        publish = PublishCommand({"bucket": None})
+        publish = PublishCommand({"bucket": None, "region": None, "options": None})
         publish.project_config["bucket"] = "default"
         with pytest.raises(Exception) as e:
             publish.run()


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
gdk configuration supports bucket, region and options parameters under publish key. These configuration values as used with `gdk component publish` command. The cli publish command takes in `bucket` name as argument. 

With this change, region and options configuration values can also be provided as arguments to the publish command. 
`gdk component publish -r <region-name> -o <options-json-string>`. If these values are provided in both the gdk config file and as arguments in the publish command, the cli arguments override the gdk config values.   
 
**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.