### PR TITLE
fix: init command + do not read tags and archive path in TestConfig

### DIFF
--- a/gdk/commands/test/InitCommand.py
+++ b/gdk/commands/test/InitCommand.py
@@ -14,7 +14,7 @@ from gdk.build_system.UATBuildSystem import UATBuildSystem
 
 class InitCommand(Command):
     def __init__(self, command_args) -> None:
-        super().__init__(command_args, "run")
+        super().__init__(command_args, "init")
         self.template_name = "TestTemplateForCLI"
         self.test_directory = Path(utils.get_current_directory()).joinpath("uat-features").resolve()
         self._gdk_project = GDKProject()

--- a/gdk/common/config/TestConfiguration.py
+++ b/gdk/common/config/TestConfiguration.py
@@ -2,8 +2,6 @@ class TestConfiguration:
     def __init__(self, test_config):
         self.test_build_system = "maven"
         self.otf_version = "1.1.0-SNAPSHOT"  # TODO: Default value should be the latest version of otf testing standalone jar.
-        self.otf_tag = "Sample"
-        self.nucleus_version = "LATEST"  # TODO: Default value should be the latest version of Nucleus.
         self.otf_options = {}
 
         self._set_test_config(test_config)
@@ -17,9 +15,4 @@ class TestConfiguration:
 
     def _set_otf_config(self, test_config):
         self.otf_version = test_config.get("otf_version", self.otf_version)
-        self._set_otf_options(test_config.get("otf_options", {}))
-
-    def _set_otf_options(self, otf_options):
-        self.otf_options = otf_options
-        self.otf_tag = otf_options.get("tags", self.otf_tag)
-        self.nucleus_version = otf_options.get("ggc.version", self.nucleus_version)
+        self.otf_options = test_config.get("otf_options", {})

--- a/integration_tests/gdk/common/config/test_GDKProject.py
+++ b/integration_tests/gdk/common/config/test_GDKProject.py
@@ -23,7 +23,6 @@ class GDKProjectTest(TestCase):
         assert gdk_config.component_name == "abc"
         assert gdk_config.test_config.otf_version == "1.1.0-SNAPSHOT"
         assert gdk_config.test_config.test_build_system == "maven"
-        assert gdk_config.test_config.otf_tag == "Sample"
         assert gdk_config.test_config.otf_options == {}
 
         c_dir = Path(".").resolve()
@@ -44,8 +43,6 @@ class GDKProjectTest(TestCase):
         assert gdk_config.component_name == "abc"
         assert gdk_config.test_config.otf_version == "1.2.0"
         assert gdk_config.test_config.test_build_system == "maven"
-        assert gdk_config.test_config.otf_tag == "testtags"
-        assert gdk_config.test_config.nucleus_version == "2.0.0"
         c_dir = Path(".").resolve()
         assert c_dir.joinpath("greengrass-build") == gdk_config.gg_build_dir
         assert c_dir.joinpath("greengrass-build/artifacts/abc/NEXT_PATCH") == gdk_config.gg_build_component_artifacts_dir


### PR DESCRIPTION
**Issue #, if available:**
Remove redundant test configuration and fix `init` command. 

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.