### PR TITLE
feat: implement gdk build command

### DIFF
--- a/gdk/commands/test/BuildCommand.py
+++ b/gdk/commands/test/BuildCommand.py
@@ -1,0 +1,101 @@
+from gdk.commands.Command import Command
+from gdk.common.config.GDKProject import GDKProject
+from gdk.build_system.UATBuildSystem import UATBuildSystem
+from pathlib import Path
+import gdk.common.utils as utils
+import shutil
+import logging
+
+
+class BuildCommand(Command):
+    def __init__(self, command_args) -> None:
+        super().__init__(command_args, "build")
+        self._gdk_project = GDKProject()
+        self._test_config = self._gdk_project.test_config
+        self.test_directory = utils.get_current_directory().joinpath("uat-features")
+        self.recipe_file_name = self._gdk_project.recipe_file.name
+        self._gg_build_uat_dir = self._gdk_project.gg_build_dir.joinpath("uat-features")
+        self.should_create_uat_recipe = False
+
+    def run(self):
+        """
+        This method is called when customer runs the `gdk test build` command.
+
+        1. Remove the UAT module from greengrass-build if it exists.
+        2. Copy the UAT folder to the greengrass-build directory and perform the following steps:
+        3. Update the feature files with component name and UAT recipe file path.
+        4. Create the UAT recipe file in the greengrass-build folder.
+        5. Build the UAT module.
+        """
+        build_recipe_file = self._gdk_project.gg_build_recipes_dir.joinpath(self.recipe_file_name)
+        uat_recipe_file = self._gdk_project.gg_build_recipes_dir.joinpath("uat_" + self.recipe_file_name)
+        self._clean_uat_build_dir()
+        self._copy_uat_dir_to_build()
+        self.update_feature_files(build_recipe_file, uat_recipe_file)
+        self.create_uat_recipe_file(build_recipe_file, uat_recipe_file)
+        self.build_uat_module()
+
+    def _clean_uat_build_dir(self):
+        if self._gg_build_uat_dir.exists():
+            logging.debug("Removing the UAT module from greengrass-build directory")
+            shutil.rmtree(self._gg_build_uat_dir)
+
+    def build_uat_module(self):
+        logging.info("Building the UAT module")
+        build_system = UATBuildSystem.get(self._test_config.test_build_system)
+        build_system.build(self._gg_build_uat_dir)
+
+    def _copy_uat_dir_to_build(self):
+        logging.debug("Copying the UAT module to greengrass-build directory")
+        shutil.copytree(self.test_directory, self._gg_build_uat_dir)
+
+    def update_feature_files(self, build_recipe_file: Path, uat_recipe_file: Path):
+        """
+        Update .feature files that have GDK_COMPONENT_NAME and/or GDK_COMPONENT_RECIPE_FILE variables with the component name
+        and uat_recipe file path respectively.
+
+        If a feature file contains GDK_COMPONENT_RECIPE_FILE variable, the component must be built before building the test
+        module or an exception is thrown.
+        """
+        feature_files = list(self._gg_build_uat_dir.rglob("*.feature"))
+        for feature_file in feature_files:
+            with open(feature_file, "r", encoding="utf-8") as f:
+                feature_file_content = f.read()
+
+            if "GDK_COMPONENT_NAME" not in feature_file_content and "GDK_COMPONENT_RECIPE_FILE" not in feature_file_content:
+                continue
+
+            if "GDK_COMPONENT_NAME" in feature_file_content:
+                feature_file_content = feature_file_content.replace("GDK_COMPONENT_NAME", self._gdk_project.component_name)
+
+            if "GDK_COMPONENT_RECIPE_FILE" in feature_file_content:
+                if not build_recipe_file.exists():
+                    raise Exception(
+                        "Component is not built. Build it with `gdk component build` command before building the testing"
+                        " module."
+                    )
+                else:
+                    self.should_create_uat_recipe = True
+                    feature_file_content = feature_file_content.replace("GDK_COMPONENT_RECIPE_FILE", uat_recipe_file.as_uri())
+            logging.info("Updating feature file: %s", feature_file.as_uri())
+            with open(feature_file, "w", encoding="utf-8") as f:
+                f.write(feature_file_content)
+
+    def create_uat_recipe_file(self, build_recipe_file: Path, uat_recipe_file: Path) -> None:
+        """
+        When the component is built using `gdk component build` command gdk creates a build recipe file. This method uses that
+        build recipe file and creates a uat_recipe file in the greengrass-build/recipes folder by replacing the s3 artifact
+        URIs with their absolute file paths.
+        """
+        if not self.should_create_uat_recipe:
+            return
+
+        artifact_uri = f"{utils.s3_prefix}BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION"
+
+        with open(build_recipe_file, "r", encoding="utf-8") as f:
+            content = f.read()
+            content = content.replace(artifact_uri, self._gdk_project.gg_build_component_artifacts_dir.as_uri())
+
+        logging.info("Creating the UAT recipe file: %s", uat_recipe_file.as_uri())
+        with open(uat_recipe_file, "w", encoding="utf-8") as f:
+            f.write(content)

--- a/gdk/commands/test/test.py
+++ b/gdk/commands/test/test.py
@@ -1,4 +1,5 @@
 from gdk.commands.test.InitCommand import InitCommand
+from gdk.commands.test.BuildCommand import BuildCommand
 
 
 def init(d_args):
@@ -18,3 +19,4 @@ def build(d_args):
     """
     gdk test build
     """
+    BuildCommand(d_args).run()

--- a/integration_tests/gdk/test/test_integ_uat_BuildCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_BuildCommand.py
@@ -27,6 +27,10 @@ class UATBuildCommandTest(TestCase):
             Path(self.tmpdir).joinpath("greengrass-build/recipes").joinpath("recipe.yaml").resolve(),
         )
 
+        artifact_path = Path(self.tmpdir).joinpath("greengrass-build/artifacts/abc/NEXT_PATCH").joinpath("hello_world.py")
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.touch()
+
         # Test
         build_command = BuildCommand({})
         build_command.run()

--- a/integration_tests/gdk/test/test_integ_uat_BuildCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_BuildCommand.py
@@ -1,0 +1,90 @@
+from unittest import TestCase
+
+import pytest
+from pathlib import Path
+import os
+from gdk.commands.test.BuildCommand import BuildCommand
+from gdk.build_system.Maven import Maven
+import shutil
+
+
+class UATBuildCommandTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker, tmpdir):
+        self.mocker = mocker
+        self.tmpdir = tmpdir
+        self.c_dir = Path(".").resolve()
+        self.mocker.patch("gdk.commands.component.project_utils.get_recipe_file", return_value=Path("recipe.yaml"))
+        self.mocker.patch.object(Maven, "build", return_value=None)
+        os.chdir(tmpdir)
+        yield
+        os.chdir(self.c_dir)
+
+    def test_when_test_module_build_then_update_features(self):
+        self.setup_test_data_config("config.json")
+        shutil.copy(
+            Path(self.c_dir).joinpath("integration_tests/test_data/recipes/").joinpath("build_recipe.yaml").resolve(),
+            Path(self.tmpdir).joinpath("greengrass-build/recipes").joinpath("recipe.yaml").resolve(),
+        )
+
+        # Test
+        build_command = BuildCommand({})
+        build_command.run()
+
+        uat_recipe_file = Path(self.tmpdir).joinpath("greengrass-build/recipes").joinpath("uat_recipe.yaml")
+        uat_features = Path(self.tmpdir).joinpath("greengrass-build/uat-features")
+
+        assert uat_recipe_file.exists()
+        assert uat_features.exists()
+        with open(uat_recipe_file, mode="r") as f:
+            content = f.read()
+            assert Path(self.tmpdir).joinpath("greengrass-build/artifacts/abc/NEXT_PATCH").as_uri() in content
+        with open(uat_features.joinpath("src/main/resources/greengrass/features/component.feature"), mode="r") as f:
+            content = f.read()
+            assert uat_recipe_file.as_uri() in content
+
+        with open(
+            Path(self.tmpdir).joinpath("uat-features/src/main/resources/greengrass/features/component.feature"), mode="r"
+        ) as f:
+            content = f.read()
+            assert uat_recipe_file.as_uri() not in content
+
+    def test_when_test_module_build_with_no_interpolation_then_do_not_create_uat_recipe_file(self):
+        # Setup test data. Update the feature files ahead so the build command has nothing to update.
+        self.setup_test_data_config("config.json")
+        uat_features = Path(self.tmpdir).joinpath("uat-features")
+        with open(uat_features.joinpath("src/main/resources/greengrass/features/component.feature"), mode="r") as f:
+            content = f.read()
+            content = content.replace("GDK_COMPONENT_NAME", "some-component-name").replace(
+                "GDK_COMPONENT_RECIPE_FILE", "some-recipe-file"
+            )
+
+        with open(uat_features.joinpath("src/main/resources/greengrass/features/component.feature"), mode="w") as f:
+            f.write(content)
+
+        # Test
+        build_command = BuildCommand({})
+        build_command.run()
+        uat_recipe_file = Path(self.tmpdir).joinpath("greengrass-build/recipes").joinpath("uat_recipe.yaml")
+
+        assert Path(self.tmpdir).joinpath("greengrass-build/uat-features").exists()
+        assert not uat_recipe_file.exists()
+
+    def test_when_test_module_build_with_interpolation_and_component_not_built_then_raise_exception(self):
+        self.setup_test_data_config("config.json")
+        # Test
+        with pytest.raises(Exception) as e:
+            build_command = BuildCommand({})
+            build_command.run()
+        assert "Component is not built" in e.value.args[0]
+
+    def setup_test_data_config(self, config_file):
+        # Setup test data
+        source = Path(self.c_dir).joinpath("integration_tests/test_data/config/").joinpath(config_file).resolve()
+        shutil.copy(source, Path(self.tmpdir).joinpath("gdk-config.json"))
+        shutil.unpack_archive(
+            Path(self.c_dir).joinpath("integration_tests/test_data/templates/TestTemplateForCLI.zip").resolve(),
+            extract_dir=Path(self.tmpdir),
+        )
+        shutil.move(Path(self.tmpdir).joinpath("TestTemplateForCLI"), Path(self.tmpdir).joinpath("uat-features"))
+        Path(self.tmpdir).joinpath("greengrass-build/recipes").mkdir(parents=True)

--- a/integration_tests/test_data/recipes/build_recipe.yaml
+++ b/integration_tests/test_data/recipes/build_recipe.yaml
@@ -1,0 +1,33 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: com.example.HelloWorld
+ComponentVersion: '1.0.0'
+ComponentDescription: My first AWS IoT Greengrass component.
+ComponentPublisher: Amazon
+ComponentConfiguration:
+  DefaultConfiguration:
+    Message: world
+    SampleList:
+    - '1'
+    - '2'
+    - '3'
+    SampleNestedList:
+    - - '1'
+    - - '2'
+    - - '3'
+    SampleMap:
+      key1: value1
+      key2:
+        key3:
+        - value2
+        - value3
+        key4:
+          key41: value4
+Manifests:
+  - Platform:
+      os: linux
+    Lifecycle:
+      Run: |
+        python3 -u {artifacts:path}/hello_world.py '{configuration:/Message}'
+    Artifacts:
+      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/hello_world.py

--- a/tests/gdk/commands/test/test_uat_BuildCommand.py
+++ b/tests/gdk/commands/test/test_uat_BuildCommand.py
@@ -1,0 +1,162 @@
+import pytest
+from unittest import TestCase
+from unittest.mock import call
+from gdk.commands.test.BuildCommand import BuildCommand
+from pathlib import Path
+from unittest import mock
+import platform
+
+
+class BuildCommandUnitTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker):
+        self.mocker = mocker
+
+        config = {
+            "component": {
+                "abc": {
+                    "author": "abc",
+                    "version": "1.0.0",
+                    "build": {"build_system": "zip"},
+                    "publish": {"bucket": "default", "region": "us-east-1"},
+                }
+            }
+        }
+
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+        self.mocker.patch("gdk.commands.component.project_utils.get_recipe_file", return_value=Path("."))
+
+    def test_update_features_with_no_interpolation(self):
+        build_cmd = BuildCommand({})
+        mock_rglob = self.mocker.patch("pathlib.Path.rglob", return_value=[Path("abc.feature")])
+
+        with mock.patch("builtins.open", mock.mock_open(read_data="nothing_to_update")) as mock_file:
+            build_cmd.update_feature_files("recipe.yaml", "uat_recipe.yaml")
+            assert mock_file.call_args_list == [call(Path(".").joinpath("abc.feature"), "r", encoding="utf-8")]
+
+        assert mock_rglob.call_args_list == [call("*.feature")]
+
+    def test_update_features_with_component_name_interpolation(self):
+        self.mocker.patch("pathlib.Path.as_uri", return_value="file:///abc.feature")
+        mock_rglob = self.mocker.patch("pathlib.Path.rglob", return_value=[Path("abc.feature")])
+        build_cmd = BuildCommand({})
+
+        with mock.patch("builtins.open", mock.mock_open(read_data="This is GDK_COMPONENT_NAME")) as mock_file:
+            build_cmd.update_feature_files("recipe.yaml", "uat_recipe.yaml")
+            assert mock_file.call_args_list == [
+                call(Path(".").joinpath("abc.feature"), "r", encoding="utf-8"),
+                call(Path(".").joinpath("abc.feature"), "w", encoding="utf-8"),
+            ]
+
+            assert mock_file.return_value.write.call_args_list == [call("This is abc")]
+
+        assert mock_rglob.call_args_list == [call("*.feature")]
+
+    def test_update_features_with_component_recipe_file_interpolation(self):
+        mock_rglob = self.mocker.patch("pathlib.Path.rglob", return_value=[Path("abc.feature")])
+        self.mocker.patch("pathlib.Path.exists", return_value=True)
+        self.mocker.patch("pathlib.Path.as_uri", return_value="file:///abc.feature")
+        build_cmd = BuildCommand({})
+
+        with mock.patch(
+            "builtins.open", mock.mock_open(read_data="This is GDK_COMPONENT_NAME and GDK_COMPONENT_RECIPE_FILE")
+        ) as mock_file:
+            build_cmd.update_feature_files(Path("recipe.yaml"), Path("uat_recipe.yaml"))
+            assert mock_file.call_args_list == [
+                call(Path(".").joinpath("abc.feature"), "r", encoding="utf-8"),
+                call(Path(".").joinpath("abc.feature"), "w", encoding="utf-8"),
+            ]
+            assert mock_file.return_value.write.call_args_list == [call("This is abc and file:///abc.feature")]
+
+        assert mock_rglob.call_args_list == [call("*.feature")]
+
+    def test_update_features_with_component_recipe_file_without_build_raises_exception(self):
+        mock_rglob = self.mocker.patch("pathlib.Path.rglob", return_value=[Path("abc.feature")])
+        self.mocker.patch("pathlib.Path.exists", return_value=False)
+        self.mocker.patch("pathlib.Path.as_uri", return_value="file:///abc.feature")
+        build_cmd = BuildCommand({})
+
+        with mock.patch(
+            "builtins.open", mock.mock_open(read_data="This is GDK_COMPONENT_NAME and GDK_COMPONENT_RECIPE_FILE")
+        ) as mock_file:
+            with pytest.raises(Exception) as e:
+                build_cmd.update_feature_files(Path("recipe.yaml"), Path("uat_recipe.yaml"))
+                assert mock_file.call_args_list == [call(Path(".").joinpath("abc.feature"), "r", encoding="utf-8")]
+            assert "Component is not built" in e.value.args[0]
+
+        assert mock_rglob.call_args_list == [call("*.feature")]
+
+    def test_create_uat_recipe_from_build_recipe_without_replacing_s3_uri(self):
+        self.mocker.patch("pathlib.Path.exists", return_value=True)
+        self.mocker.patch("pathlib.Path.as_uri", return_value="file:///abc.feature")
+        build_cmd = BuildCommand({})
+        build_cmd.should_create_uat_recipe = True
+        with mock.patch("builtins.open", mock.mock_open(read_data="recipe with s3://BUCKET/abc.feature")) as mock_file:
+            build_cmd.create_uat_recipe_file(Path("recipe.yaml"), Path("uat_recipe.yaml"))
+            assert mock_file.call_args_list == [
+                call(Path(".").joinpath("recipe.yaml"), "r", encoding="utf-8"),
+                call(Path(".").joinpath("uat_recipe.yaml"), "w", encoding="utf-8"),
+            ]
+            assert mock_file.return_value.write.call_args_list == [call("recipe with s3://BUCKET/abc.feature")]
+
+    def test_create_uat_recipe_from_build_recipe_with_replacing_s3_uri(self):
+        self.mocker.patch("pathlib.Path.exists", return_value=True)
+
+        def get_as_uris(self):
+            return str(self)
+
+        self.mocker.patch.object(Path, "as_uri", get_as_uris)
+        build_cmd = BuildCommand({})
+        build_cmd.should_create_uat_recipe = True
+        with mock.patch(
+            "builtins.open",
+            mock.mock_open(read_data="recipe with s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/somefile.json"),
+        ) as mock_file:
+            build_cmd.create_uat_recipe_file(Path("recipe.yaml"), Path("uat_recipe.yaml"))
+            assert mock_file.call_args_list == [
+                call(Path(".").joinpath("recipe.yaml"), "r", encoding="utf-8"),
+                call(Path(".").joinpath("uat_recipe.yaml"), "w", encoding="utf-8"),
+            ]
+
+            print(mock_file.return_value.write.call_args_list)
+            assert mock_file.return_value.write.call_args_list == [
+                call(
+                    "recipe with "
+                    + Path().absolute().joinpath("greengrass-build/artifacts/abc/1.0.0/somefile.json").resolve().as_uri()
+                )
+            ]
+
+    def test_create_uat_recipe_from_should_not_create_uat_recipe(self):
+        self.mocker.patch("pathlib.Path.exists", return_value=True)
+
+        def get_as_uris(self):
+            return str(self)
+
+        self.mocker.patch.object(Path, "as_uri", get_as_uris)
+        build_cmd = BuildCommand({})
+        build_cmd.should_create_uat_recipe = False
+        with mock.patch(
+            "builtins.open",
+            mock.mock_open(read_data="recipe with s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/somefile.json"),
+        ) as mock_file:
+            build_cmd.create_uat_recipe_file(Path("recipe.yaml"), Path("uat_recipe.yaml"))
+            assert mock_file.call_args_list == []
+
+    def test_build_uat_module(self):
+        uat_build_cmd = self.mocker.patch("subprocess.run", return_value=None)
+        self.mocker.patch("pathlib.Path.exists", return_value=True)
+        build_cmd = BuildCommand({})
+        build_cmd.build_uat_module()
+
+        if platform.system() == "Windows":
+            assert uat_build_cmd.call_args_list == [
+                call(
+                    ["mvn.cmd", "package"],
+                    check=True,
+                    cwd=Path().absolute().joinpath("greengrass-build/uat-features").resolve(),
+                )
+            ]
+        else:
+            assert uat_build_cmd.call_args_list == [
+                call(["mvn", "package"], check=True, cwd=Path().absolute().joinpath("greengrass-build/uat-features").resolve())
+            ]


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Implement `gdk test build` command which is responsible for building the UAT module set up by the customer using OTF testing standalone jar as a dependency. Before building the module, the following steps are performed in order:

1. Remove the `uat-features` folder from `greengrass-build` directory. 
2. Copy the `uat-features` folder from gdk project to the `greengrass-build` directory. This is to avoid updating the original feature files. 
3. Update the feature files that contain the strings `GDK_COMPONENT_NAME` and `GDK_COMPONENT_RECIPE_FILE` with component name and uat_recipe path. 
4. Create uat_recipe file only when there's at least one feature file with `GDK_COMPONENT_RECIPE_FILE` variable. This UAT recipe file is created from the build recipe file by replacing the S3 URIs with absolute path to built artifacts on file system.
5. Customer must build the component using `gdk component build` before running `gdk test build command` if one or more feature files have `GDK_COMPONENT_RECIPE_FILE` variable. 
6. After all the interpolations are done, the testing module is built. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [x] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.