### PR TITLE
feat: download nucleus archive to default path

### DIFF
--- a/gdk/commands/test/RunCommand.py
+++ b/gdk/commands/test/RunCommand.py
@@ -1,6 +1,10 @@
 from gdk.commands.Command import Command
 from gdk.common.config.GDKProject import GDKProject
 from gdk.build_system.UATBuildSystem import UATBuildSystem
+from gdk.commands.test.config.RunConfiguration import RunConfiguration
+from pathlib import Path
+from gdk.common.URLDownloader import URLDownloader
+import logging
 
 
 class RunCommand(Command):
@@ -9,19 +13,26 @@ class RunCommand(Command):
         self._gdk_project = GDKProject()
         self._test_directory = self._gdk_project.gg_build_dir.joinpath("uat-features").resolve()
         self._test_build_system = self._gdk_project.test_config.test_build_system
+        self._config = RunConfiguration(self._gdk_project, command_args)
+        self._nucleus_archive_link = "https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-latest.zip"
 
     def run(self):
         """
         This method is called when customer runs the `gdk test run` command
 
         1. Check if the test module is built. Otherwise, raise an exception.
-        2. TODO: If ggc.archive path is not configured, then download the latest nucleus archive from url
+        2. If 'ggc-archive' path is set to default, then download the latest nucleus archive from url if it doesn't exist.
         3. TODO: Run the test module jar with configured options.
         """
         if not self._is_test_module_built():
             raise Exception(
                 "UAT module is not built. Please build the test module using `gdk test build`command before running the tests."
             )
+
+        _nucleus_path = Path(self._config.options.get("ggc-archive"))
+        if self._should_download_nucleus_archive(_nucleus_path):
+            logging.info("Downloading latest nucleus archive from url %s", self._nucleus_archive_link)
+            URLDownloader(self._nucleus_archive_link).download(_nucleus_path)
 
     def _is_test_module_built(self) -> bool:
         """
@@ -31,3 +42,10 @@ class RunCommand(Command):
         test_build_folder = self._test_directory.joinpath(*uat_build_system.build_folder).resolve()
 
         return test_build_folder.exists()
+
+    def _should_download_nucleus_archive(self, _nucleus_path: Path) -> bool:
+        """
+        If ggc-archive path is set to default path and if it doesn't already exist at this path, then download the latest
+        nucleus archive from url.
+        """
+        return _nucleus_path == Path(self._config.default_nucleus_archive_path).resolve() and not _nucleus_path.exists()

--- a/gdk/commands/test/config/RunConfiguration.py
+++ b/gdk/commands/test/config/RunConfiguration.py
@@ -8,7 +8,7 @@ class RunConfiguration:
         self._gdk_project = _gdk_project
         self._test_options_from_config = self._gdk_project.test_config.otf_options
         self._default_tags = "Sample"
-        self._default_nucleus_archive_path = self._gdk_project.gg_build_dir.joinpath("greengrass-nucleus-latest.zip").resolve()
+        self.default_nucleus_archive_path = self._gdk_project.gg_build_dir.joinpath("greengrass-nucleus-latest.zip").resolve()
         self.options = {}
         self._update_options()
 
@@ -30,7 +30,7 @@ class RunConfiguration:
         """
         _nucleus_archive = self._test_options_from_config.get("ggc-archive", None)
         if not _nucleus_archive:
-            return self._default_nucleus_archive_path
+            return self.default_nucleus_archive_path
 
         _nucleus_archive_path = Path(_nucleus_archive).resolve()
         if not _nucleus_archive_path.exists():


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
if `ggc-archive` is not configured in the `gdk-config.json` file, then the default value is set to path `greengrass-build/greengrass-nucleus-latest.zip`. 

If nucleus archive does not exist at that location, then the latest version of nucleus is downloaded from URL. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.