### PR TITLE
fix: do not validate region in schema  & use ssm client to get supported regions

### DIFF
--- a/gdk/aws_clients/AWSClient.py
+++ b/gdk/aws_clients/AWSClient.py
@@ -1,0 +1,18 @@
+import boto3
+
+service_clients = {}
+
+
+def ssm(region_name="us-east-1"):
+    return _get_client("ssm", region_name)
+
+
+def sts(region_name=None):
+    return _get_client("sts", region_name)
+
+
+def _get_client(_service_name, _region_name):
+    _client = service_clients.get(_service_name, {})
+    if not _client.get(_region_name, None):
+        service_clients.update({_service_name: {_region_name: boto3.client(_service_name, region_name=_region_name)}})
+    return service_clients[_service_name][_region_name]

--- a/gdk/static/config_schema.json
+++ b/gdk/static/config_schema.json
@@ -119,25 +119,8 @@
                                     "type": "string"
                                 },
                                 "region": {
-                                    "description": "AWS regions supported by AWS IoT Greengrassv2. Must be one of the enum values.",
-                                    "type": "string",
-                                    "enum": [
-                                        "us-east-2",
-                                        "us-east-1",
-                                        "us-west-2",
-                                        "ap-south-1",
-                                        "ap-northeast-2",
-                                        "ap-southeast-1",
-                                        "ap-southeast-2",
-                                        "ap-northeast-1",
-                                        "ca-central-1",
-                                        "cn-north-1",
-                                        "eu-central-1",
-                                        "eu-west-1",
-                                        "eu-west-2",
-                                        "us-gov-west-1",
-                                        "us-gov-east-1"
-                                    ]
+                                    "description": "AWS regions supported by AWS IoT Greengrassv2.",
+                                    "type": "string"
                                 },
                                 "options": {
                                     "type": "object",
@@ -151,8 +134,7 @@
                                 }
                             },
                             "required": [
-                                "bucket",
-                                "region"
+                                "bucket"
                             ]
                         }
                     },

--- a/tests/gdk/common/test_configuration.py
+++ b/tests/gdk/common/test_configuration.py
@@ -45,7 +45,6 @@ def test_get_configuration_valid_component_config_found(mocker):
         "invalid_build_command.json",
         "invalid_build_command_string.json",
         "invalid_build_command_array.json",
-        "invalid_region_config.json",
     ],
 )
 def test_get_configuration_invalid_config_file(mocker, file_name):


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Remove region validation from schema.
- Get greengrass supported regions using ssm client and validate it in the publish command. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.