### PR TITLE
refactor: move GGv2 client out from the publish command class

### DIFF
--- a/gdk/aws_clients/Greengrassv2Client.py
+++ b/gdk/aws_clients/Greengrassv2Client.py
@@ -1,0 +1,64 @@
+import logging
+
+
+class Greengrassv2Client:
+    """
+    Greengrasv2 client utils wrapper
+    """
+
+    def __init__(self, project_configuration, service_clients):
+        self.project_config = project_configuration
+        self.greengrass_client = service_clients["greengrass_client"]
+
+    def get_highest_component_version_(self) -> str:
+        """
+        Gets highest version of the component from the sorted order of its versions from an account in a region.
+
+        Makes a boto3 request with greengrass service client to list all versions of a component in an account.
+
+        Returns
+        ----
+            version: Highest version of the component if it exists already. Else returns None.
+        """
+
+        try:
+            region = self.project_config["region"]
+            component_name = self.project_config["component_name"]
+            account_num = self.project_config["account_number"]
+            component_arn = f"arn:aws:greengrass:{region}:{account_num}:components:{component_name}"
+
+            component_versions = self._get_component_version(component_arn)
+            if not component_versions:
+                return None
+            return component_versions[0]["componentVersion"]
+        except Exception as exc:
+            raise Exception(
+                f"Error while getting the component versions of '{component_name}' in '{region}' from the account"
+                f" '{account_num}' during publish.\n{exc}"
+            ) from exc
+
+    def _get_component_version(self, component_arn) -> dict:
+        comp_list_response = self.greengrass_client.list_component_versions(arn=component_arn)
+        return comp_list_response["componentVersions"]
+
+    def create_gg_component(self) -> None:
+        """
+        Creates a GreengrassV2 private component using its recipe.
+
+        Raises an exception if the recipe is invalid or the request is not successful.
+
+        """
+        component_name = self.project_config["component_name"]
+        component_version = self.project_config["component_version"]
+        publish_recipe_file = self.project_config["publish_recipe_file"]
+        with open(publish_recipe_file) as f:
+            try:
+                self.greengrass_client.create_component_version(inlineRecipe=f.read())
+                logging.info(
+                    "Created private version '%s' of the component '%s' in the account.", component_version, component_name
+                )
+            except Exception as exc:
+                logging.error("Failed to create the component using the recipe at '%s'.", publish_recipe_file)
+                raise Exception(
+                    f"Creating private version '{component_version}' of the component '{component_name}' failed.\n{exc}"
+                ) from exc

--- a/gdk/common/utils.py
+++ b/gdk/common/utils.py
@@ -2,10 +2,11 @@ import logging
 import shutil
 from pathlib import Path
 
-import gdk
-import gdk._version as version
 import requests
 from packaging.version import Version
+
+import gdk
+import gdk._version as version
 
 
 def get_static_file_path(file_name):
@@ -128,6 +129,17 @@ def cli_version_check():
             f"New version of GDK CLI - {latest_cli_version} is available. Please update the cli using the command"
             f" `{update_command}`.\n"
         )
+
+
+def get_next_patch_version(version_number: str) -> str:
+    split_with_hyphen = version_number.split("-")
+    split_with_plus = split_with_hyphen[0].split("+")
+    semver_numeric = split_with_plus[0].split(".")
+    major = semver_numeric[0]
+    minor = semver_numeric[1]
+    patch = semver_numeric[2]
+    next_patch_version = int(patch) + 1
+    return f"{major}.{minor}.{str(next_patch_version)}"
 
 
 error_line = "\n=============================== ERROR ===============================\n"

--- a/integration_tests/gdk/components/test_integ_PublishCommand.py
+++ b/integration_tests/gdk/components/test_integ_PublishCommand.py
@@ -47,7 +47,7 @@ def test_publish_command_instantiation(mocker, mock_project_config):
     mock_run = mocker.patch.object(PublishCommand, "run", return_value=None)
     mock_get_service_clients = mocker.patch(
         "gdk.commands.component.project_utils.get_service_clients",
-        return_value={"s3_client": None},
+        return_value={"s3_client": None, "greengrass_client": None},
     )
     parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "publish"]))
 

--- a/tests/gdk/aws_clients/test_Greengrassv2Client.py
+++ b/tests/gdk/aws_clients/test_Greengrassv2Client.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+from unittest import TestCase, mock
+from unittest.mock import call
+
+import pytest
+from urllib3.exceptions import HTTPError
+
+from gdk.aws_clients.Greengrassv2Client import Greengrassv2Client
+
+
+class Greengrassv2ClientTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker):
+        self.mocker = mocker
+        self.project_config = {
+            "account_number": "1234",
+            "component_name": "c_name",
+            "region": "test-region",
+            "publish_recipe_file": Path("some-recipe.yaml"),
+            "component_version": "1.0.0",
+        }
+        self.mock_ggv2_client = self.mocker.patch("boto3.client", return_value=None)
+        self.service_clients = {"greengrass_client": self.mock_ggv2_client}
+
+    def test_get_next_patch_component_version(self):
+        greengrass_client = Greengrassv2Client(self.project_config, self.service_clients)
+        response = {"componentVersions": [{"componentVersion": "1.0.4"}, {"componentVersion": "1.0.1"}]}
+        mock_get_next_patch_component_version = self.mocker.patch(
+            "boto3.client.list_component_versions", return_value=response
+        )
+        c_arn = "arn:aws:greengrass:test-region:1234:components:c_name"
+        highest_component_version = greengrass_client.get_highest_component_version_()
+        assert mock_get_next_patch_component_version.call_args_list == [call(arn=c_arn)]
+        assert highest_component_version == "1.0.4"
+
+    def test_get_next_patch_component_version_no_components(self):
+        greengrass_client = Greengrassv2Client(self.project_config, self.service_clients)
+        mock_get_next_patch_component_version = self.mocker.patch(
+            "boto3.client.list_component_versions", return_value={"componentVersions": []}
+        )
+        c_arn = "arn:aws:greengrass:test-region:1234:components:c_name"
+        highest_component_version = greengrass_client.get_highest_component_version_()
+        assert mock_get_next_patch_component_version.call_args_list == [call(arn=c_arn)]
+        assert highest_component_version is None
+
+    def test_get_next_patch_component_version_exception(self):
+        greengrass_client = Greengrassv2Client(self.project_config, self.service_clients)
+        mock_get_next_patch_component_version = self.mocker.patch(
+            "boto3.client.list_component_versions", side_effect=HTTPError("listing error")
+        )
+        c_arn = "arn:aws:greengrass:test-region:1234:components:c_name"
+        with pytest.raises(Exception) as e:
+            greengrass_client.get_highest_component_version_()
+        assert mock_get_next_patch_component_version.call_args_list == [call(arn=c_arn)]
+        assert (
+            "Error while getting the component versions of 'c_name' in 'test-region' from the account '1234' during"
+            " publish.\nlisting error"
+            == e.value.args[0]
+        )
+
+    def test_create_gg_component(self):
+        greengrass_client = Greengrassv2Client(self.project_config, self.service_clients)
+        mock_create_component = self.mocker.patch("boto3.client.create_component_version", return_value=None)
+
+        with mock.patch("builtins.open", mock.mock_open(read_data="some-recipe-content")) as mock_file:
+            greengrass_client.create_gg_component()
+            assert mock_file.call_args_list == [call(Path("some-recipe.yaml"))]
+            assert mock_create_component.call_args_list == [call(inlineRecipe="some-recipe-content")]
+
+    def test_create_gg_component_exception(self):
+        greengrass_client = Greengrassv2Client(self.project_config, self.service_clients)
+        mock_create_component = self.mocker.patch(
+            "boto3.client.create_component_version", return_value=None, side_effect=HTTPError("error")
+        )
+        greengrass_client.project_config["publish_recipe_file"] = Path("some-recipe.yaml")
+
+        with mock.patch("builtins.open", mock.mock_open(read_data="some-recipe-content")) as mock_file:
+            with pytest.raises(Exception) as e:
+                greengrass_client.create_gg_component()
+            assert "Creating private version '1.0.0' of the component 'c_name' failed." in e.value.args[0]
+            assert mock_file.call_args_list == [call(Path("some-recipe.yaml"))]
+            assert mock_create_component.call_args_list == [call(inlineRecipe="some-recipe-content")]

--- a/tests/gdk/common/test_utils.py
+++ b/tests/gdk/common/test_utils.py
@@ -1,8 +1,10 @@
 import logging
 from pathlib import Path
 
-import gdk.common.utils as utils
+import pytest
 from urllib3.exceptions import HTTPError
+
+import gdk.common.utils as utils
 
 
 def test_get_static_file_path_exists(mocker):
@@ -150,3 +152,32 @@ def test_cli_version_check_latest_available(mocker):
     utils.cli_version_check()
     assert mock_get_latest_cli_version.called
     assert spy_log.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "1.0.0",
+        "1.0.0-alpha+meta",
+        "1.0.0-alpha",
+        "1.0.0-alpha.beta",
+        "1.0.0-alpha.beta.1",
+        "1.0.0-alpha.123",
+        "1.0.0-alpha0.valid",
+        "1.0.0-alpha.0valid",
+        "1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay",
+        "1.0.0-rc.1+build.123",
+        "1.0.0-DEV-SNAPSHOT",
+        "1.0.0+meta",
+        "1.0.0+meta-valid",
+        "1.0.0+build.1848",
+        "1.0.0-alpha+beta",
+        "1.0.0----RC-SNAPSHOT.12.9.1--.12+788",
+        "1.0.0----R-S.12.9.1--.12+meta",
+        "1.0.0----RC-SNAPSHOT.12.9.1--.12",
+        "1.0.0+0.build.1-rc.10000aaa-kk-0.1",
+        "1.0.0-0A.is.legal",
+    ],
+)
+def test_get_next_patch_version(version):
+    assert utils.get_next_patch_version(version) == "1.0.1"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
These changes create a new adapter class for performing Greengrassv2 client operations based on the project config.
 
**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.