### PR TITLE
feat: add test build command to the cli model

### DIFF
--- a/gdk/commands/methods.py
+++ b/gdk/commands/methods.py
@@ -30,3 +30,7 @@ def _gdk_test_init(d_args):
 
 def _gdk_test_run(d_args):
     test.run(d_args)
+
+
+def _gdk_test_build(d_args):
+    test.build(d_args)

--- a/gdk/commands/test/test.py
+++ b/gdk/commands/test/test.py
@@ -12,3 +12,9 @@ def run(d_args):
     """
     gdk test run
     """
+
+
+def build(d_args):
+    """
+    gdk test build
+    """

--- a/gdk/static/cli_model.json
+++ b/gdk/static/cli_model.json
@@ -131,6 +131,9 @@
                     "init": {
                         "help": "Initialize GDK project with user acceptance testing module"
                     },
+                    "build": {
+                        "help": "Build user acceptance testing module."
+                    },
                     "run": {
                         "help": "Run user acceptance tests on GreengrassV2 components."
                     }

--- a/integration_tests/gdk/test_integ_CLIParser.py
+++ b/integration_tests/gdk/test_integ_CLIParser.py
@@ -47,6 +47,13 @@ def test_main_parse_args_test_run(mocker):
     assert mock_test_run.called
 
 
+def test_main_parse_args_test_build(mocker):
+    mock_test_build = mocker.patch("gdk.commands.test.test.build", return_value=None)
+    args = CLIParser.cli_parser.parse_args(["test", "build"])
+    parse_args_actions.run_command(args)
+    assert mock_test_build.called
+
+
 def test_main_parse_args_gdk(capsys):
     args = CLIParser.cli_parser.parse_args([])
     parse_args_actions.run_command(args)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds build command to the cli model.  With this change, customers can run `gdk test build` command using the CLI. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.