### PR TITLE
feat: setup fake server to test telemetry requests are sent upon running commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,8 @@ lint:
 tests_unit:
 	coverage run --source=gdk -m pytest -v -s tests && coverage xml --fail-under=99
 
+tests_integration:
+	coverage run --source=gdk -m pytest -v -s integration_tests && coverage xml --fail-under=90
+
 tests_uat:
 	coverage run --source=gdk -m behave -v uat/ -D instrumented=true && coverage xml --fail-under=77

--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ The AWS IoT Greengrass Development Kit Command-Line Interface (GDK CLI) provides
 
 Please follow the [GDK CLI public documentation](https://docs.aws.amazon.com/greengrass/v2/developerguide/greengrass-development-kit-cli.html) to learn more about the available commands and configuration that GDK CLI has to offer.
 
-### Getting Started
+<br />
+
+---
+
+<br />
+
+## Getting Started
 
 #### Prerequisites
  1. [Python3](https://www.python.org/downloads/) and [pip](https://pip.pypa.io/en/latest/installation/): As the GDK CLI tool is written in python, you need to have python3 and pip installed. The most recent version of python includes pip.
@@ -88,3 +94,18 @@ Configure AWS CLI with your credentials as shown here - https://docs.aws.amazon.
 5. Creates new version of the component in your AWS account.
 
 `gdk component publish`
+
+
+<br />
+
+---
+
+
+<br />
+
+## Running Tests
+
+<br />
+
+* Unit tests: `make tests_unit`
+* Integration tests: `make tests_integration`

--- a/integration_tests/gdk/telemetry/integration_base.py
+++ b/integration_tests/gdk/telemetry/integration_base.py
@@ -1,0 +1,72 @@
+from threading import Thread
+import time
+from flask import Flask, Response, request
+from werkzeug.serving import make_server
+
+
+TELEMETRY_ENDPOINT_PORT = "18298"
+TELEMETRY_ENDPOINT_HOST = "localhost"
+TELEMETRY_ENDPOINT_URL = "http://{}:{}".format(TELEMETRY_ENDPOINT_HOST, TELEMETRY_ENDPOINT_PORT)
+
+
+class TelemetryServer:
+    """
+    HTTP Server used for integration tests to simulate the the GDK Telemetry service
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        self.flask_app = Flask(__name__)
+
+        self.flask_app.add_url_rule(
+            "/metrics",
+            endpoint="/metrics",
+            view_func=self._request_handler,
+            methods=["POST"],
+            provide_automatic_options=False,
+        )
+
+        self._requests = []
+
+    def __enter__(self):
+        self.server = make_server(TELEMETRY_ENDPOINT_HOST, TELEMETRY_ENDPOINT_PORT, self.flask_app)
+        self.thread = Thread(target=self.server.serve_forever)
+        self.thread.daemon = True  # When test completes, this thread will die automatically
+        self.thread.start()  # Start the thread
+
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        # Flask will start shutting down only *after* the above request completes.
+        # Just give the server a little bit of time to teardown finish
+        time.sleep(2)
+
+        self.server.shutdown()
+        self.thread.join()
+
+    def get_metrics_endpoint(self):
+        return f"{TELEMETRY_ENDPOINT_URL}/metrics"
+
+    def get_request(self, index):
+        return self._requests[index]
+
+    def get_all_requests(self):
+        return list(self._requests)
+
+    def _request_handler(self, **kwargs):
+        """
+        Handles Flask requests
+        """
+
+        # `request` is a variable populated by Flask automatically when handler method is called
+        request_data = {
+            "endpoint": request.endpoint,
+            "method": request.method,
+            "data": request.get_json(),
+            "headers": dict(request.headers),
+        }
+
+        self._requests.append(request_data)
+
+        return Response(response={}, status=200)

--- a/integration_tests/gdk/telemetry/test_server_setup.py
+++ b/integration_tests/gdk/telemetry/test_server_setup.py
@@ -1,0 +1,24 @@
+
+import requests
+from unittest import TestCase
+
+
+from integration_tests.gdk.telemetry.integration_base import TelemetryServer
+
+
+class TestTelemetryServerSetup(TestCase):
+    """
+    Test case to ensure the test telemetry server is setup correctly
+    """
+
+    def test_sending_a_request(self):
+        with TelemetryServer() as server:
+            self.assertEqual(0, len(server.get_all_requests()))
+
+            fake_metric = {"name": "publish"}
+            requests.post(server.get_metrics_endpoint(), json=fake_metric)
+
+            all_requests = server.get_all_requests()
+            self.assertEqual(1, len(all_requests))
+            data = all_requests[0]['data']
+            self.assertEqual(fake_metric, data)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,3 +14,4 @@ pytest-mock
 behave
 behave-html-formatter
 Faker
+Flask


### PR DESCRIPTION
**Description of changes:**
As part of collecting telemetry data we want to ensure the correct data and payloads are submitted to the service. 

* Create test telemetry server to ensure data is sent upon running a gdk command.

**Why is this change necessary:**

Ensure we test telemetry from the user's standpoint

**How was this change tested:**

Run integration tests `make tests_integration`
