### PR TITLE
refactor: exit commands with full exception message + add debug logs

### DIFF
--- a/gdk/CLIParser.py
+++ b/gdk/CLIParser.py
@@ -187,7 +187,8 @@ def main():
         args_namespace = cli_parser.parse_args()
         parse_args_actions.run_command(args_namespace)
     except Exception as e:
-        print(f"{utils.error_line}{e}")
+        print(f"{utils.error_line}")
+        logging.exception(e)
         exit(1)
 
 

--- a/gdk/aws_clients/Greengrassv2Client.py
+++ b/gdk/aws_clients/Greengrassv2Client.py
@@ -31,11 +31,14 @@ class Greengrassv2Client:
             if not component_versions:
                 return None
             return component_versions[0]["componentVersion"]
-        except Exception as exc:
-            raise Exception(
-                f"Error while getting the component versions of '{component_name}' in '{region}' from the account"
-                f" '{account_num}' during publish.\n{exc}"
-            ) from exc
+        except Exception:
+            logging.error(
+                "Error while getting the component versions of '%s' in '%s' from the account '%s' during publish.",
+                component_name,
+                region,
+                account_num,
+            )
+            raise
 
     def _get_component_version(self, component_arn) -> dict:
         comp_list_response = self.greengrass_client.list_component_versions(arn=component_arn)
@@ -57,8 +60,6 @@ class Greengrassv2Client:
                 logging.info(
                     "Created private version '%s' of the component '%s' in the account.", component_version, component_name
                 )
-            except Exception as exc:
+            except Exception:
                 logging.error("Failed to create the component using the recipe at '%s'.", publish_recipe_file)
-                raise Exception(
-                    f"Creating private version '{component_version}' of the component '{component_name}' failed.\n{exc}"
-                ) from exc
+                raise

--- a/gdk/build_system/Zip.py
+++ b/gdk/build_system/Zip.py
@@ -51,9 +51,9 @@ class Zip:
                                 root_dir=artifacts_zip_build)
             logging.debug("Archive complete.")
 
-        except Exception as e:
-            raise Exception(
-                """Failed to zip the component in default build mode.\n{}""".format(e))
+        except Exception:
+            logging.error("Failed to zip the component in default build mode.")
+            raise
 
     def get_ignored_file_patterns(self) -> list:
         """

--- a/gdk/commands/component/BuildCommand.py
+++ b/gdk/commands/component/BuildCommand.py
@@ -103,8 +103,9 @@ class BuildCommand(Command):
             # Build the project with specified build system
             self.run_build_command()
             self.build_recipe_transformer.transform(self._get_build_folder_by_build_system())
-        except Exception as e:
-            raise Exception("""{}\n{}""".format(error_messages.BUILD_FAILED, e))
+        except Exception:
+            logging.error(error_messages.BUILD_FAILED)
+            raise
 
     def get_build_cmd_from_platform(self, build_system):
         """
@@ -152,8 +153,9 @@ class BuildCommand(Command):
             else:
                 logging.info("Running the build command '{}'".format(" ".join(build_command)))
                 sp.run(build_command, check=True)
-        except Exception as e:
-            raise Exception(f"Error building the component with the given build system.\n{e}")
+        except Exception:
+            logging.error("Error building the component with the given build system.")
+            raise
 
     def _build_system_zip(self):
         # Delegate to avoid breaking tests - TODO: We need to avoid testing private methods

--- a/gdk/commands/component/InitCommand.py
+++ b/gdk/commands/component/InitCommand.py
@@ -74,15 +74,17 @@ class InitCommand(Command):
             template_name = "{}-{}".format(template, language)
             logging.info("Fetching the component template '{}' from Greengrass Software Catalog.".format(template_name))
             self.download_and_clean(template_name, "template", project_dir)
-        except Exception as e:
-            raise Exception("Could not initialize the project with component template '{}'.\n{}".format(template, e))
+        except Exception:
+            logging.error("Could not initialize the project with component template '%s'.", template)
+            raise
 
     def init_with_repository(self, repository, project_dir):
         try:
             logging.info("Fetching the component repository '{}' from Greengrass Software Catalog.".format(repository))
             self.download_and_clean(repository, "repository", project_dir)
-        except Exception as e:
-            raise Exception("Could not initialize the project with component repository '{}'.\n{}".format(repository, e))
+        except Exception:
+            logging.error("Could not initialize the project with component repository '%s'.", repository)
+            raise
 
     def download_and_clean(self, comp_name, comp_type, project_dir):
         """
@@ -105,11 +107,9 @@ class InitCommand(Command):
         if download_response.status_code != 200:
             try:
                 download_response.raise_for_status()
-            except Exception as e:
-                logging.error(e)
-                raise e
-            finally:
-                raise Exception(error_messages.INIT_FAILS_DURING_COMPONENT_DOWNLOAD.format(comp_type))
+            except Exception:
+                logging.error(error_messages.INIT_FAILS_DURING_COMPONENT_DOWNLOAD.format(comp_type))
+                raise
 
         logging.debug("Downloading the component {}...".format(comp_type))
         with zipfile.ZipFile(BytesIO(download_response.content)) as zfile:

--- a/gdk/commands/component/ListCommand.py
+++ b/gdk/commands/component/ListCommand.py
@@ -31,9 +31,9 @@ class ListCommand(Command):
         response = requests.get(url)
         try:
             response.raise_for_status()
-        except Exception as e:
-            logging.error(e)
-            raise Exception(error_messages.LISTING_COMPONENTS_FAILED)
+        except Exception:
+            logging.error(error_messages.LISTING_COMPONENTS_FAILED)
+            raise
 
         try:
             return response.json()
@@ -49,8 +49,8 @@ class ListCommand(Command):
         HelloWorld-python, HelloWorld-java.
         """
         try:
-            language = re.search(r'\b(java|python)\b', template_name).group(1)
-            template_name = re.sub(r'\b\-(java|python)\b', '', template_name)
+            language = re.search(r"\b(java|python)\b", template_name).group(1)
+            template_name = re.sub(r"\b\-(java|python)\b", "", template_name)
             return f"{template_name} ({language})"
         except Exception:
             return template_name

--- a/gdk/commands/component/PublishCommand.py
+++ b/gdk/commands/component/PublishCommand.py
@@ -29,9 +29,9 @@ class PublishCommand(Command):
             component_name = self.project_config["component_name"]
             component_version = self.project_config["component_version"]
             self._publish_component_version(component_name, component_version)
-        except Exception as e:
+        except Exception:
             logging.error("Failed to publish new version of the component '{}'".format(self.project_config["component_name"]))
-            raise Exception("{}\n{}".format(error_messages.PUBLISH_FAILED, e))
+            raise
 
     def try_build(self):
         # TODO: This method should just warn and proceed. It should not build the component.
@@ -81,10 +81,9 @@ class PublishCommand(Command):
         if self.arguments.get("options"):
             try:
                 self.project_config["options"] = self._read_options(self.arguments["options"])
-            except Exception as exc:
-                raise Exception(
-                    "Please provide a valid json file path or a json string as the options argument.\nError:\t" + str(exc)
-                )
+            except Exception:
+                logging.error("Please provide a valid json file path or a json string as the options argument.")
+                raise
 
     def _read_options(self, options):
         try:
@@ -190,8 +189,9 @@ class PublishCommand(Command):
             next_version = utils.get_next_patch_version(c_next_patch_version)
             logging.info("Using '{}' as the next version of the component '{}' to create.".format(next_version, c_name))
             return next_version
-        except Exception as e:
-            raise Exception("Failed to calculate the next version of the component during publish.\n{}".format(e))
+        except Exception:
+            logging.error("Failed to calculate the next version of the component during publish.")
+            raise
 
     def get_account_number(self):
         """
@@ -212,8 +212,9 @@ class PublishCommand(Command):
             account_num = caller_identity_response["Account"]
             logging.debug("Identified account number as '{}'.".format(account_num))
             return account_num
-        except Exception as e:
-            raise Exception("Error while fetching account number from credentials.\n{}".format(e))
+        except Exception:
+            logging.error("Error while fetching account number from credentials.")
+            raise
 
     def get_component_version_from_config(self):
         """

--- a/gdk/commands/component/PublishCommand.py
+++ b/gdk/commands/component/PublishCommand.py
@@ -5,7 +5,6 @@ from gdk.commands.component.transformer.PublishRecipeTransformer import PublishR
 
 import gdk.commands.component.component as component
 import gdk.commands.component.project_utils as project_utils
-import gdk.common.exceptions.error_messages as error_messages
 import gdk.common.utils as utils
 from gdk.aws_clients.Greengrassv2Client import Greengrassv2Client
 from gdk.aws_clients.S3Client import S3Client

--- a/gdk/commands/component/component.py
+++ b/gdk/commands/component/component.py
@@ -1,36 +1,22 @@
 def init(d_args):
     from gdk.commands.component.InitCommand import InitCommand
 
-    try:
-        InitCommand(d_args).run()
-    except Exception as e:
-        raise Exception(f"Could not initialize the project due to the following error.\n{e}")
+    InitCommand(d_args).run()
 
 
 def build(d_args):
     from gdk.commands.component.BuildCommand import BuildCommand
 
-    try:
-        BuildCommand(d_args).run()
-    except Exception as e:
-        raise Exception(f"Could not build the project due to the following error.\n{e}")
+    BuildCommand(d_args).run()
 
 
 def publish(d_args):
     from gdk.commands.component.PublishCommand import PublishCommand
 
-    try:
-        PublishCommand(d_args).run()
-    except Exception as e:
-        raise Exception(f"Could not publish the component due to the following error.\n{e}")
+    PublishCommand(d_args).run()
 
 
 def list(d_args):
     from gdk.commands.component.ListCommand import ListCommand
 
-    try:
-        ListCommand(d_args).run()
-    except Exception as e:
-        raise Exception(
-            f"Could not list the available components from Greengrass Software Catalog due to the following error.\n{e}"
-        )
+    ListCommand(d_args).run()

--- a/gdk/commands/component/transformer/BuildRecipeTransformer.py
+++ b/gdk/commands/component/transformer/BuildRecipeTransformer.py
@@ -134,4 +134,5 @@ class BuildRecipeTransformer:
 
         component_recipe_file_name = self.project_config["component_recipe_file"].name
         gg_build_recipe_file = Path(self.project_config["gg_build_recipes_dir"]).joinpath(component_recipe_file_name).resolve()
+        logging.debug("Creating component recipe at '%s'.", gg_build_recipe_file)
         CaseInsensitiveRecipeFile().write(gg_build_recipe_file, parsed_component_recipe)

--- a/gdk/commands/component/transformer/PublishRecipeTransformer.py
+++ b/gdk/commands/component/transformer/PublishRecipeTransformer.py
@@ -85,4 +85,5 @@ class PublishRecipeTransformer:
 
         """
         publish_recipe_file = Path(self.project_config["publish_recipe_file"]).resolve()
+        logging.debug("Creating component recipe at '%s'.", publish_recipe_file)
         CaseInsensitiveRecipeFile().write(publish_recipe_file, parsed_component_recipe)

--- a/integration_tests/gdk/components/test_integ_BuildCommand.py
+++ b/integration_tests/gdk/components/test_integ_BuildCommand.py
@@ -122,7 +122,10 @@ def test_build_command_instantiation_failed_conflicting_args(mocker):
 def test_build_run():
     with pytest.raises(Exception) as e:
         parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
-    assert "Could not build the project due to the following error." in e.value.args[0]
+    assert (
+        error_messages.CONFIG_FILE_NOT_EXISTS
+        in e.value.args[0]
+    )
 
 
 def test_build_run_default_zip_json(mocker, supported_build_system, rglob_build_file):
@@ -284,7 +287,7 @@ def test_default_build_component_error_run_build_command(mocker, rglob_build_fil
     )
     with pytest.raises(Exception) as e:
         parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "build"]))
-    assert error_messages.BUILD_FAILED in e.value.args[0]
+    assert "err in run_build_command" in e.value.args[0]
     assert mock_run_build_command.assert_called_once
     assert not mock_transform.called
 

--- a/integration_tests/gdk/components/test_integ_InitCommand.py
+++ b/integration_tests/gdk/components/test_integ_InitCommand.py
@@ -94,7 +94,7 @@ class CommandTest(TestCase):
         with pytest.raises(Exception) as e:
             parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "init", "--repository", "dummy"]))
 
-        assert "Could not initialize the project due to the following error." in e.value.args[0]
+        assert "Some exception" in e.value.args[0]
 
         assert mock_is_directory_empty.call_count == 0
         assert mock_init_with_template.call_count == 0
@@ -212,7 +212,7 @@ class CommandTest(TestCase):
                 CLIParser.cli_parser.parse_args(["component", "init", "-t", "template", "-l", "python"])
             )
 
-        assert "Could not initialize the project with component template 'template'." in e.value.args[0]
+        assert "error" in e.value.args[0]
         assert mock_is_directory_empty.call_count == 1
         assert mock_conflicting_args.call_count == 1
         mock_download_and_clean.assert_called_once_with("template-python", "template", utils.current_directory)
@@ -225,7 +225,7 @@ class CommandTest(TestCase):
         with pytest.raises(Exception) as e:
             parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "init", "--repository", "dummy"]))
 
-        assert "Could not initialize the project with component repository 'dummy'." in e.value.args[0]
+        assert "error" in e.value.args[0]
         assert mock_is_directory_empty.call_count == 1
         assert mock_conflicting_args.call_count == 1
         mock_download_and_clean.assert_called_once_with("dummy", "repository", utils.current_directory)
@@ -246,7 +246,7 @@ class CommandTest(TestCase):
                     CLIParser.cli_parser.parse_args(["component", "init", "-t", "template", "-l", "python"])
                 )
 
-                assert "Failed to download the selected component" in e.value.args[0]
+                assert "some error" in e.value.args[0]
                 assert mock_template_download.call_count == 1
                 assert mock_is_directory_empty.call_count == 1
                 assert mock_conflicting_args.called
@@ -268,7 +268,7 @@ class CommandTest(TestCase):
             with pytest.raises(Exception) as e:
                 parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "init", "-r", "repo"]))
 
-                assert "Failed to download the selected component" in e.value.args[0]
+                assert "some error" in e.value.args[0]
                 assert mock_template_download.call_count == 1
                 assert mock_is_directory_empty.call_count == 1
                 assert mock_conflicting_args.called

--- a/integration_tests/gdk/components/test_integ_ListCommand.py
+++ b/integration_tests/gdk/components/test_integ_ListCommand.py
@@ -28,7 +28,7 @@ def test_list_template_failed_request(mocker):
     with pytest.raises(Exception) as e:
         parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "list", "--template"]))
     assert mock_list_req.called
-    assert error_messages.LISTING_COMPONENTS_FAILED in e.value.args[0]
+    assert "some error" in e.value.args[0]
 
 
 def test_list_repository_failed_request(mocker):
@@ -37,7 +37,7 @@ def test_list_repository_failed_request(mocker):
     with pytest.raises(Exception) as e:
         parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["component", "list", "--repository"]))
     assert mock_list_req.called
-    assert error_messages.LISTING_COMPONENTS_FAILED in e.value.args[0]
+    assert "some error" in e.value.args[0]
 
 
 def test_list_template_not_json(mocker):

--- a/integration_tests/gdk/components/test_integ_ListCommand.py
+++ b/integration_tests/gdk/components/test_integ_ListCommand.py
@@ -2,7 +2,6 @@ import logging
 
 import gdk.CLIParser as CLIParser
 import gdk.common.consts as consts
-import gdk.common.exceptions.error_messages as error_messages
 import gdk.common.parse_args_actions as parse_args_actions
 import pytest
 from urllib3.exceptions import HTTPError

--- a/integration_tests/gdk/components/test_integ_PublishCommand.py
+++ b/integration_tests/gdk/components/test_integ_PublishCommand.py
@@ -159,34 +159,9 @@ def test_publish_run_with_all_arguments(mocker, get_service_clients, mock_projec
 
 @pytest.mark.parametrize(
     "options_arg",
-    ["file/path/not_exists.json", '{"invalid_json_string":{"missing":quotes"}}'],
-)
-def test_publish_with_invalid_options(mocker, options_arg, get_service_clients, mock_project_config):
-    mocker.patch(
-        "gdk.common.utils.dir_exists",
-        return_value=True,
-    )
-    if options_arg == "file_exists.json":
-        mocker.patch(
-            "gdk.common.utils.file_exists",
-            return_value=True,
-        )
-
-    with pytest.raises(Exception) as e:
-        with patch("builtins.open", mock_open()):
-            parse_args_actions.run_command(
-                CLIParser.cli_parser.parse_args(
-                    ["component", "publish", "-d", "-b", "new-bucket-arg", "-r", "us-west-2", "-o", options_arg]
-                )
-            )
-    assert "The json file path provided in the command does not exist" in e.value.args[0]
-
-
-@pytest.mark.parametrize(
-    "options_arg",
     ["file/path/not_exists.json"],
 )
-def test_publish_with_invalid_options(mocker, options_arg, get_service_clients, mock_project_config):
+def test_publish_with_invalid_options_file_not_exists(mocker, options_arg, get_service_clients, mock_project_config):
     mocker.patch(
         "gdk.common.utils.dir_exists",
         return_value=True,

--- a/integration_tests/gdk/components/test_integ_PublishCommand.py
+++ b/integration_tests/gdk/components/test_integ_PublishCommand.py
@@ -179,7 +179,57 @@ def test_publish_with_invalid_options(mocker, options_arg, get_service_clients, 
                     ["component", "publish", "-d", "-b", "new-bucket-arg", "-r", "us-west-2", "-o", options_arg]
                 )
             )
-    assert "Please provide a valid json file path or a json string as the options argument" in e.value.args[0]
+    assert "The json file path provided in the command does not exist" in e.value.args[0]
+
+
+@pytest.mark.parametrize(
+    "options_arg",
+    ["file/path/not_exists.json"],
+)
+def test_publish_with_invalid_options(mocker, options_arg, get_service_clients, mock_project_config):
+    mocker.patch(
+        "gdk.common.utils.dir_exists",
+        return_value=True,
+    )
+    if options_arg == "file_exists.json":
+        mocker.patch(
+            "gdk.common.utils.file_exists",
+            return_value=True,
+        )
+
+    with pytest.raises(Exception) as e:
+        with patch("builtins.open", mock_open()):
+            parse_args_actions.run_command(
+                CLIParser.cli_parser.parse_args(
+                    ["component", "publish", "-d", "-b", "new-bucket-arg", "-r", "us-west-2", "-o", options_arg]
+                )
+            )
+    assert "The json file path provided in the command does not exist" in e.value.args[0]
+
+
+@pytest.mark.parametrize(
+    "options_arg",
+    ['{"missing":quotes"}'],
+)
+def test_publish_with_invalid_options(mocker, options_arg, get_service_clients, mock_project_config):
+    mocker.patch(
+        "gdk.common.utils.dir_exists",
+        return_value=True,
+    )
+    if options_arg == "file_exists.json":
+        mocker.patch(
+            "gdk.common.utils.file_exists",
+            return_value=True,
+        )
+
+    with pytest.raises(Exception) as e:
+        with patch("builtins.open", mock_open()):
+            parse_args_actions.run_command(
+                CLIParser.cli_parser.parse_args(
+                    ["component", "publish", "-d", "-b", "new-bucket-arg", "-r", "us-west-2", "-o", options_arg]
+                )
+            )
+    assert "JSON string is incorrectly formatted." in e.value.args[0]
 
 
 @pytest.mark.parametrize(
@@ -212,7 +262,7 @@ def test_publish_with_invalid_options_file(mocker, options_arg_file_contents, ge
                     ]
                 )
             )
-    assert "Please provide a valid json file path or a json string as the options argument" in e.value.args[0]
+    assert "JSON string is incorrectly formatted." in e.value.args[0]
 
 
 def test_publish_run_next_patch(mocker, get_service_clients, mock_project_config):

--- a/tests/gdk/aws_clients/test_Greengrassv2Client.py
+++ b/tests/gdk/aws_clients/test_Greengrassv2Client.py
@@ -53,8 +53,7 @@ class Greengrassv2ClientTest(TestCase):
             greengrass_client.get_highest_component_version_()
         assert mock_get_next_patch_component_version.call_args_list == [call(arn=c_arn)]
         assert (
-            "Error while getting the component versions of 'c_name' in 'test-region' from the account '1234' during"
-            " publish.\nlisting error"
+            "listing error"
             == e.value.args[0]
         )
 
@@ -70,13 +69,13 @@ class Greengrassv2ClientTest(TestCase):
     def test_create_gg_component_exception(self):
         greengrass_client = Greengrassv2Client(self.project_config, self.service_clients)
         mock_create_component = self.mocker.patch(
-            "boto3.client.create_component_version", return_value=None, side_effect=HTTPError("error")
+            "boto3.client.create_component_version", return_value=None, side_effect=HTTPError("gg error")
         )
         greengrass_client.project_config["publish_recipe_file"] = Path("some-recipe.yaml")
 
         with mock.patch("builtins.open", mock.mock_open(read_data="some-recipe-content")) as mock_file:
             with pytest.raises(Exception) as e:
                 greengrass_client.create_gg_component()
-            assert "Creating private version '1.0.0' of the component 'c_name' failed." in e.value.args[0]
+            assert "gg error" in e.value.args[0]
             assert mock_file.call_args_list == [call(Path("some-recipe.yaml"))]
             assert mock_create_component.call_args_list == [call(inlineRecipe="some-recipe-content")]

--- a/tests/gdk/aws_clients/test_S3Client.py
+++ b/tests/gdk/aws_clients/test_S3Client.py
@@ -51,7 +51,7 @@ class S3ClientTest(TestCase):
         self.mocker.patch("boto3.client.create_bucket", side_effect=HTTPError("some error"))
         with pytest.raises(Exception) as e:
             s3_client_utils.create_bucket(bucket, region)
-        assert type(e.value.args[0]) == HTTPError
+        assert "some error" in e.value.args[0]
         assert mock_valid_bucket_exists.call_args_list == [call("test-bucket", "region")]
 
     def test_create_bucket_valid_bucket_for_artifacts_exists(self):
@@ -127,7 +127,7 @@ class S3ClientTest(TestCase):
         with pytest.raises(Exception) as e:
             s3_client_utils.valid_bucket_for_artifacts_exists("bucket", "us-east-1")
         mock_get_bucket_location.assert_called_with(Bucket="bucket")
-        assert "Could not verify if the bucket 'bucket' exists in the region 'us-east-1'.\nError:some-error" in e.value.args[0]
+        assert "some-error" in e.value.args[0]
 
     def test_valid_bucket_for_artifacts_exists_owned_by_someone(self):
         bucket = "test-bucket"
@@ -146,11 +146,7 @@ class S3ClientTest(TestCase):
             s3_client_utils.valid_bucket_for_artifacts_exists(bucket, region)
 
         assert mock_get_bucket_location.call_args_list == [call(Bucket=bucket)]
-        assert (
-            "Bucket 'test-bucket' already exists and is not owned by you. Please provide a different name for the bucket in"
-            " the configuration"
-            in str(e.value.args[0])
-        )
+        assert "An error occurred (403) when calling the GetBucketLocation" in str(e.value.args[0])
 
     def test_valid_bucket_for_artifacts_exists_not_exists(self):
         bucket = "test-bucket"
@@ -186,11 +182,7 @@ class S3ClientTest(TestCase):
             s3_client_utils.valid_bucket_for_artifacts_exists(bucket, region)
 
         assert mock_get_bucket_location.call_args_list == [call(Bucket=bucket)]
-        assert (
-            "Could not verify if the bucket 'test-bucket' exists in the region 'region'.\nError:An error occurred (400) when"
-            " calling the GetBucketLocation operation: Bad Request"
-            in e.value.args[0]
-        )
+        assert "An error occurred (400) when calling the GetBucketLocation operation: Bad Request" in e.value.args[0]
 
     def test_upload_artifacts(self):
         project_config = {

--- a/tests/gdk/commands/component/test_BuildCommand.py
+++ b/tests/gdk/commands/component/test_BuildCommand.py
@@ -81,8 +81,7 @@ class BuildCommandTest(TestCase):
         with pytest.raises(Exception) as e:
             build.default_build_component()
 
-        assert "\ngenerating" in e.value.args[0]
-        assert error_messages.BUILD_FAILED in e.value.args[0]
+        assert "generating" in e.value.args[0]
         assert mock_run_build_command.assert_called_once
         assert mock_transform.assert_called_once
         assert mock_build_info.assert_called_once
@@ -125,7 +124,7 @@ class BuildCommandTest(TestCase):
             build.run_build_command()
         assert not mock_build_system_zip.called
         assert mock_subprocess_run.called
-        assert "Error building the component with the given build system." in e.value.args[0]
+        assert "some error" in e.value.args[0]
 
         assert mock_get_supported_component_builds.called
         assert mock_get_cmd_from_platform.called
@@ -145,7 +144,7 @@ class BuildCommandTest(TestCase):
         build.project_config["component_build_config"]["build_system"] = "zip"
         with pytest.raises(Exception) as e:
             build.run_build_command()
-        assert "Error building the component with the given build system." in e.value.args[0]
+        assert "some error" in e.value.args[0]
         assert mock_build_system_zip.called
         assert mock_get_cmd_from_platform.call_count == 1
         assert mock_get_supported_component_builds.call_count == 1
@@ -294,7 +293,7 @@ class BuildCommandTest(TestCase):
         with pytest.raises(Exception) as e:
             build._build_system_zip()
 
-        assert "Failed to zip the component in default build mode." in e.value.args[0]
+        assert "some error" in e.value.args[0]
         assert not mock_subprocess_run.called
         mock_build_info.assert_called_with()
         mock_clean_dir.assert_called_with(zip_build_path)
@@ -333,7 +332,7 @@ class BuildCommandTest(TestCase):
         with pytest.raises(Exception) as e:
             build._build_system_zip()
 
-        assert "Failed to zip the component in default build mode." in e.value.args[0]
+        assert "some error" in e.value.args[0]
         assert not mock_subprocess_run.called
         mock_build_info.assert_called_with()
         mock_clean_dir.assert_called_with(zip_build_path)
@@ -345,11 +344,10 @@ class BuildCommandTest(TestCase):
         assert mock_get_supported_component_builds.call_count == 1
 
     def test_build_system_zip_error_get_build_folder_by_build_system(self):
-        zip_build_path = Path("zip-build").resolve()
         mock_build_info = self.mocker.patch.object(
             BuildCommand,
             "_get_build_folder_by_build_system",
-            return_value=zip_build_path,
+            side_effect=Error("some-error"),
         )
         mock_clean_dir = self.mocker.patch("gdk.common.utils.clean_dir", return_value=None)
         mock_copytree = self.mocker.patch("shutil.copytree")
@@ -371,7 +369,7 @@ class BuildCommandTest(TestCase):
         with pytest.raises(Exception) as e:
             build._build_system_zip()
 
-        assert "Failed to zip the component in default build mode." in e.value.args[0]
+        assert "some-error" in e.value.args[0]
         assert not mock_subprocess_run.called
         mock_build_info.assert_called_with()
         assert not mock_clean_dir.called
@@ -404,7 +402,7 @@ class BuildCommandTest(TestCase):
         with pytest.raises(Exception) as e:
             build._build_system_zip()
 
-        assert "Failed to zip the component in default build mode." in e.value.args[0]
+        assert "some error" in e.value.args[0]
         assert not mock_subprocess_run.called
         mock_build_info.assert_called_with()
         assert mock_clean_dir.called

--- a/tests/gdk/commands/component/test_BuildCommand.py
+++ b/tests/gdk/commands/component/test_BuildCommand.py
@@ -8,7 +8,6 @@ import pytest
 import gdk.common.utils as utils
 from gdk.build_system.Zip import Zip
 from gdk.commands.component.BuildCommand import BuildCommand
-from gdk.common.exceptions import error_messages
 from gdk.commands.component.transformer.BuildRecipeTransformer import BuildRecipeTransformer
 
 

--- a/tests/gdk/commands/component/test_InitCommand.py
+++ b/tests/gdk/commands/component/test_InitCommand.py
@@ -174,7 +174,7 @@ class InitCommandTest(TestCase):
         init = InitCommand({})
         with pytest.raises(Exception) as e:
             init.init_with_template(template, language, project_dir)
-        assert "Could not initialize the project with component template" in e.value.args[0]
+        assert "Some error" in e.value.args[0]
         mock_download_and_clean.assert_any_call("template-language", "template", project_dir)
 
     def test_init_with_repository_valid(self):
@@ -196,7 +196,7 @@ class InitCommandTest(TestCase):
         init = InitCommand({})
         with pytest.raises(Exception) as e:
             init.init_with_repository(repository, project_dir)
-        assert "Could not initialize the project with component repository" in e.value.args[0]
+        assert "Some error" in e.value.args[0]
         mock_download_and_clean.assert_any_call(repository, "repository", project_dir)
 
     @patch("zipfile.ZipFile")
@@ -247,7 +247,7 @@ class InitCommandTest(TestCase):
             with pytest.raises(Exception) as e:
                 init.download_and_clean(formatted_template_name, template, project_dir)
 
-            assert "Failed to download the selected component" in e.value.args[0]
+            assert "some error" in e.value.args[0]
             assert mock_template_download.call_count == 1
             assert mock_get_available_templates.call_count == 1
             assert not mock_file.called
@@ -272,7 +272,7 @@ class InitCommandTest(TestCase):
             with pytest.raises(Exception) as e:
                 init.download_and_clean(formatted_template_name, template, project_dir)
 
-            assert "Failed to download the selected component" in e.value.args[0]
+            assert "some error" in e.value.args[0]
             assert mock_template_download.call_count == 1
             assert mock_get_available_templates.call_count == 1
             assert not mock_file.called

--- a/tests/gdk/commands/component/test_ListCommand.py
+++ b/tests/gdk/commands/component/test_ListCommand.py
@@ -52,7 +52,7 @@ class ListCommandTest(TestCase):
         list = ListCommand({})
         with pytest.raises(Exception) as e:
             list.get_component_list_from_github("url")
-        assert e.value.args[0] == error_messages.LISTING_COMPONENTS_FAILED
+        assert e.value.args[0] == "some error"
         assert mock_template_list.call_count == 1
 
     def test_run_template(self):

--- a/tests/gdk/commands/component/test_PublishCommand.py
+++ b/tests/gdk/commands/component/test_PublishCommand.py
@@ -6,7 +6,6 @@ from gdk.commands.component.transformer.PublishRecipeTransformer import PublishR
 import pytest
 from urllib3.exceptions import HTTPError
 
-import gdk.common.exceptions.error_messages as error_messages
 from gdk.aws_clients.Greengrassv2Client import Greengrassv2Client
 from gdk.aws_clients.S3Client import S3Client
 from gdk.commands.component.PublishCommand import PublishCommand

--- a/tests/gdk/commands/component/test_PublishCommand.py
+++ b/tests/gdk/commands/component/test_PublishCommand.py
@@ -115,7 +115,7 @@ class PublishCommandTest(TestCase):
         with pytest.raises(Exception) as e:
             publish.get_next_version()
         assert mock_get_next_patch_component_version.call_count == 1
-        assert e.value.args[0] == "Failed to calculate the next version of the component during publish.\nsome error"
+        assert e.value.args[0] == "some error"
 
     def test_upload_artifacts_with_no_artifacts(self):
         publish = PublishCommand({})
@@ -288,7 +288,7 @@ class PublishCommandTest(TestCase):
         assert mock_project_built.call_count == 1
         assert publish.project_config["account_number"] == "1234"
         assert publish.project_config["bucket"] == "default-us-east-1-1234"
-        assert e.value.args[0] == "{}\n{}".format(error_messages.PUBLISH_FAILED, "some error")
+        assert e.value.args[0] == "some error"
         assert mock_get_account_num.call_count == 1
         assert mock_get_component_version_from_config.call_count == 1
 
@@ -296,11 +296,11 @@ class PublishCommandTest(TestCase):
         mock_client = self.mocker.patch("boto3.client", return_value=None)
         publish = PublishCommand({})
         publish.service_clients = {"sts_client": mock_client}
-        mock_get_caller_identity = self.mocker.patch("boto3.client.get_caller_identity", return_value=None)
+        mock_get_caller_identity = self.mocker.patch("boto3.client.get_caller_identity", side_effect=HTTPError("some error"))
         with pytest.raises(Exception) as e:
             publish.get_account_number()
         assert mock_get_caller_identity.call_count == 1
-        assert "Error while fetching account number from credentials." in e.value.args[0]
+        assert "some error" in e.value.args[0]
 
     def test_get_account_number(self):
         mock_client = self.mocker.patch("boto3.client", return_value=None)

--- a/tests/gdk/commands/component/test_component.py
+++ b/tests/gdk/commands/component/test_component.py
@@ -45,7 +45,7 @@ def test_component_build_exception(mocker):
     d_args = {"build": None}
     with pytest.raises(Exception) as e:
         component.build(d_args)
-    assert "Could not build the project due to the following error." in e.value.args[0]
+    assert "Error in build" in e.value.args[0]
     assert mock_component_build.call_count == 1
     assert mock_component_build_run.call_count == 0
     mock_component_build.assert_called_with(d_args)
@@ -67,7 +67,7 @@ def test_component_publish_exception(mocker):
     d_args = {"publish": None}
     with pytest.raises(Exception) as e:
         component.publish(d_args)
-    assert "Could not publish the component due to the following error." in e.value.args[0]
+    assert "Error in publish" in e.value.args[0]
     assert mock_component_publish.call_count == 1
     assert mock_component_publish_run.call_count == 0
     mock_component_publish.assert_called_with(d_args)
@@ -89,10 +89,7 @@ def test_component_list_exception(mocker):
     d_args = {"list": None}
     with pytest.raises(Exception) as e:
         component.list(d_args)
-    assert (
-        "Could not list the available components from Greengrass Software Catalog due to the following error"
-        in e.value.args[0]
-    )
+    assert "Error in list" in e.value.args[0]
     assert mock_component_list.call_count == 1
     assert mock_component_list_run.call_count == 0
     mock_component_list.assert_called_with(d_args)

--- a/uat/component_build.feature
+++ b/uat/component_build.feature
@@ -28,7 +28,7 @@ Feature: gdk component build works
     And we verify component zip build files
     And command output contains "Could not find"
     And command output contains "HelloWorld.zip"
-    And command output contains "Failed to build the component with the given project configuration."
+    And command output contains "Could not find artifact with URI 's3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/HelloWorld.zip' on s3 or inside the build folders."
 
   @version(min='1.1.0')
   @change_cwd

--- a/uat/t_setup.py
+++ b/uat/t_setup.py
@@ -27,7 +27,7 @@ class GdkProcess:
 
         try:
             if capture_output:
-                output = sp.run(["gdk"] + arguments, check=True, stdout=sp.PIPE)
+                output = sp.run(["gdk"] + arguments, check=True, stdout=sp.PIPE, stderr=sp.STDOUT)
                 return ProcessOutput(output.returncode, output.stdout.decode())
             else:
                 output = sp.run(["gdk"] + arguments)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Print full exception trace when the command fails. 

- Log messages as errors and propagate the exception all the way up. 
- Update tests to reflect the same. 
- Add debug level logs wherever applicable. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.