### PR TITLE
feat: add supported build systems for UATs

### DIFF
--- a/gdk/build_system/GDKBuildSystem.py
+++ b/gdk/build_system/GDKBuildSystem.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+
+class GDKBuildSystem(ABC):
+    """
+    Class for GDK build system
+    """
+
+    @property
+    @abstractmethod
+    def build_command(self) -> List[str]:
+        """
+        Build command for the build system
+        """
+
+    @property
+    @abstractmethod
+    def build_folder(self) -> List[str]:
+        """
+        Build folder created after running the build command
+        """
+
+    @property
+    @abstractmethod
+    def build_system_identifier(self) -> List[str]:
+        """
+        List of files used to identify the build system
+        """
+
+    @abstractmethod
+    def build(self) -> None:
+        """
+        Build the project
+        """

--- a/gdk/build_system/Gradle.py
+++ b/gdk/build_system/Gradle.py
@@ -1,0 +1,20 @@
+import subprocess as sp
+
+from gdk.build_system.GDKBuildSystem import GDKBuildSystem
+
+
+class Gradle(GDKBuildSystem):
+    @property
+    def build_command(self):
+        return ["gradle", "clean", "build"]
+
+    @property
+    def build_folder(self):
+        return ["build", "libs"]
+
+    @property
+    def build_system_identifier(self):
+        return ["build.gradle", "build.gradle.kts"]
+
+    def build(self):
+        sp.run(self.build_command, check=True)

--- a/gdk/build_system/Gradle.py
+++ b/gdk/build_system/Gradle.py
@@ -6,7 +6,7 @@ from gdk.build_system.GDKBuildSystem import GDKBuildSystem
 class Gradle(GDKBuildSystem):
     @property
     def build_command(self):
-        return ["gradle", "clean", "build"]
+        return ["gradle", "build"]
 
     @property
     def build_folder(self):

--- a/gdk/build_system/GradleWrapper.py
+++ b/gdk/build_system/GradleWrapper.py
@@ -8,9 +8,9 @@ class GradleWrapper(GDKBuildSystem):
     def build_command(self):
         os_platform = platform.system()
         if os_platform == "Windows":
-            return ["./gradlew.bat", "clean", "build"]
+            return ["./gradlew.bat", "build"]
         else:
-            return ["./gradlew", "clean", "build"]
+            return ["./gradlew", "build"]
 
     @property
     def build_folder(self):

--- a/gdk/build_system/GradleWrapper.py
+++ b/gdk/build_system/GradleWrapper.py
@@ -1,0 +1,24 @@
+import subprocess as sp
+from gdk.build_system.GDKBuildSystem import GDKBuildSystem
+import platform
+
+
+class GradleWrapper(GDKBuildSystem):
+    @property
+    def build_command(self):
+        os_platform = platform.system()
+        if os_platform == "Windows":
+            return ["./gradlew.bat", "clean", "build"]
+        else:
+            return ["./gradlew", "clean", "build"]
+
+    @property
+    def build_folder(self):
+        return ["build", "libs"]
+
+    @property
+    def build_system_identifier(self):
+        return ["build.gradle", "build.gradle.kts"]
+
+    def build(self):
+        sp.run(self.build_command, check=True)

--- a/gdk/build_system/Maven.py
+++ b/gdk/build_system/Maven.py
@@ -8,9 +8,9 @@ class Maven(GDKBuildSystem):
     def build_command(self):
         os_platform = platform.system()
         if os_platform == "Windows":
-            return ["mvn.cmd", "clean", "package"]
+            return ["mvn.cmd", "package"]
         else:
-            return ["mvn", "clean", "package"]
+            return ["mvn", "package"]
 
     @property
     def build_folder(self):

--- a/gdk/build_system/Maven.py
+++ b/gdk/build_system/Maven.py
@@ -1,0 +1,24 @@
+import platform
+import subprocess as sp
+from gdk.build_system.GDKBuildSystem import GDKBuildSystem
+
+
+class Maven(GDKBuildSystem):
+    @property
+    def build_command(self):
+        os_platform = platform.system()
+        if os_platform == "Windows":
+            return ["mvn.cmd", "clean", "package"]
+        else:
+            return ["mvn", "clean", "package"]
+
+    @property
+    def build_folder(self):
+        return ["target"]
+
+    @property
+    def build_system_identifier(self):
+        return ["pom.xml"]
+
+    def build(self):
+        sp.run(self.build_command, check=True)

--- a/gdk/build_system/UATBuildSystem.py
+++ b/gdk/build_system/UATBuildSystem.py
@@ -1,0 +1,25 @@
+from gdk.build_system.GDKBuildSystem import GDKBuildSystem
+from gdk.build_system.Gradle import Gradle
+from gdk.build_system.GradleWrapper import GradleWrapper
+from gdk.build_system.Maven import Maven
+
+
+class UATBuildSystem:
+    """
+    Delegates build tasks to the appropriate build system
+    """
+
+    @classmethod
+    def get(self, system_type: str) -> GDKBuildSystem:
+        system = system_type.strip().lower()
+        if not system or system == "":
+            raise Exception("Build system not specified")
+
+        if system == "maven":
+            return Maven()
+        elif system == "gradle":
+            return Gradle()
+        elif system == "gradlew":
+            return GradleWrapper()
+        else:
+            raise Exception(f"Build system type '{system_type}' is not supported")

--- a/integration_tests/gdk/build_system/test_GDKBuildSystem.py
+++ b/integration_tests/gdk/build_system/test_GDKBuildSystem.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+
+from gdk.build_system.UATBuildSystem import UATBuildSystem
+from pathlib import Path
+import os
+import shutil
+import pytest
+
+
+class GDKBuildSystemTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker, tmpdir):
+        self.mocker = mocker
+        self.tmpdir = tmpdir
+        self.c_dir = Path(".").resolve()
+        os.chdir(tmpdir)
+        yield
+        os.chdir(self.c_dir)
+
+    def test_GDKBuildSystem_maven(self):
+        # Set up test data
+        source = Path(self.c_dir).joinpath("integration_tests/test_data").joinpath("maven")
+        dest = Path(self.tmpdir).joinpath("maven").resolve()
+        shutil.copytree(source, dest)
+        os.chdir(dest)
+
+        build_system = UATBuildSystem.get("maven")
+        build_system.build()
+
+        target_folder = dest.joinpath("target").joinpath("HelloWorld-1.0.0.jar").resolve()
+        assert target_folder.exists()

--- a/integration_tests/test_data/maven/pom.xml
+++ b/integration_tests/test_data/maven/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.hello</groupId>
+  <artifactId>HelloWorld</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0.0</version>
+  <name>HelloWorld</name>
+  <url>http://maven.apache.org</url>
+  <properties>
+    <junitVersion>5.5.2</junitVersion>
+    <mavenPluginVersion>2.1</mavenPluginVersion>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${mavenPluginVersion}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>hello.HelloWorld</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/gdk/build_system/test_UATBuildSystem.py
+++ b/tests/gdk/build_system/test_UATBuildSystem.py
@@ -18,9 +18,9 @@ class UATBuildSystemTests(TestCase):
         assert build_system.build_folder == ["target"]
         assert build_system.build_system_identifier == ["pom.xml"]
         if platform.system() == "Windows":
-            assert mock_subprocess.call_args_list == [call(["mvn.cmd", "clean", "package"], check=True)]
+            assert mock_subprocess.call_args_list == [call(["mvn.cmd", "package"], check=True)]
         else:
-            assert mock_subprocess.call_args_list == [call(["mvn", "clean", "package"], check=True)]
+            assert mock_subprocess.call_args_list == [call(["mvn", "package"], check=True)]
 
     def test_gradle_build_system(self):
         mock_subprocess = self.mocker.patch("subprocess.run")

--- a/tests/gdk/build_system/test_UATBuildSystem.py
+++ b/tests/gdk/build_system/test_UATBuildSystem.py
@@ -29,9 +29,9 @@ class UATBuildSystemTests(TestCase):
 
         assert build_system.build_folder == ["build", "libs"]
         assert build_system.build_system_identifier == ["build.gradle", "build.gradle.kts"]
-        assert mock_subprocess.call_args_list == [call(["gradle", "clean", "build"], check=True)]
+        assert mock_subprocess.call_args_list == [call(["gradle", "build"], check=True)]
 
-    def test_gradle_wrapper_windows_build_system(self):
+    def test_gradle_wrapper_build_system(self):
         mock_subprocess = self.mocker.patch("subprocess.run")
         build_system = UATBuildSystem.get("gradlew")
         build_system.build()
@@ -40,9 +40,9 @@ class UATBuildSystemTests(TestCase):
         assert build_system.build_system_identifier == ["build.gradle", "build.gradle.kts"]
 
         if platform.system() == "Windows":
-            assert mock_subprocess.call_args_list == [call(["./gradlew.bat", "clean", "build"], check=True)]
+            assert mock_subprocess.call_args_list == [call(["./gradlew.bat", "build"], check=True)]
         else:
-            assert mock_subprocess.call_args_list == [call(["./gradlew", "clean", "build"], check=True)]
+            assert mock_subprocess.call_args_list == [call(["./gradlew", "build"], check=True)]
 
     def test_build_system_not_supported(self):
         with pytest.raises(Exception) as e:

--- a/tests/gdk/build_system/test_UATBuildSystem.py
+++ b/tests/gdk/build_system/test_UATBuildSystem.py
@@ -1,0 +1,55 @@
+from unittest import TestCase
+import pytest
+from gdk.build_system.UATBuildSystem import UATBuildSystem
+from unittest.mock import call
+import platform
+
+
+class UATBuildSystemTests(TestCase):
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker):
+        self.mocker = mocker
+
+    def test_maven_build_system(self):
+        mock_subprocess = self.mocker.patch("subprocess.run")
+        build_system = UATBuildSystem.get("maven")
+        build_system.build()
+
+        assert build_system.build_folder == ["target"]
+        assert build_system.build_system_identifier == ["pom.xml"]
+        if platform.system() == "Windows":
+            assert mock_subprocess.call_args_list == [call(["mvn.cmd", "clean", "package"], check=True)]
+        else:
+            assert mock_subprocess.call_args_list == [call(["mvn", "clean", "package"], check=True)]
+
+    def test_gradle_build_system(self):
+        mock_subprocess = self.mocker.patch("subprocess.run")
+        build_system = UATBuildSystem.get("gradle")
+        build_system.build()
+
+        assert build_system.build_folder == ["build", "libs"]
+        assert build_system.build_system_identifier == ["build.gradle", "build.gradle.kts"]
+        assert mock_subprocess.call_args_list == [call(["gradle", "clean", "build"], check=True)]
+
+    def test_gradle_wrapper_windows_build_system(self):
+        mock_subprocess = self.mocker.patch("subprocess.run")
+        build_system = UATBuildSystem.get("gradlew")
+        build_system.build()
+
+        assert build_system.build_folder == ["build", "libs"]
+        assert build_system.build_system_identifier == ["build.gradle", "build.gradle.kts"]
+
+        if platform.system() == "Windows":
+            assert mock_subprocess.call_args_list == [call(["./gradlew.bat", "clean", "build"], check=True)]
+        else:
+            assert mock_subprocess.call_args_list == [call(["./gradlew", "clean", "build"], check=True)]
+
+    def test_build_system_not_supported(self):
+        with pytest.raises(Exception) as e:
+            UATBuildSystem.get("does-not-exist")
+        assert "Build system type 'does-not-exist' is not supported" in e.value.args[0]
+
+    def test_build_system_empty_(self):
+        with pytest.raises(Exception) as e:
+            UATBuildSystem.get("  ")
+        assert "Build system not specified" in e.value.args[0]


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adding classes for build system supported by GDK for UATs. Supported build system were initially provided as a static JSON file. Component build system will be refactored to use these build system classes in future. 

**Why is this change necessary:**
Needed by `gdk test build` command

**How was this change tested:**
Added unit tests. These will be covered in integration tests when the command is added. 

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.