### PR TITLE
test: fix last command type to cleanup aws resources properly

### DIFF
--- a/uat/steps/gdk_cli.py
+++ b/uat/steps/gdk_cli.py
@@ -26,5 +26,5 @@ def gdk_command_with_args_and_capture_mode(context, capture_output, commands=Non
     context.last_cli_output = context.gdk_cli.run(
         args, capture_output=capture_output
     )
-    context.last_cli_command_type = f"{commands[0]} {commands[1]}"
+    context.last_cli_command_type = f"{args[0]} {args[1]}"
     context.last_cli_command_args = args


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
AWS resources are cleaned up after each scenario if the last command used is of type `gdk component publish`. 
The last command type used is not set properly all this time (set as `c o`  for any command type) and so the resources created were cleaned up resulting in exceeding the limit for number of components (5000). 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.