### PR TITLE
fix: fix excludes typo in config schema & add a UAT to verify

### DIFF
--- a/gdk/static/config_schema.json
+++ b/gdk/static/config_schema.json
@@ -80,7 +80,7 @@
                                                 "type": "object",
                                                 "description": "configuration options for the zip build system",
                                                 "properties": {
-                                                    "exclude": {
+                                                    "excludes": {
                                                         "type": "array",
                                                         "description": "regex patterns of files to exclude",
                                                         "minItems": 1

--- a/tests/gdk/build_system/test_zip_build_configuration.py
+++ b/tests/gdk/build_system/test_zip_build_configuration.py
@@ -34,7 +34,7 @@ def configuration_base(options: dict) -> dict:
 
 @pytest.mark.parametrize(
     "options",
-    [None, {"exclude": ["*.ts"]}, dict()],
+    [None, {"excludes": ["*.ts"]}, dict()],
 )
 def test_valid_configuration_options(options):
     validate_configuration(configuration_base(options))

--- a/uat/component_build.feature
+++ b/uat/component_build.feature
@@ -115,3 +115,22 @@ Feature: gdk component build works
     When we quietly run gdk component build
     Then command was successful
     And we verify component build files
+
+
+  @version(min='1.2.0')
+  @change_cwd
+  Scenario: build template zip with excludes options
+    Given we have cli installed
+    And we make directory HelloWorld
+    And we run gdk component init -t HelloWorld -l python
+    And command was successful
+    And we verify gdk project files
+    And change component name to com.example.PythonHelloWorld
+    And change build options to {"excludes":["main.py"]}
+    When we run gdk component build
+    Then command was successful
+    And we verify component zip build files
+    And we verify build artifact named HelloWorld.zip
+    And we verify the following files in HelloWorld.zip
+      | excluded    | included  |
+      | ["main.py"] | ["tests"] |

--- a/uat/steps/component.py
+++ b/uat/steps/component.py
@@ -1,6 +1,7 @@
+import ast
 import os
 import t_utils
-
+import shutil
 from behave import step
 from pathlib import Path
 from constants import (
@@ -69,9 +70,44 @@ def update_component_config_build_system(context, build_system):
     t_utils.update_config_build_sytem(config_file, context.last_component, build_system)
 
 
+@step("change build options to {build_options}")
+def update_component_config_build_options(context, build_options):
+    cwd = context.cwd if "cwd" in context else os.getcwd()
+    config_file = Path(cwd).joinpath(GG_CONFIG_JSON).resolve()
+    assert config_file.exists(), f"{GG_CONFIG_JSON} does not exist"
+    t_utils.update_config_build_options(config_file, context.last_component, build_options)
+
+
 @step('change artifact uri for {platform_type} platform from {search} to {replace}')
 def update_artifact_uri(context, platform_type, search, replace):
     cwd = context.cwd if "cwd" in context else os.getcwd()
     recipe_file = Path(cwd).joinpath(GG_RECIPE_YAML).resolve()
     assert recipe_file.exists(), f"{GG_RECIPE_YAML} does not exist"
     t_utils.replace_uri_in_recipe(recipe_file, platform_type, search, replace)
+
+
+@step("we verify the following files in {artifact_name}")
+def verify_files_in_build_zip_artifact(context, artifact_name):
+    cwd = context.cwd if "cwd" in context else os.getcwd()
+    component_name = context.last_component
+    artifact_path = (
+        Path(cwd)
+        .joinpath(GG_BUILD_DIR)
+        .joinpath("artifacts")
+        .joinpath(component_name)
+        .joinpath("NEXT_PATCH")
+        .joinpath(artifact_name)
+        .resolve()
+    )
+    assert artifact_path.exists(), f"Artifact {artifact_name} not found at {artifact_path}"
+    unpack_dir = Path(cwd).joinpath("unarchived-artifact").resolve()
+    shutil.unpack_archive(artifact_path, unpack_dir)
+
+    for row in context.table:
+        excluded_files = ast.literal_eval(row["excluded"])
+        included_files = ast.literal_eval(row["included"])
+
+    for file in excluded_files:
+        assert not unpack_dir.joinpath(file).exists(), f"File {file} found at {unpack_dir}"
+    for file in included_files:
+        assert unpack_dir.joinpath(file).exists(), f"File {file} not found at {unpack_dir}"

--- a/uat/t_utils.py
+++ b/uat/t_utils.py
@@ -22,10 +22,18 @@ def update_config(config_file, component_name, region, bucket, author, version="
 
 
 def update_config_build_sytem(config_file, component_name, build_system):
-    # Update gdk-config file mandatory field like region.
     with open(str(config_file), "r") as f:
         config = json.loads(f.read())
         config["component"][component_name]["build"]["build_sytem"] = build_system
+    with open(str(config_file), "w") as f:
+        f.write(json.dumps(config, indent=4))
+
+
+def update_config_build_options(config_file, component_name, build_options):
+    with open(str(config_file), "r") as f:
+        config = json.loads(f.read())
+        d = {"options": json.loads(build_options)}
+        config["component"][component_name]["build"].update(d)
     with open(str(config_file), "w") as f:
         f.write(json.dumps(config, indent=4))
 


### PR DESCRIPTION
**Issue #, if available:**
#143 
**Description of changes:**
Fixes typo in `excludes` option of GDK config schema. 

**Why is this change necessary:**
- This change is needed to correctly exclude the files during zip and also match the documentation. 

**How was this change tested:**
- Added a new UAT that verifies the option and also the files in the final zip artifact. 
- Failed UAT run: https://github.com/aws-greengrass/aws-greengrass-gdk-cli/actions/runs/4558031750/jobs/8040432001?pr=149#step:15:7903
- Passing UAT run after updating schema: https://github.com/aws-greengrass/aws-greengrass-gdk-cli/actions/runs/4558111632/jobs/8040600772?pr=149


TODO: The minimum version of this UAT must be bumped to 1.2.2 - Will do that in the follow up PR. 
**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.