### PR TITLE
refactor: add utility method to download and extract and refactor init methods

### DIFF
--- a/gdk/common/URLDownloader.py
+++ b/gdk/common/URLDownloader.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 import requests
 import logging
+import zipfile
+from io import BytesIO
+import tempfile
+import shutil
 
 
 class URLDownloader:
@@ -9,13 +13,41 @@ class URLDownloader:
 
     def download(self, destination: Path):
         logging.debug("Downloading the content from URL %s to the file %s", self.url, destination.name)
-        download_response = requests.get(self.url, stream=True, timeout=30)
-        if download_response.status_code != 200:
-            try:
-                download_response.raise_for_status()
-            except Exception:
-                logging.error("Failed to download the file from %s", self.url)
-                raise
+        download_response = self._get_download_response()
         # TODO: Write in chunks so as to not overload the memory in case of large files
         with open(destination, "wb") as file:
             file.write(download_response.content)
+
+    def download_and_extract(self, destination: Path):
+        logging.debug("Downloading the content from URL %s to the destination %s", self.url, destination.name)
+        download_response = self._get_download_response()
+        with zipfile.ZipFile(BytesIO(download_response.content)) as zfile:
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                # Extracts the zip file into temporary directory - /some-temp-dir/downloaded-zip-folder/
+                zfile.extractall(tmpdirname)
+                self._create_dir(destination)
+                # Moves the unarchived contents from temporary folder (downloaded-zip-folder) to current directory.
+                for f in Path(tmpdirname).joinpath(zfile.namelist()[0]).iterdir():
+                    shutil.move(str(f), destination)
+
+    def _get_download_response(self) -> requests.Response:
+        """
+        Returns the response of the download request.
+        """
+        try:
+            download_response = requests.get(self.url, stream=True, timeout=30)
+            if download_response.status_code != 200:
+                download_response.raise_for_status()
+        except Exception:
+            logging.error("Failed to download the file from %s", self.url)
+            raise
+        return download_response
+
+    def _create_dir(self, project_dir: Path):
+        """
+        Creates a new directory if it does not exist already.
+        """
+        if project_dir.exists():
+            return
+        logging.debug("Creating a new project directory '%s'", str(project_dir))
+        project_dir.mkdir(parents=True, exist_ok=False)

--- a/integration_tests/gdk/components/test_integ_InitCommand.py
+++ b/integration_tests/gdk/components/test_integ_InitCommand.py
@@ -127,7 +127,7 @@ class InitCommandIntegTest(TestCase):
         assert "Not found" in e.value.args[0]
         assert mock_requests_get.call_args_list == [
             call(self.url + "templates.json"),
-            call("https://dummy-link", stream=True),
+            call("https://dummy-link", stream=True, timeout=30),
         ]
 
         assert utils.is_directory_empty(self.tmpdir)
@@ -153,7 +153,7 @@ class InitCommandIntegTest(TestCase):
         assert "Not found" in e.value.args[0]
         assert mock_requests_get.call_args_list == [
             call(self.url + "community-components.json"),
-            call("https://dummy-link", stream=True),
+            call("https://dummy-link", stream=True, timeout=30),
         ]
 
         assert utils.is_directory_empty(self.tmpdir)

--- a/tests/gdk/commands/component/test_InitCommand.py
+++ b/tests/gdk/commands/component/test_InitCommand.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-from unittest.mock import Mock, mock_open, patch
 
 import gdk.common.exceptions.error_messages as error_messages
 import pytest
@@ -7,7 +6,6 @@ from gdk.commands.component.InitCommand import InitCommand
 from gdk.commands.component.ListCommand import ListCommand
 from gdk.common.exceptions.CommandError import ConflictingArgumentsError
 from urllib3.exceptions import HTTPError
-from pathlib import Path
 
 
 class InitCommandTest(TestCase):
@@ -112,21 +110,6 @@ class InitCommandTest(TestCase):
         assert mock_init_with_template.call_count == 1
         assert mock_init_with_repository.call_count == 0
 
-    # def test_init_run_with_name_args_invalid(self):
-    #     test_d_args = {"language": "python", "template": "name", "name": "new-dir"}
-    #     mock_is_directory_empty = self.mocker.patch("gdk.common.utils.is_directory_empty", return_value=True)
-    #     mock_init_with_template = self.mocker.patch.object(InitCommand, "init_with_template", return_value=None)
-    #     mock_init_with_repository = self.mocker.patch.object(InitCommand, "init_with_repository", return_value=None)
-    #     mock_mkdir = self.mocker.patch("pathlib.Path.mkdir", return_value=None, side_effect=FileExistsError("Some error"))
-    #     with pytest.raises(Exception) as e:
-    #         InitCommand(test_d_args).run()
-
-    #     assert e.value.args[0] == error_messages.INIT_DIR_EXISTS_ERROR.format("new-dir")
-    #     assert mock_is_directory_empty.call_count == 0
-    #     assert mock_mkdir.call_count == 1
-    #     assert mock_init_with_template.call_count == 0
-    #     assert mock_init_with_repository.call_count == 0
-
     def test_init_run_with_invalid_args(self):
         test_d_args = {"language": None, "template": None, "repository": None, "name": None}
         mock_is_directory_empty = self.mocker.patch("gdk.common.utils.is_directory_empty", return_value=True)
@@ -186,85 +169,6 @@ class InitCommandTest(TestCase):
             init.init_with_repository(repository, project_dir)
         assert "Some error" in e.value.args[0]
         mock_download_and_clean.assert_any_call(repository, "repository", project_dir)
-
-    @patch("zipfile.ZipFile")
-    def test_download_and_clean_valid(self, mock_zip):
-        mock_get_available_templates = self.mocker.patch.object(
-            ListCommand,
-            "get_component_list_from_github",
-            return_value={"template-language": "template-url"},
-        )
-
-        mock_response = self.mocker.Mock(status_code=200, content="".encode())
-        mock_template_download = self.mocker.patch("requests.get", return_value=mock_response)
-        mock_make_dir = self.mocker.patch("pathlib.Path.mkdir", return_value=None)
-        mock_za = Mock()
-        mock_za.return_value.namelist.return_value = ["one"]
-        mock_za.return_value.extractall.return_value = None
-        mock_zip.return_value.__enter__ = mock_za
-        project_dir = Path("dir").resolve()
-
-        mock_iter_dir = self.mocker.patch("pathlib.Path.iterdir", return_value=["dummy-folder1"])
-        mock_move = self.mocker.patch("shutil.move", return_value=None)
-        self.mocker.patch.object(InitCommand, "__init__", return_value=None)
-        init = InitCommand({})
-        init.download_and_clean("template-language", "template", project_dir)
-        assert mock_iter_dir.call_count == 1
-        assert mock_move.call_count == 1
-        mock_move.assert_any_call("dummy-folder1", project_dir)
-        assert mock_template_download.call_count == 1
-        assert mock_get_available_templates.call_count == 1
-        assert mock_make_dir.call_count == 1
-
-    def test_init_with_template_invalid_url_server_error(self):
-        template = "template"
-        language = "language"
-        project_dir = "dir"
-        formatted_template_name = f"{template}-{language}"
-        mock_get_available_templates = self.mocker.patch.object(
-            ListCommand,
-            "get_component_list_from_github",
-            return_value={formatted_template_name: "template-url"},
-        )
-        mock_response = self.mocker.Mock(
-            status_code=500, raise_for_status=self.mocker.Mock(side_effect=HTTPError("some error"))
-        )
-        mock_template_download = self.mocker.patch("requests.get", return_value=mock_response)
-        self.mocker.patch.object(InitCommand, "__init__", return_value=None)
-        init = InitCommand({})
-        with patch("builtins.open", mock_open()) as mock_file:
-            with pytest.raises(Exception) as e:
-                init.download_and_clean(formatted_template_name, template, project_dir)
-
-            assert "some error" in e.value.args[0]
-            assert mock_template_download.call_count == 1
-            assert mock_get_available_templates.call_count == 1
-            assert not mock_file.called
-
-    def test_init_with_template_invalid_url_not_found(self):
-        template = "template"
-        language = "language"
-        project_dir = "dir"
-        formatted_template_name = f"{template}-{language}"
-        mock_get_available_templates = self.mocker.patch.object(
-            ListCommand,
-            "get_component_list_from_github",
-            return_value={formatted_template_name: "template-url"},
-        )
-        mock_response = self.mocker.Mock(
-            status_code=404, raise_for_status=self.mocker.Mock(side_effect=HTTPError("some error"))
-        )
-        mock_template_download = self.mocker.patch("requests.get", return_value=mock_response)
-        self.mocker.patch.object(InitCommand, "__init__", return_value=None)
-        init = InitCommand({})
-        with patch("builtins.open", mock_open()) as mock_file:
-            with pytest.raises(Exception) as e:
-                init.download_and_clean(formatted_template_name, template, project_dir)
-
-            assert "some error" in e.value.args[0]
-            assert mock_template_download.call_count == 1
-            assert mock_get_available_templates.call_count == 1
-            assert not mock_file.called
 
     def test_get_download_url_valid_template(self):
         template = "template"

--- a/tests/gdk/commands/component/test_InitCommand.py
+++ b/tests/gdk/commands/component/test_InitCommand.py
@@ -197,7 +197,7 @@ class InitCommandTest(TestCase):
 
         mock_response = self.mocker.Mock(status_code=200, content="".encode())
         mock_template_download = self.mocker.patch("requests.get", return_value=mock_response)
-
+        mock_make_dir = self.mocker.patch("pathlib.Path.mkdir", return_value=None)
         mock_za = Mock()
         mock_za.return_value.namelist.return_value = ["one"]
         mock_za.return_value.extractall.return_value = None
@@ -214,6 +214,7 @@ class InitCommandTest(TestCase):
         mock_move.assert_any_call("dummy-folder1", project_dir)
         assert mock_template_download.call_count == 1
         assert mock_get_available_templates.call_count == 1
+        assert mock_make_dir.call_count == 1
 
     def test_init_with_template_invalid_url_server_error(self):
         template = "template"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add a utility method `download_and_extract` in the `URLDownloader` class and refactor `component init` and `test init` code to use the same.  Updated tests. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.