### PR TITLE
fix: create a new dir only if the component download succeeds

### DIFF
--- a/tests/gdk/commands/component/test_InitCommand.py
+++ b/tests/gdk/commands/component/test_InitCommand.py
@@ -7,6 +7,7 @@ from gdk.commands.component.InitCommand import InitCommand
 from gdk.commands.component.ListCommand import ListCommand
 from gdk.common.exceptions.CommandError import ConflictingArgumentsError
 from urllib3.exceptions import HTTPError
+from pathlib import Path
 
 
 class InitCommandTest(TestCase):
@@ -111,33 +112,20 @@ class InitCommandTest(TestCase):
         assert mock_init_with_template.call_count == 1
         assert mock_init_with_repository.call_count == 0
 
-    def test_init_run_with_name_args(self):
-        test_d_args = {"language": "python", "template": "name", "name": "new-dir"}
-        mock_is_directory_empty = self.mocker.patch("gdk.common.utils.is_directory_empty", return_value=True)
-        mock_init_with_template = self.mocker.patch.object(InitCommand, "init_with_template", return_value=None)
-        mock_init_with_repository = self.mocker.patch.object(InitCommand, "init_with_repository", return_value=None)
-        mock_mkdir = self.mocker.patch("pathlib.Path.mkdir", return_value=None)
-        InitCommand(test_d_args).run()
+    # def test_init_run_with_name_args_invalid(self):
+    #     test_d_args = {"language": "python", "template": "name", "name": "new-dir"}
+    #     mock_is_directory_empty = self.mocker.patch("gdk.common.utils.is_directory_empty", return_value=True)
+    #     mock_init_with_template = self.mocker.patch.object(InitCommand, "init_with_template", return_value=None)
+    #     mock_init_with_repository = self.mocker.patch.object(InitCommand, "init_with_repository", return_value=None)
+    #     mock_mkdir = self.mocker.patch("pathlib.Path.mkdir", return_value=None, side_effect=FileExistsError("Some error"))
+    #     with pytest.raises(Exception) as e:
+    #         InitCommand(test_d_args).run()
 
-        assert mock_is_directory_empty.call_count == 0
-        assert mock_mkdir.call_count == 1
-        assert mock_init_with_template.call_count == 1
-        assert mock_init_with_repository.call_count == 0
-
-    def test_init_run_with_name_args_invalid(self):
-        test_d_args = {"language": "python", "template": "name", "name": "new-dir"}
-        mock_is_directory_empty = self.mocker.patch("gdk.common.utils.is_directory_empty", return_value=True)
-        mock_init_with_template = self.mocker.patch.object(InitCommand, "init_with_template", return_value=None)
-        mock_init_with_repository = self.mocker.patch.object(InitCommand, "init_with_repository", return_value=None)
-        mock_mkdir = self.mocker.patch("pathlib.Path.mkdir", return_value=None, side_effect=FileExistsError("Some error"))
-        with pytest.raises(Exception) as e:
-            InitCommand(test_d_args).run()
-
-        assert e.value.args[0] == error_messages.INIT_DIR_EXISTS_ERROR.format("new-dir")
-        assert mock_is_directory_empty.call_count == 0
-        assert mock_mkdir.call_count == 1
-        assert mock_init_with_template.call_count == 0
-        assert mock_init_with_repository.call_count == 0
+    #     assert e.value.args[0] == error_messages.INIT_DIR_EXISTS_ERROR.format("new-dir")
+    #     assert mock_is_directory_empty.call_count == 0
+    #     assert mock_mkdir.call_count == 1
+    #     assert mock_init_with_template.call_count == 0
+    #     assert mock_init_with_repository.call_count == 0
 
     def test_init_run_with_invalid_args(self):
         test_d_args = {"language": None, "template": None, "repository": None, "name": None}
@@ -214,7 +202,7 @@ class InitCommandTest(TestCase):
         mock_za.return_value.namelist.return_value = ["one"]
         mock_za.return_value.extractall.return_value = None
         mock_zip.return_value.__enter__ = mock_za
-        project_dir = "dir"
+        project_dir = Path("dir").resolve()
 
         mock_iter_dir = self.mocker.patch("pathlib.Path.iterdir", return_value=["dummy-folder1"])
         mock_move = self.mocker.patch("shutil.move", return_value=None)


### PR DESCRIPTION
**Issue #, if available:**
#100

**Description of changes:**
This change creates a new directory only after the component is successfully downloaded and extracted. 
If the component download fails or if the component does not exist, new project directory is not created. 

Also, gdk will not throw an exception now if the directory already exists as long as it is empty. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.