### PR TITLE
fix: bucket creation and parsing lists in recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Configure AWS CLI with your credentials as shown here - https://docs.aws.amazon.
         "gdk_version": "1.0.0"
     }
    ```
-   2. Replace `<PLACEHOLDER_AUTHOR>` with your name, `<PLACEHOLDER_BUCKET>` with a s3 bucket name and `<PLACEHOLDER_REGION>` with an aws region.
+   2. Replace `<PLACEHOLDER_AUTHOR>` with your name, `<PLACEHOLDER_BUCKET>` with a prefix for an Amazon S3 bucket name and `<PLACEHOLDER_REGION>` with an AWS region. The specified bucket will be created in the specified region if it doesn't exist (name format: `{PLACEHOLDER_BUCKET}-{PLACEHOLDER_REGION}-{account_number}`).
    3. After replace these value the `gdk-config.json` file should look similar to:
    ```json
     {

--- a/gdk/aws_clients/S3Client.py
+++ b/gdk/aws_clients/S3Client.py
@@ -84,10 +84,10 @@ class S3Client:
             )
         except ClientError as exc:
             error_code = exc.response["Error"]["Code"]
-            if error_code != "403" and error_code != "404":
+            if error_code != "AccessDenied" and error_code != "NoSuchBucket":
                 logging.error("Could not verify if the bucket '%s' exists in the region '%s'.", bucket, region)
                 raise
-            elif error_code == "403":
+            elif error_code == "AccessDenied":
                 logging.error(
                     "Bucket '%s' already exists and is not owned by you. Please provide a different name for the"
                     " bucket in the configuration.",

--- a/gdk/common/CaseInsensitive.py
+++ b/gdk/common/CaseInsensitive.py
@@ -1,7 +1,7 @@
 import json
-import yaml
 from pathlib import Path
 
+import yaml
 from requests.structures import CaseInsensitiveDict as _CaseInsensitiveDict
 
 
@@ -27,7 +27,7 @@ class CaseInsensitiveDict(_CaseInsensitiveDict):
             if isinstance(value, dict):
                 case_insensitive_dict.update({key: CaseInsensitiveDict(value)})
             elif isinstance(value, list):
-                case_insensitive_dict.update({key: [CaseInsensitiveDict(val) for val in value if isinstance(val, dict)]})
+                case_insensitive_dict.update({key: [CaseInsensitiveDict(val) if isinstance(val, dict) else val for val in value ]})
 
     def _convert_nested_case_insensitive_dict(self, dictObj: dict) -> dict:
         for key, value in dictObj.items():
@@ -38,8 +38,9 @@ class CaseInsensitiveDict(_CaseInsensitiveDict):
                     {
                         key: [
                             self._convert_nested_case_insensitive_dict(dict(val))
-                            for val in value
                             if isinstance(val, CaseInsensitiveDict)
+                            else val
+                            for val in value
                         ]
                     }
                 )

--- a/gdk/common/CaseInsensitive.py
+++ b/gdk/common/CaseInsensitive.py
@@ -27,7 +27,9 @@ class CaseInsensitiveDict(_CaseInsensitiveDict):
             if isinstance(value, dict):
                 case_insensitive_dict.update({key: CaseInsensitiveDict(value)})
             elif isinstance(value, list):
-                case_insensitive_dict.update({key: [CaseInsensitiveDict(val) if isinstance(val, dict) else val for val in value ]})
+                case_insensitive_dict.update(
+                    {key: [CaseInsensitiveDict(val) if isinstance(val, dict) else val for val in value]}
+                )
 
     def _convert_nested_case_insensitive_dict(self, dictObj: dict) -> dict:
         for key, value in dictObj.items():

--- a/tests/gdk/aws_clients/test_S3Client.py
+++ b/tests/gdk/aws_clients/test_S3Client.py
@@ -135,7 +135,7 @@ class S3ClientTest(TestCase):
 
         def throw_err(*args, **kwargs):
             ex = boto3.client("s3").exceptions.ClientError(
-                {"Error": {"Code": "403", "Message": "Forbidden"}}, "GetBucketLocation"
+                {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}, "GetBucketLocation"
             )
             raise ex
 
@@ -146,7 +146,7 @@ class S3ClientTest(TestCase):
             s3_client_utils.valid_bucket_for_artifacts_exists(bucket, region)
 
         assert mock_get_bucket_location.call_args_list == [call(Bucket=bucket)]
-        assert "An error occurred (403) when calling the GetBucketLocation" in str(e.value.args[0])
+        assert "An error occurred (AccessDenied) when calling the GetBucketLocation" in str(e.value.args[0])
 
     def test_valid_bucket_for_artifacts_exists_not_exists(self):
         bucket = "test-bucket"
@@ -154,7 +154,7 @@ class S3ClientTest(TestCase):
 
         def throw_err(*args, **kwargs):
             ex = boto3.client("s3").exceptions.ClientError(
-                {"Error": {"Code": "404", "Message": "Not Found"}}, "GetBucketLocation"
+                {"Error": {"Code": "NoSuchBucket", "Message": "Not Found"}}, "GetBucketLocation"
             )
             raise ex
 

--- a/tests/gdk/common/test_CaseInsensitive.py
+++ b/tests/gdk/common/test_CaseInsensitive.py
@@ -1,11 +1,13 @@
+import json
+import tempfile
 from pathlib import Path
 from unittest import TestCase
-import tempfile
+
 import pytest
 import yaml
-from gdk.common.CaseInsensitive import CaseInsensitiveRecipeFile
-import json
-from gdk.common.CaseInsensitive import CaseInsensitiveDict
+
+from gdk.common.CaseInsensitive import (CaseInsensitiveDict,
+                                        CaseInsensitiveRecipeFile)
 
 
 class CaseInsensitiveRecipeFileTest(TestCase):
@@ -79,11 +81,13 @@ class CaseInsensitiveDictTest(TestCase):
             "key1": "value1",
             "key2": [{"key21": "value21"}, {"key22": "value22"}],
             "key3": {"key31": {"key311": "key312"}},
+            "key4": ["entry1", "entry2"]
         }
         cis = CaseInsensitiveDict(dictionary)
         assert "KEY1" in cis
         assert cis["KEY2"][0]["KEy21"] == "value21"
         assert cis["KEy3"]["key31"]["KeY311"] == "key312"
+        assert len(cis["key4"]) == 2
         assert cis.to_dict() == dictionary
 
     def test_when_update_value_then_key_not_changed(self):

--- a/tests/gdk/static/project_utils/valid_component_recipe.json
+++ b/tests/gdk/static/project_utils/valid_component_recipe.json
@@ -6,7 +6,35 @@
   "ComponentPublisher": "Amazon",
   "ComponentConfiguration": {
     "DefaultConfiguration": {
-      "Message": "world"
+      "Message": "world",
+      "SampleList": [
+        "1",
+        "2",
+        "3"
+      ],
+      "SampleNestedList": [
+        [
+          "1"
+        ],
+        [
+          "2"
+        ],
+        [
+          "3"
+        ]
+      ],
+      "SampleMap": {
+        "key1": "value1",
+        "key2": {
+          "key3": [
+            "value2",
+            "value3"
+          ],
+          "key4": {
+            "key41": "value4"
+          }
+        }
+      }
     }
   },
   "Manifests": [

--- a/tests/gdk/static/project_utils/valid_component_recipe.yaml
+++ b/tests/gdk/static/project_utils/valid_component_recipe.yaml
@@ -7,6 +7,22 @@ ComponentPublisher: Amazon
 ComponentConfiguration:
   DefaultConfiguration:
     Message: world
+    SampleList:
+    - '1'
+    - '2'
+    - '3'
+    SampleNestedList:
+    - - '1'
+    - - '2'
+    - - '3'
+    SampleMap:
+      key1: value1
+      key2:
+        key3:
+        - value2
+        - value3
+        key4:
+          key41: value4
 Manifests:
   - Platform:
       os: linux


### PR DESCRIPTION
**Issue #, if available:** None

**Description of changes:** Fix doc and implementation for non-existing buckets. Fix list expansion.

**Why is this change necessary:** New projects without bucket don't work

**How was this change tested:** Manual test with non-existing and non-accessible bucket, unit tests changed

**Any additional information or context required to review the change:**
Issue 1 reproduction:
- Run `component build` and `component publish` on a new project without an existing bucket

Issue 2 reproduction:
- Create a component recipe like this: https://github.com/awslabs/aws-greengrass-labs-bluetooth-gateway/blob/main/src/recipe.json
- Run `component build`
- Check `greengrass-build/recipe.json` and see that `operations` and `resources` are now empty lists
--> this will cause the component deployment to fail

**Checklist:**
- [x] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.