### PR TITLE
feat: add helper class to read config of run command

### DIFF
--- a/gdk/commands/test/config/RunConfiguration.py
+++ b/gdk/commands/test/config/RunConfiguration.py
@@ -1,0 +1,49 @@
+from gdk.common.config.GDKProject import GDKProject
+from pathlib import Path
+
+
+class RunConfiguration:
+    def __init__(self, _gdk_project: GDKProject, _args) -> None:
+        self._args = _args
+        self._gdk_project = _gdk_project
+        self._test_options_from_config = self._gdk_project.test_config.otf_options
+        self._default_tags = "Sample"
+        self._default_nucleus_archive_path = self._gdk_project.gg_build_dir.joinpath("greengrass-nucleus-latest.zip").resolve()
+        self.options = {}
+        self._update_options()
+
+    def _update_options(self) -> None:
+        """
+        Read otf_options provided in the gdk-config.json. Validate and update only `tags` and `ggc-archive` for now as these
+        are required options. Use rest of the options as they're provided in the test config.
+        """
+        self.options = self._test_options_from_config.copy()
+        self.options["ggc-archive"] = str(self._get_archive_path())
+        self.options["tags"] = self._get_tags()
+
+    def _get_archive_path(self) -> Path:
+        """
+        Read and validate `ggc-archive` provided in the gdk-config.json. Raise an exception if the archive doesn't exist at
+        the given path.
+
+        If no `ggc-archive` is provided, then use default nucleus archive path - greengrass-build/greengrass-nucleus-latest.zip
+        """
+        _nucleus_archive = self._test_options_from_config.get("ggc-archive", None)
+        if not _nucleus_archive:
+            return self._default_nucleus_archive_path
+
+        _nucleus_archive_path = Path(_nucleus_archive).resolve()
+        if not _nucleus_archive_path.exists():
+            raise Exception(
+                f"Cannot find nucleus archive at path {_nucleus_archive}. Please check 'ggc-archive' in the test config"
+            )
+        return _nucleus_archive_path
+
+    def _get_tags(self) -> str:
+        """
+        Read and validate `tags` provided in the gdk-config.json. If no tags are provided, then use default `Sample` tag.
+        """
+        tags = self._test_options_from_config.get("tags", self._default_tags)
+        if not tags:
+            raise Exception("Test tags provided in the config are invalid. Please check 'tags' in the test config")
+        return tags

--- a/tests/gdk/commands/test/config/test_RunConfiguration.py
+++ b/tests/gdk/commands/test/config/test_RunConfiguration.py
@@ -1,0 +1,126 @@
+import pytest
+from unittest import TestCase
+from pathlib import Path
+import os
+from gdk.commands.test.config.RunConfiguration import RunConfiguration
+from gdk.common.config.GDKProject import GDKProject
+
+
+class RunConfigurationUnitTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker, tmpdir):
+        self.mocker = mocker
+        self.tmpdir = tmpdir
+        self.c_dir = Path(".").resolve()
+        os.chdir(tmpdir)
+        yield
+        os.chdir(self.c_dir)
+
+    def test_given_gdk_config_with_no_test_when_get_test_run_configuration_then_return_default_configuration(self):
+        config = self._get_config()
+
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+        gdk_project = GDKProject()
+        run_config = RunConfiguration(gdk_project, {})
+
+        assert run_config.options.get("tags") == "Sample"
+        assert run_config.options.get("ggc-archive") == str(
+            Path().absolute().joinpath("greengrass-build/greengrass-nucleus-latest.zip").resolve()
+        )
+
+        assert len(run_config.options) == 2
+
+    def test_given_gdk_config_with_tags_when_get_test_run_configuration_tags_then_return_given_tags(self):
+        config = self._get_config(
+            {
+                "test": {
+                    "otf_options": {"tags": "some-tags", "ggc-version": "1.0.0"},
+                }
+            }
+        )
+
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+        gdk_project = GDKProject()
+        run_config = RunConfiguration(gdk_project, {})
+
+        assert run_config.options.get("tags") == "some-tags"
+        assert (
+            run_config.options.get("ggc-archive")
+            == Path().absolute().joinpath("greengrass-build/greengrass-nucleus-latest.zip").resolve().__str__()
+        )
+
+        assert len(run_config.options) == 3
+
+    def test_given_gdk_config_with_empty_tags_when_get_test_run_configuration_tags_then_raise_exception(self):
+        config = self._get_config(
+            {
+                "test": {
+                    "otf_options": {"tags": "", "ggc-version": "1.0.0"},
+                }
+            }
+        )
+
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+        gdk_project = GDKProject()
+        with pytest.raises(Exception) as e:
+            RunConfiguration(gdk_project, {})
+
+        assert "Test tags provided in the config are invalid. Please check 'tags' in the test config" in str(e.value)
+
+    def test_given_gdk_config_with_nucleus_archive_path_when_get_configuration_archive_path_then_validate_and_return(
+        self,
+    ):
+        config = self._get_config(
+            {
+                "test": {
+                    "otf_options": {"ggc-archive": "some-path.zip"},
+                }
+            }
+        )
+
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+        self.mocker.patch("pathlib.Path.exists", return_value=True)
+
+        gdk_project = GDKProject()
+        run_config = RunConfiguration(gdk_project, {})
+
+        assert run_config.options.get("tags") == "Sample"
+        assert run_config.options.get("ggc-archive") == Path().joinpath("some-path.zip").resolve().__str__()
+
+        assert len(run_config.options) == 2
+
+    def test_given_gdk_config_with_nucleus_archive_path_when_path_not_exists_then_raise_exception(self):
+        config = self._get_config(
+            {
+                "test": {
+                    "otf_options": {"ggc-archive": "some-path.zip"},
+                }
+            }
+        )
+
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+
+        gdk_project = GDKProject()
+
+        with pytest.raises(Exception) as e:
+            RunConfiguration(gdk_project, {})
+
+        assert (
+            "Cannot find nucleus archive at path some-path.zip. Please check 'ggc-archive' in the test config"
+            in e.value.args[0]
+        )
+
+    def _get_config(self, value=None):
+        config = {
+            "component": {
+                "abc": {
+                    "author": "abc",
+                    "version": "1.0.0",
+                    "build": {"build_system": "zip"},
+                    "publish": {"bucket": "default", "region": "us-east-1"},
+                }
+            }
+        }
+        if value:
+            config.update(value)
+        return config


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This helper class is added to read and validate configuration provided in both `gdk-config.json` and  as `run` command arguments.

The `RunConfiguration` class validates `tags` and `ggc-archive`  provided in the `otf_options` configuration. If these options are not provided, then default values are used as these are required to the run the testing jar. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.