### PR TITLE
Emit install metric only once.

### DIFF
--- a/gdk/runtime_config.py
+++ b/gdk/runtime_config.py
@@ -1,0 +1,91 @@
+import json
+import logging
+import os
+from enum import Enum
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigKey(Enum):
+    INSTALLED = 'installed'
+
+
+class Singleton(type):
+    """
+    Metaclass makes a class a singleton.
+    """
+
+    def __init__(cls, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        cls.__instance = None
+
+    def __call__(cls, *args, **kwargs):
+        """
+        Called every time a new instance of a class is being implemented.
+        """
+        force_create = kwargs.get('force_create', False)
+
+        if not cls.__instance or force_create is True:
+            cls.__instance = super().__call__(*args, **kwargs)
+
+        return cls.__instance
+
+
+class RuntimeConfig(metaclass=Singleton):
+    """
+    Wrapper around a dict that persists values used by the application by flushing them to
+    disk.
+    """
+    DEFAULT_CONFIG_FILE_NAME = 'runtime.json'
+
+    def __init__(self, *args, **kwargs):
+        self._config = dict()
+        self._load_config()
+
+    def set(self, key: ConfigKey, value: str):
+        self._config[key] = value
+        self._flush()
+
+    def get(self, key: ConfigKey):
+        return self._config.get(key, None)
+
+    def has(self, key: ConfigKey) -> bool:
+        return key in self._config
+
+    @property
+    def config_dir(self) -> Path:
+        return Path(os.path.expanduser('~/.gdk'))
+
+    @property
+    def config_path(self) -> Path:
+        return Path(self.config_dir, self.DEFAULT_CONFIG_FILE_NAME)
+
+    def _load_config(self):
+        """
+        Load the configuration from disk
+        """
+        if not self.config_path.exists():
+            return
+
+        config_keys = [k.value for k in ConfigKey]
+
+        try:
+            content = self.config_path.read_text()
+            json_content = json.loads(content)
+            self._config = {ConfigKey(k): v for (k, v) in json_content.items() if k in config_keys}
+        except (OSError, ValueError) as ex:
+            logger.debug("Failed to load config to file %s", self.config_path, exc_info=ex)
+
+    def _flush(self):
+        """
+        Flush the config to disk.
+        """
+        try:
+            conf = {k.value: v for (k, v) in self._config.items()}
+            config_str = json.dumps(conf)
+            if not self.config_dir.exists():
+                os.makedirs(self.config_dir, mode=0o700, exist_ok=True)
+            self.config_path.write_text(config_str)
+        except (OSError, ValueError) as ex:
+            logger.debug("Failed to flush config to file %s", self.config_path, exc_info=ex)

--- a/gdk/runtime_config.py
+++ b/gdk/runtime_config.py
@@ -44,6 +44,7 @@ class RuntimeConfig(metaclass=Singleton):
 
     def __init__(self, *args, **kwargs):
         self._config = dict()
+        self._config_path = None
         self._load_config()
 
     def set(self, key: ConfigKey, value: str):
@@ -62,7 +63,14 @@ class RuntimeConfig(metaclass=Singleton):
 
     @property
     def config_path(self) -> Path:
-        return Path(self.config_dir, self.DEFAULT_CONFIG_FILE_NAME)
+        if not self._config_path:
+            self._config_path = Path(self.config_dir, self.DEFAULT_CONFIG_FILE_NAME)
+
+        return self._config_path
+
+    @config_path.setter
+    def config_path(self, config_path: Path) -> None:
+        self._config_path = config_path
 
     def _load_config(self):
         """

--- a/gdk/runtime_config.py
+++ b/gdk/runtime_config.py
@@ -32,6 +32,9 @@ class Singleton(type):
         return cls.__instance
 
 
+GDK_RUNTIME_CONFIG_DIR = "__GDK_RUNTIME_CONFIG_PATH"
+
+
 class RuntimeConfig(metaclass=Singleton):
     """
     Wrapper around a dict that persists values used by the application by flushing them to
@@ -50,11 +53,11 @@ class RuntimeConfig(metaclass=Singleton):
     def get(self, key: ConfigKey):
         return self._config.get(key, None)
 
-    def has(self, key: ConfigKey) -> bool:
-        return key in self._config
-
     @property
     def config_dir(self) -> Path:
+        if os.getenv(GDK_RUNTIME_CONFIG_DIR):
+            return Path(os.getenv(GDK_RUNTIME_CONFIG_DIR))
+
         return Path(os.path.expanduser('~/.gdk'))
 
     @property

--- a/gdk/telemetry/emit.py
+++ b/gdk/telemetry/emit.py
@@ -1,3 +1,5 @@
+from gdk._version import __version__
+from gdk.runtime_config import ConfigKey, RuntimeConfig
 from gdk.telemetry.metric import Metric
 from gdk.telemetry.telemetry import ITelemetry, Telemetry
 
@@ -9,8 +11,16 @@ class Emit:
     """
 
     def __init__(self, emiter: ITelemetry = None):
+        self.runtime_config = RuntimeConfig()
         self._emiter = emiter or Telemetry()
 
     def installed_metric(self):
+        """
+        Sends an installed metric only once after the cli has been installed
+        """
+        if self.runtime_config.has(ConfigKey.INSTALLED):
+            return
+
         metric = Metric.Factory.installed_metric()
         self._emiter.emit(metric)
+        self.runtime_config.set(ConfigKey.INSTALLED, __version__)

--- a/gdk/telemetry/emit.py
+++ b/gdk/telemetry/emit.py
@@ -18,7 +18,9 @@ class Emit:
         """
         Sends an installed metric only once after the cli has been installed
         """
-        if self.runtime_config.has(ConfigKey.INSTALLED):
+        installed_version = self.runtime_config.get(ConfigKey.INSTALLED)
+
+        if installed_version == __version__:
             return
 
         metric = Metric.Factory.installed_metric()

--- a/gdk/telemetry/telemetry.py
+++ b/gdk/telemetry/telemetry.py
@@ -13,6 +13,9 @@ class ITelemetry(ABC):
 
     @abstractmethod
     def emit(self, metric: Metric):
+        """
+        Abstract method for a telemetry class to send telemetry metrics to a destination.
+        """
         pass
 
 

--- a/integration_tests/gdk/telemetry/telemetry_base.py
+++ b/integration_tests/gdk/telemetry/telemetry_base.py
@@ -1,6 +1,6 @@
 import os
-
 import sys
+import tempfile
 import time
 from threading import Thread
 from unittest import TestCase
@@ -8,10 +8,10 @@ from unittest import TestCase
 from flask import Flask, Response, request
 from mock import patch
 from werkzeug.serving import make_server
-from gdk import CLIParser
-from gdk.runtime_config import RuntimeConfig
 
-from gdk.telemetry import GDK_CLI_TELEMETRY_ENDPOINT_URL, GDK_CLI_TELEMETRY
+from gdk import CLIParser
+from gdk.runtime_config import GDK_RUNTIME_CONFIG_DIR, RuntimeConfig
+from gdk.telemetry import GDK_CLI_TELEMETRY, GDK_CLI_TELEMETRY_ENDPOINT_URL
 
 TELEMETRY_ENDPOINT_PORT = "18298"
 TELEMETRY_ENDPOINT_HOST = "localhost"
@@ -23,19 +23,14 @@ class TelemetryTestCase(TestCase):
     Base case for all telemetry related tests
     """
 
-    @classmethod
-    def setUpClass(cls):
-        config = RuntimeConfig(force_create=True)
-
-        # Delete the persisted config file if exists after each test
-        if os.path.exists(config.config_path):
-            os.remove(config.config_path)
-
-        os.environ[GDK_CLI_TELEMETRY_ENDPOINT_URL] = TELEMETRY_ENDPOINT_URL
+    def setUp(self) -> None:
+        self.setup_telemetry_url()
+        self.setup_runtime_config_path()
+        self.teardown_runtime_config()
 
     def tearDown(self) -> None:
+        self.teardown_runtime_config()
         self.disable_telemetry()
-        return super().tearDown()
 
     def run_command(self, command_list=[]):
         if len(command_list) == 0:
@@ -46,6 +41,19 @@ class TelemetryTestCase(TestCase):
 
         with patch.object(sys, 'argv', argv):
             CLIParser.main()
+
+    def setup_telemetry_url(self) -> None:
+        os.environ[GDK_CLI_TELEMETRY_ENDPOINT_URL] = TELEMETRY_ENDPOINT_URL
+
+    def setup_runtime_config_path(self) -> None:
+        temp_dir = tempfile.mktemp()
+        os.environ[GDK_RUNTIME_CONFIG_DIR] = temp_dir
+
+    def teardown_runtime_config(self) -> None:
+        config = RuntimeConfig(force_create=True)
+        # Delete the persisted config file if exists after each test
+        if config.config_path.exists():
+            os.remove(config.config_path)
 
     def disable_telemetry(self):
         os.environ[GDK_CLI_TELEMETRY] = "0"

--- a/integration_tests/gdk/telemetry/telemetry_base.py
+++ b/integration_tests/gdk/telemetry/telemetry_base.py
@@ -1,4 +1,5 @@
 import os
+
 import sys
 import time
 from threading import Thread
@@ -8,6 +9,7 @@ from flask import Flask, Response, request
 from mock import patch
 from werkzeug.serving import make_server
 from gdk import CLIParser
+from gdk.runtime_config import RuntimeConfig
 
 from gdk.telemetry import GDK_CLI_TELEMETRY_ENDPOINT_URL, GDK_CLI_TELEMETRY
 
@@ -23,6 +25,12 @@ class TelemetryTestCase(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        config = RuntimeConfig(force_create=True)
+
+        # Delete the persisted config file if exists after each test
+        if os.path.exists(config.config_path):
+            os.remove(config.config_path)
+
         os.environ[GDK_CLI_TELEMETRY_ENDPOINT_URL] = TELEMETRY_ENDPOINT_URL
 
     def tearDown(self) -> None:

--- a/integration_tests/gdk/telemetry/test_emit_telemetry.py
+++ b/integration_tests/gdk/telemetry/test_emit_telemetry.py
@@ -1,10 +1,11 @@
 import pytest
+
 from .telemetry_base import TelemetryServer, TelemetryTestCase
 
 
 class TestEmitTelemetry(TelemetryTestCase):
 
-    def test_emit_installed_metric_on_first_run(self):
+    def test_emit_installed_metric_on_first_run_only(self):
         self.enable_telemetry()
 
         with TelemetryServer() as server:
@@ -13,10 +14,11 @@ class TestEmitTelemetry(TelemetryTestCase):
             all_requests = server.get_all_requests()
             self.assertEqual(1, len(all_requests))
 
-    @pytest.mark.skip("Not yet implemented")
-    def test_emit_failure_doesnot_spot_command_run(self):
-        pass
+            self.run_command(["component", "list", "--template"])
+
+            all_requests = server.get_all_requests()
+            self.assertEqual(1, len(all_requests))
 
     @pytest.mark.skip("Not yet implemented")
-    def test_only_emits_install_metric_one_time(self):
+    def test_emit_failure_doesnot_spot_command_run(self):
         pass

--- a/integration_tests/gdk/telemetry/test_emit_telemetry.py
+++ b/integration_tests/gdk/telemetry/test_emit_telemetry.py
@@ -1,9 +1,19 @@
 import pytest
 
+from gdk.runtime_config import ConfigKey, RuntimeConfig
+
 from .telemetry_base import TelemetryServer, TelemetryTestCase
 
 
 class TestEmitTelemetry(TelemetryTestCase):
+
+    def setup_previous_version_installed(self):
+        """
+        Simualtes the gdk runtime config having recorded an older version of the gdk. Than
+        the one currently recorded on the _version.py file.
+        """
+        config = RuntimeConfig()
+        config.set(ConfigKey.INSTALLED, "1.0.0")
 
     def test_emit_installed_metric_on_first_run_only(self):
         self.enable_telemetry()
@@ -18,6 +28,19 @@ class TestEmitTelemetry(TelemetryTestCase):
 
             all_requests = server.get_all_requests()
             self.assertEqual(1, len(all_requests))
+
+    def test_emit_installed_metric_if_a_new_version_is_installed(self):
+        self.enable_telemetry()
+
+        with TelemetryServer() as server:
+            self.run_command(["component", "list", "--template"])
+
+            self.setup_previous_version_installed()
+
+            self.run_command(["component", "list", "--template"])
+
+            all_requests = server.get_all_requests()
+            self.assertEqual(2, len(all_requests))
 
     @pytest.mark.skip("Not yet implemented")
     def test_emit_failure_doesnot_spot_command_run(self):

--- a/integration_tests/gdk/telemetry/test_telemetry_setup.py
+++ b/integration_tests/gdk/telemetry/test_telemetry_setup.py
@@ -28,6 +28,7 @@ class TestTelemetryServerSetup(TelemetryTestCase):
             telemetry.emit(sample_metric)
 
             all_requests = server.get_all_requests()
+            self.assertEqual(1, len(all_requests))
             request = all_requests[0]
 
             expected_data = {

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -2,20 +2,16 @@
 
 import json
 import os
-from unittest import TestCase
+import tempfile
+from pathlib import Path
 
 from gdk._version import __version__
-from gdk.runtime_config import ConfigKey, RuntimeConfig
+from gdk.runtime_config import (GDK_RUNTIME_CONFIG_DIR, ConfigKey,
+                                RuntimeConfig)
+from integration_tests.gdk.telemetry.telemetry_base import TelemetryTestCase
 
 
-class TestRuntimeConfig(TestCase):
-
-    def tearDown(self) -> None:
-        config = RuntimeConfig(force_create=True)
-
-        # Delete the persisted config file if exists after each test
-        if os.path.exists(config.config_path):
-            os.remove(config.config_path)
+class TestRuntimeConfig(TelemetryTestCase):
 
     def test_there_is_a_single_instance(self):
         config_a = RuntimeConfig()
@@ -66,3 +62,11 @@ class TestRuntimeConfig(TestCase):
 
         config = RuntimeConfig(force_create=True)
         self.assertIsNone(config.get(ConfigKey.INSTALLED))
+
+    def test_it_can_load_the_config_path_from_an_env_variable(self):
+        temp_dir = tempfile.mktemp()
+        os.environ[GDK_RUNTIME_CONFIG_DIR] = temp_dir
+
+        config = RuntimeConfig()
+        expected_path = Path(temp_dir, "runtime.json")
+        self.assertEqual(str(expected_path), str(config.config_path))

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -1,0 +1,68 @@
+
+
+import json
+import os
+from unittest import TestCase
+
+from gdk._version import __version__
+from gdk.runtime_config import ConfigKey, RuntimeConfig
+
+
+class TestRuntimeConfig(TestCase):
+
+    def tearDown(self) -> None:
+        config = RuntimeConfig(force_create=True)
+
+        # Delete the persisted config file if exists after each test
+        if os.path.exists(config.config_path):
+            os.remove(config.config_path)
+
+    def test_there_is_a_single_instance(self):
+        config_a = RuntimeConfig()
+        config_b = RuntimeConfig()
+
+        self.assertEqual(config_a, config_b)
+
+    def test_it_can_store_values(self):
+        config = RuntimeConfig(force_create=True)
+        config.set(ConfigKey.INSTALLED, __version__)
+
+        version = config.get(ConfigKey.INSTALLED)
+        self.assertEqual(version, __version__)
+
+    def test_it_returns_none_when_value_not_stored(self):
+        config = RuntimeConfig(force_create=True)
+        version = config.get(ConfigKey.INSTALLED)
+
+        self.assertIsNone(version)
+
+    def test_it_persists_config_to_the_file_system(self):
+        config = RuntimeConfig()
+        config.set(ConfigKey.INSTALLED, __version__)
+
+        self.assertTrue(config.config_path.exists())
+
+        content = config.config_path.read_text()
+        json_content = json.loads(content)
+
+        expected = {ConfigKey.INSTALLED.value: __version__}
+        self.assertEqual(expected, json_content)
+
+    def test_it_loads_persisted_config_from_file_system(self):
+        config_a = RuntimeConfig()
+        config_a.set(ConfigKey.INSTALLED, __version__)
+
+        config_b = RuntimeConfig(force_create=True)
+        version = config_b.get(ConfigKey.INSTALLED)
+
+        self.assertEqual(__version__, version)
+
+    def test_it_does_not_load_config_if_corrupted_json_file(self):
+        config = RuntimeConfig()
+        config.set(ConfigKey.INSTALLED, __version__)
+
+        # Corrupt the file to an invalid json
+        config.config_path.write_text("hello")
+
+        config = RuntimeConfig(force_create=True)
+        self.assertIsNone(config.get(ConfigKey.INSTALLED))


### PR DESCRIPTION
**Description of changes:**
This PR adds Runtime Config which is basically a singleton we can use to store information we need to store for subsequent runs. Currently the object is not thread safe but we could implement locking later.  It is used so we record if we have already emitted the installed metrics and will be used to record if we have shown the user the install prompt.

The runtime config is just meant to hold key value pairs. If we ever decided to change keys in the config in a future version we would have to nix it and recreate it or use a different name and ignore the old one. The only harm tampering with the file is that the user MAY cause it to trigger other an install metric one more time. When we load it we only take in the keys that we define on the app, the rest are ignored

**Why is this change necessary:**

* Ensure there are certain actions we just perform once across multiple runs of the CLI.

**How was this change tested:**

Unit and integration tests