### PR TITLE
feat: emit basic install metric

### DIFF
--- a/gdk/CLIParser.py
+++ b/gdk/CLIParser.py
@@ -5,6 +5,7 @@ import gdk.common.consts as consts
 import gdk.common.model_actions as model_actions
 import gdk.common.parse_args_actions as parse_args_actions
 import gdk.common.utils as utils
+from gdk.telemetry.emit import Emit
 
 
 class ArgumentParser(argparse.ArgumentParser):
@@ -180,6 +181,8 @@ class CLIParser:
 
 def main():
     try:
+        Emit().installed_metric()
+
         # Check the version of the cli before command parsing.
         utils.cli_version_check()
         args_namespace = cli_parser.parse_args()

--- a/gdk/telemetry/emit.py
+++ b/gdk/telemetry/emit.py
@@ -1,0 +1,16 @@
+from gdk.telemetry.metric import Metric
+from gdk.telemetry.telemetry import ITelemetry, Telemetry
+
+
+class Emit:
+    """
+    Wrapper around metrics and telemetry that allows us to specify an
+    emiter to submit a Metric
+    """
+
+    def __init__(self, emiter: ITelemetry = None):
+        self._emiter = emiter or Telemetry()
+
+    def installed_metric(self):
+        metric = Metric.Factory.installed_metric()
+        self._emiter.emit(metric)

--- a/gdk/telemetry/metric.py
+++ b/gdk/telemetry/metric.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 import time
 from enum import Enum
 
@@ -7,7 +8,7 @@ from gdk._version import __version__
 logger = logging.getLogger(__name__)
 
 
-MetricType = Enum('MetricTypes', ["INSTALLED", "BUILD", "PUBLISH", "TEMPLATE", "PING"])
+MetricType = Enum('MetricTypes', ["INSTALLED", "COMPONENT_BUILD", "COMPONENT_PUBLISH", "TEMPLATE", "PING"])
 
 
 class Metric:
@@ -19,6 +20,19 @@ class Metric:
 
     def add_dimension(self, key: str, value: str):
         self.dimensions[key] = value
+
+    class Factory:
+
+        @staticmethod
+        def installed_metric(epoch=int(time.time())):
+            metric = Metric(MetricType.INSTALLED, epoch)
+            metric.add_dimension("osPlatform", platform.system())
+            metric.add_dimension("osRelease", platform.release())
+            metric.add_dimension("machine", platform.machine())
+            metric.add_dimension("arch", platform.architecture()[0])
+            metric.add_dimension("pythonVersion", platform.python_version())
+
+            return metric
 
 
 class MetricEncoder:

--- a/gdk/telemetry/telemetry.py
+++ b/gdk/telemetry/telemetry.py
@@ -1,14 +1,22 @@
 import logging
+from abc import ABC, abstractmethod
 
 import requests
 
-from gdk.telemetry import get_telemetry_url, get_telemetry_enabled
+from gdk.telemetry import get_telemetry_enabled, get_telemetry_url
 from gdk.telemetry.metric import Metric, MetricEncoder
 
 logger = logging.getLogger(__name__)
 
 
-class Telemetry:
+class ITelemetry(ABC):
+
+    @abstractmethod
+    def emit(self, metric: Metric):
+        pass
+
+
+class Telemetry(ITelemetry):
     """
     Wrapper around requests to sends telemetry data to the telemetry service.
     """

--- a/integration_tests/gdk/telemetry/telemetry_base.py
+++ b/integration_tests/gdk/telemetry/telemetry_base.py
@@ -1,16 +1,20 @@
 import os
+import subprocess
+import sys
 import time
 from threading import Thread
 from unittest import TestCase
 
 from flask import Flask, Response, request
+from mock import patch
 from werkzeug.serving import make_server
+from gdk import CLIParser
 
 from gdk.telemetry import GDK_CLI_TELEMETRY_ENDPOINT_URL, GDK_CLI_TELEMETRY
 
 TELEMETRY_ENDPOINT_PORT = "18298"
 TELEMETRY_ENDPOINT_HOST = "localhost"
-TELEMETRY_ENDPOINT_URL = "http://{}:{}".format(TELEMETRY_ENDPOINT_HOST, TELEMETRY_ENDPOINT_PORT)
+TELEMETRY_ENDPOINT_URL = "http://{}:{}/metrics".format(TELEMETRY_ENDPOINT_HOST, TELEMETRY_ENDPOINT_PORT)
 
 
 class TelemetryTestCase(TestCase):
@@ -20,11 +24,21 @@ class TelemetryTestCase(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        os.environ[GDK_CLI_TELEMETRY_ENDPOINT_URL] = f"{TELEMETRY_ENDPOINT_URL}/metrics"
+        os.environ[GDK_CLI_TELEMETRY_ENDPOINT_URL] = TELEMETRY_ENDPOINT_URL
 
     def tearDown(self) -> None:
         self.disable_telemetry()
         return super().tearDown()
+
+    def run_command(self, command_list=[]):
+        if len(command_list) == 0:
+            raise Exception("No command was specified")
+
+        argv = ["gdk"]
+        argv.extend(command_list)
+
+        with patch.object(sys, 'argv', argv):
+            CLIParser.main()
 
     def disable_telemetry(self):
         os.environ[GDK_CLI_TELEMETRY] = "0"

--- a/integration_tests/gdk/telemetry/telemetry_base.py
+++ b/integration_tests/gdk/telemetry/telemetry_base.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import sys
 import time
 from threading import Thread

--- a/integration_tests/gdk/telemetry/test_emit_telemetry.py
+++ b/integration_tests/gdk/telemetry/test_emit_telemetry.py
@@ -1,21 +1,22 @@
-
-
 import pytest
-from gdk import CLIParser
-from gdk.common.parse_args_actions import run_command
-
-from .telemetry_base import TelemetryTestCase, TelemetryServer
+from .telemetry_base import TelemetryServer, TelemetryTestCase
 
 
 class TestEmitTelemetry(TelemetryTestCase):
 
-    def setUp(self) -> None:
+    def test_emit_installed_metric_on_first_run(self):
         self.enable_telemetry()
 
-    @pytest.mark.skip(reason="metric not yet being emited")
-    def test_emit_installed_metric_on_first_run(self):
         with TelemetryServer() as server:
-            run_command(CLIParser.cli_parser.parse_args(["component", "list", "--template"]))
+            self.run_command(["component", "list", "--template"])
 
             all_requests = server.get_all_requests()
             self.assertEqual(1, len(all_requests))
+
+    @pytest.mark.skip("Not yet implemented")
+    def test_emit_failure_doesnot_spot_command_run(self):
+        pass
+
+    @pytest.mark.skip("Not yet implemented")
+    def test_only_emits_install_metric_one_time(self):
+        pass

--- a/tests/gdk/telemetry/test_emit.py
+++ b/tests/gdk/telemetry/test_emit.py
@@ -1,0 +1,21 @@
+
+from unittest import TestCase
+
+from gdk.telemetry.emit import Emit
+from gdk.telemetry.metric import MetricType
+from tests.helpers.telemetry_fake import TelemetryFake
+
+
+class TestEmit(TestCase):
+
+    def setUp(self) -> None:
+        self.telemetry = TelemetryFake()
+
+    def test_emitting_installed_metric(self):
+        Emit(self.telemetry).installed_metric()
+
+        emitted = self.telemetry.get_emitted_metrics()
+        self.assertEqual(1, len(emitted))
+
+        metric = emitted[0]
+        self.assertEqual(MetricType.INSTALLED, metric.type)

--- a/tests/gdk/telemetry/test_metric.py
+++ b/tests/gdk/telemetry/test_metric.py
@@ -3,6 +3,8 @@
 import time
 from unittest import TestCase
 
+from mock import ANY
+
 from gdk._version import __version__
 from gdk.telemetry.metric import Metric, MetricEncoder, MetricType
 
@@ -32,4 +34,24 @@ class TestMetric(TestCase):
             "timestamp": epoch,
             "dimensions": {"hello": "world"}
         }
+        self.assertEqual(expected, encoded)
+
+    def test_build_install_metric(self):
+        epoch = int(time.time())
+        metric = Metric.Factory.installed_metric(epoch)
+        encoded = MetricEncoder().encode(metric)
+
+        expected = {
+            "name": "INSTALLED",
+            "meta": {"gdk_version": __version__},
+            "timestamp": epoch,
+            "dimensions": {
+                "osPlatform": ANY,
+                "osRelease": ANY,
+                "machine": ANY,
+                "arch": ANY,
+                "pythonVersion": ANY
+            }
+        }
+
         self.assertEqual(expected, encoded)

--- a/tests/helpers/telemetry_fake.py
+++ b/tests/helpers/telemetry_fake.py
@@ -1,0 +1,15 @@
+
+from gdk.telemetry.metric import Metric
+from gdk.telemetry.telemetry import ITelemetry
+
+
+class TelemetryFake(ITelemetry):
+
+    def __init__(self) -> None:
+        self.emitted = []
+
+    def emit(self, metric: Metric):
+        self.emitted.append(metric)
+
+    def get_emitted_metrics(self):
+        return self.emitted


### PR DESCRIPTION
## Description
Emits install metric by default telemetry is disabled. There will be follow up requests  to ensure we don't emit metric on the same thread and that if emitting fails it doesn't stop the command from running.

## How was this tested?
unit + integ tests