### PR TITLE
feat: run testing jar with configured options

### DIFF
--- a/gdk/commands/test/RunCommand.py
+++ b/gdk/commands/test/RunCommand.py
@@ -5,6 +5,7 @@ from gdk.commands.test.config.RunConfiguration import RunConfiguration
 from pathlib import Path
 from gdk.common.URLDownloader import URLDownloader
 import logging
+import subprocess as sp
 
 
 class RunCommand(Command):
@@ -22,7 +23,7 @@ class RunCommand(Command):
 
         1. Check if the test module is built. Otherwise, raise an exception.
         2. If 'ggc-archive' path is set to default, then download the latest nucleus archive from url if it doesn't exist.
-        3. TODO: Run the test module jar with configured options.
+        3. Run the test module jar with configured options.
         """
         if not self._is_test_module_built():
             raise Exception(
@@ -34,14 +35,20 @@ class RunCommand(Command):
             logging.info("Downloading latest nucleus archive from url %s", self._nucleus_archive_link)
             URLDownloader(self._nucleus_archive_link).download(_nucleus_path)
 
+        self._run_testing_jar()
+
     def _is_test_module_built(self) -> bool:
         """
         Return true if the test module build folder exists
         """
-        uat_build_system = UATBuildSystem.get(self._test_build_system)
-        test_build_folder = self._test_directory.joinpath(*uat_build_system.build_folder).resolve()
+        return self._test_build_directory().exists()
 
-        return test_build_folder.exists()
+    def _test_build_directory(self) -> Path:
+        """
+        Return the test build directory
+        """
+        uat_build_system = UATBuildSystem.get(self._test_build_system)
+        return self._test_directory.joinpath(*uat_build_system.build_folder).resolve()
 
     def _should_download_nucleus_archive(self, _nucleus_path: Path) -> bool:
         """
@@ -49,3 +56,23 @@ class RunCommand(Command):
         nucleus archive from url.
         """
         return _nucleus_path == Path(self._config.default_nucleus_archive_path).resolve() and not _nucleus_path.exists()
+
+    def _run_testing_jar(self) -> bool:
+        """
+        Run the testing jar from the build folder using the configured options.
+        """
+        # TODO: identify jar from the build output
+        _jar_path = str(self._test_build_directory().joinpath("uat-features-1.0.0.jar").resolve())
+        _commands = ["java", "-jar", _jar_path]
+        _commands.extend(self._get_options_as_list())
+        logging.info("Running test jar with command %s", " ".join(_commands))
+        sp.run(_commands, check=True)
+
+    def _get_options_as_list(self) -> list:
+        """
+        Return options as list of arguments to the jar
+        """
+        _options_list = []
+        for opt, val in self._config.options.items():
+            _options_list.append(f"--{opt}={val}")
+        return _options_list

--- a/gdk/commands/test/RunCommand.py
+++ b/gdk/commands/test/RunCommand.py
@@ -57,7 +57,7 @@ class RunCommand(Command):
         """
         return _nucleus_path == Path(self._config.default_nucleus_archive_path).resolve() and not _nucleus_path.exists()
 
-    def _run_testing_jar(self) -> bool:
+    def _run_testing_jar(self) -> None:
         """
         Run the testing jar from the build folder using the configured options.
         """
@@ -66,13 +66,15 @@ class RunCommand(Command):
         _commands = ["java", "-jar", _jar_path]
         _commands.extend(self._get_options_as_list())
         logging.info("Running test jar with command %s", " ".join(_commands))
-        sp.run(_commands, check=True)
+
+        try:
+            sp.run(_commands, check=True)
+        except Exception:
+            logging.error("Exception occurred while running the test jar.")
+            raise
 
     def _get_options_as_list(self) -> list:
         """
         Return options as list of arguments to the jar
         """
-        _options_list = []
-        for opt, val in self._config.options.items():
-            _options_list.append(f"--{opt}={val}")
-        return _options_list
+        return [f"--{opt}={val}" for opt, val in self._config.options.items()]

--- a/tests/gdk/commands/test/test_uat_RunCommand.py
+++ b/tests/gdk/commands/test/test_uat_RunCommand.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest import TestCase
+from unittest.mock import ANY
 from gdk.commands.test.RunCommand import RunCommand
 from pathlib import Path
 import os
@@ -26,6 +27,7 @@ class RunCommandUnitTest(TestCase):
 
         self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
         self.mocker.patch("gdk.commands.component.project_utils.get_recipe_file", return_value=Path("."))
+        self.mock_sp = self.mocker.patch("subprocess.run", return_value=None)
         os.chdir(tmpdir)
         yield
         os.chdir(self.c_dir)
@@ -60,3 +62,19 @@ class RunCommandUnitTest(TestCase):
         run_cmd.run()
 
         mock_downloader.assert_called_once_with(default_path)
+
+    def test_given_default_config_when_run_uats_then_run_testing_jar_with_default_options(self):
+        self.mocker.patch("pathlib.Path.exists", return_value=True)
+        run_cmd = RunCommand({})
+        run_cmd.run()
+        self.mock_sp.assert_called_once_with(ANY, check=True)
+        command_arguments = self.mock_sp.call_args_list[0][0][0]
+        assert set(command_arguments) == set(
+            [
+                "java",
+                "-jar",
+                Path().resolve().joinpath("greengrass-build/uat-features/target/uat-features-1.0.0.jar").__str__(),
+                "--ggc-archive=" + Path().resolve().joinpath("greengrass-build/greengrass-nucleus-latest.zip").__str__(),
+                "--tags=Sample",
+            ]
+        )

--- a/tests/gdk/commands/test/test_uat_RunCommand.py
+++ b/tests/gdk/commands/test/test_uat_RunCommand.py
@@ -78,3 +78,12 @@ class RunCommandUnitTest(TestCase):
                 "--tags=Sample",
             ]
         )
+
+    def test_given_default_config_when_error_running_jar_then_raise_exception(self):
+        self.mocker.patch("pathlib.Path.exists", return_value=True)
+        self.mock_sp = self.mocker.patch("subprocess.run", side_effect=Exception("Error running jar"))
+        run_cmd = RunCommand({})
+        with pytest.raises(Exception) as e:
+            run_cmd.run()
+        assert "Error running jar" in e.value.args[0]
+        self.mock_sp.assert_called_once_with(ANY, check=True)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Runs the testing jar with configured options as arguments. 

Sample command

```
java -jar <path-to-testing-jar> --tags=<tags> --ggc-archive=<path-to-greengrass-nucleus-zip>
```

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.