### PR TITLE
refactor: improve gdk command output

### DIFF
--- a/gdk/commands/methods.py
+++ b/gdk/commands/methods.py
@@ -1,4 +1,10 @@
 from gdk.commands.component import component
+import gdk.CLIParser
+
+
+def _gdk(d_args):
+    if not d_args.get("gdk"):
+        gdk.CLIParser.cli_parser.print_help()
 
 
 def _gdk_component_init(d_args):

--- a/integration_tests/gdk/test_integ_CLIParser.py
+++ b/integration_tests/gdk/test_integ_CLIParser.py
@@ -31,3 +31,12 @@ def test_main_parse_args_list(mocker):
     args = CLIParser.cli_parser.parse_args(["component", "list", "--template", "-d"])
     parse_args_actions.run_command(args)
     assert mock_component_list.called
+
+
+def test_main_parse_args_gdk(capsys):
+    args = CLIParser.cli_parser.parse_args([])
+    parse_args_actions.run_command(args)
+    command_output = capsys.readouterr().out
+    CLIParser.cli_parser.print_help()
+    help_output = capsys.readouterr().out
+    assert command_output == help_output

--- a/tests/gdk/commands/test_methods.py
+++ b/tests/gdk/commands/test_methods.py
@@ -1,6 +1,12 @@
 import gdk.commands.methods as methods
 
 
+def test_gdk(mocker):
+    mock_component_init = mocker.patch("gdk.CLIParser.cli_parser.print_help", return_value=None)
+    methods._gdk({"gdk": None})
+    assert mock_component_init.call_count == 1
+
+
 def test_gdk_component_init(mocker):
     mock_component_init = mocker.patch("gdk.commands.component.component.init", return_value=None)
     methods._gdk_component_init({})


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix the output of `gdk` command. 

Before: 
```
[2023-04-06 11:20:55] ERROR - Command failed due to an argument error.
=============================== ERROR ===============================
unrecognized arguments: --verion

=============================== HELP ===============================

usage: gdk [-h] [-d] [-v] {component} ...

Greengrass development kit - CLI for developing AWS IoT GreengrassV2 components.

positional arguments:
  {component}
    component    Initialize, build and publish GreengrassV2 components using this command.

optional arguments:
  -h, --help     show this help message and exit
  -d, --debug    Increase command output to debug level
  -v, --version  show program's version number and exit
```
After:

```
usage: gdk [-h] [-d] [-v] {component} ...

Greengrass development kit - CLI for developing AWS IoT GreengrassV2 components.

positional arguments:
  {component}
    component    Initialize, build and publish GreengrassV2 components using this command.

optional arguments:
  -h, --help     show this help message and exit
  -d, --debug    Increase command output to debug level
  -v, --version  show program's version number and exit
```

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.