### PR TITLE
feat: initial implementation of test run command

### DIFF
--- a/gdk/commands/test/RunCommand.py
+++ b/gdk/commands/test/RunCommand.py
@@ -1,0 +1,33 @@
+from gdk.commands.Command import Command
+from gdk.common.config.GDKProject import GDKProject
+from gdk.build_system.UATBuildSystem import UATBuildSystem
+
+
+class RunCommand(Command):
+    def __init__(self, command_args) -> None:
+        super().__init__(command_args, "run")
+        self._gdk_project = GDKProject()
+        self._test_directory = self._gdk_project.gg_build_dir.joinpath("uat-features").resolve()
+        self._test_build_system = self._gdk_project.test_config.test_build_system
+
+    def run(self):
+        """
+        This method is called when customer runs the `gdk test run` command
+
+        1. Check if the test module is built. Otherwise, raise an exception.
+        2. TODO: If ggc.archive path is not configured, then download the latest nucleus archive from url
+        3. TODO: Run the test module jar with configured options.
+        """
+        if not self._is_test_module_built():
+            raise Exception(
+                "UAT module is not built. Please build the test module using `gdk test build`command before running the tests."
+            )
+
+    def _is_test_module_built(self) -> bool:
+        """
+        Return true if the test module build folder exists
+        """
+        uat_build_system = UATBuildSystem.get(self._test_build_system)
+        test_build_folder = self._test_directory.joinpath(*uat_build_system.build_folder).resolve()
+
+        return test_build_folder.exists()

--- a/gdk/commands/test/test.py
+++ b/gdk/commands/test/test.py
@@ -1,5 +1,6 @@
 from gdk.commands.test.InitCommand import InitCommand
 from gdk.commands.test.BuildCommand import BuildCommand
+from gdk.commands.test.RunCommand import RunCommand
 
 
 def init(d_args):
@@ -13,6 +14,7 @@ def run(d_args):
     """
     gdk test run
     """
+    RunCommand(d_args).run()
 
 
 def build(d_args):

--- a/tests/gdk/commands/test/test_uat_RunCommand.py
+++ b/tests/gdk/commands/test/test_uat_RunCommand.py
@@ -1,0 +1,40 @@
+import pytest
+from unittest import TestCase
+from gdk.commands.test.RunCommand import RunCommand
+from pathlib import Path
+import os
+
+
+class RunCommandUnitTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker, tmpdir):
+        self.mocker = mocker
+        self.tmpdir = Path(tmpdir)
+        self.c_dir = Path(".").resolve()
+
+        config = {
+            "component": {
+                "abc": {
+                    "author": "abc",
+                    "version": "1.0.0",
+                    "build": {"build_system": "zip"},
+                    "publish": {"bucket": "default", "region": "us-east-1"},
+                }
+            }
+        }
+
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+        self.mocker.patch("gdk.commands.component.project_utils.get_recipe_file", return_value=Path("."))
+        os.chdir(tmpdir)
+        yield
+        os.chdir(self.c_dir)
+
+    def test_given_test_module_not_built_when_run_uats_then_raise_exception(self):
+        def file_exists(self):
+            return str(self) == str(Path().resolve().joinpath("uat-features/target"))
+
+        self.mocker.patch.object(Path, "exists", file_exists)
+        run_cmd = RunCommand({})
+        with pytest.raises(Exception) as e:
+            run_cmd.run()
+        assert "UAT module is not built." in e.value.args[0]


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Initial implementation of test run command.  
This method is called when `gdk test run` is executed. Before running the UAT jar, run command verifies if the testing module is already built by checking the build folder. If it not built, then an exception is thrown. 


**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.