### PR TITLE
feat: implement test init command

### DIFF
--- a/gdk/commands/test/InitCommand.py
+++ b/gdk/commands/test/InitCommand.py
@@ -1,0 +1,45 @@
+import logging
+import tempfile
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+import requests
+
+import gdk.common.utils as utils
+from gdk.commands.Command import Command
+
+
+class InitCommand(Command):
+    def __init__(self, command_args) -> None:
+        super().__init__(command_args, "run")
+        self.template_name = "TestTemplateForCLI"
+        self.test_directory = Path(utils.get_current_directory()).joinpath("uat-features").resolve()
+
+    @property
+    def template_url(self):
+        return (
+            "https://github.com/aws-greengrass/aws-greengrass-component-templates/releases/download/v1.0/"
+            + f"{self.template_name}.zip"
+        )
+
+    def run(self):
+        if self.test_directory.exists():
+            logging.warning("Not downloading the uat template as 'uat-features' already exists in the current directory.")
+            return
+        self.download_template()
+
+    def download_template(self):
+        download_response = requests.get(self.template_url, stream=True)
+        if download_response.status_code != 200:
+            try:
+                download_response.raise_for_status()
+            except Exception:
+                logging.error("Failed to download the uat template from GitHub")
+                raise
+
+        logging.info("Downloading the uat template from GitHub")
+        with zipfile.ZipFile(BytesIO(download_response.content)) as zfile:
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                zfile.extractall(tmpdirname)
+                Path(tmpdirname).joinpath(self.template_name).rename(self.test_directory)

--- a/gdk/commands/test/test.py
+++ b/gdk/commands/test/test.py
@@ -1,7 +1,11 @@
+from gdk.commands.test.InitCommand import InitCommand
+
+
 def init(d_args):
     """
     gdk test init
     """
+    InitCommand(d_args).run()
 
 
 def run(d_args):

--- a/gdk/common/utils.py
+++ b/gdk/common/utils.py
@@ -142,6 +142,10 @@ def get_next_patch_version(version_number: str) -> str:
     return f"{major}.{minor}.{str(next_patch_version)}"
 
 
+def get_current_directory() -> Path:
+    return Path(".").resolve()
+
+
 error_line = "\n=============================== ERROR ===============================\n"
 help_line = "\n=============================== HELP ===============================\n"
 current_directory = Path(".").resolve()

--- a/integration_tests/gdk/test/test_integ_uat_InitCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_InitCommand.py
@@ -1,0 +1,40 @@
+from unittest import TestCase
+
+import gdk.CLIParser as CLIParser
+import gdk.common.parse_args_actions as parse_args_actions
+import pytest
+from pathlib import Path
+import os
+from gdk.commands.test.InitCommand import InitCommand
+
+
+class CommandUATTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker, tmpdir):
+        self.mocker = mocker
+        self.tmpdir = tmpdir
+        self.c_dir = Path(".").resolve()
+        os.chdir(tmpdir)
+        yield
+        os.chdir(self.c_dir)
+
+    def test_init_run_gdk_project(self):
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["test", "init", "-d"]))
+        uat_folder = Path(self.tmpdir).joinpath("uat-features")
+        assert uat_folder.exists()
+        assert uat_folder.joinpath("pom.xml") in list(uat_folder.iterdir())
+
+    def test_init_run_gdk_project_already_initiated(self):
+        # uat-features already exists but is empty
+        Path(self.tmpdir).joinpath("uat-features").mkdir()
+        parse_args_actions.run_command(CLIParser.cli_parser.parse_args(["test", "init", "-d"]))
+        # existing uat-features folder is not overridden
+        assert Path(self.tmpdir).resolve("uat-features").exists()
+        assert list(Path(self.tmpdir).joinpath("uat-features").iterdir()) == []
+
+    def test_init_run_gdk_project_template_not_exists(self):
+        with pytest.raises(Exception) as e:
+            init_command = InitCommand({})
+            init_command.template_name = "doesnotexist"
+            init_command.run()
+        assert f"404 Client Error: Not Found for url: {init_command.template_url}" in e.value.args[0]


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

When `gdk test init`command is run, `TestTemplateForCLI` from component templates [repo](https://github.com/aws-greengrass/aws-greengrass-component-templates) is downloaded into a new directory called `uat-features` at the current path. 

If `uat-features` directory already exists at the current path, then the commands exits with a WARNING message. Existing folder is not overridden or replaced. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.