### PR TITLE
refactor: rename uat to e2e test

### DIFF
--- a/gdk/build_system/E2ETestBuildSystem.py
+++ b/gdk/build_system/E2ETestBuildSystem.py
@@ -4,7 +4,7 @@ from gdk.build_system.GradleWrapper import GradleWrapper
 from gdk.build_system.Maven import Maven
 
 
-class UATBuildSystem:
+class E2ETestBuildSystem:
     """
     Delegates build tasks to the appropriate build system
     """

--- a/gdk/commands/methods.py
+++ b/gdk/commands/methods.py
@@ -24,13 +24,13 @@ def _gdk_component_list(d_args):
     component.list(d_args)
 
 
-def _gdk_test_init(d_args):
+def _gdk_test_hyphen_e2e_init(d_args):
     test.init(d_args)
 
 
-def _gdk_test_run(d_args):
+def _gdk_test_hyphen_e2e_run(d_args):
     test.run(d_args)
 
 
-def _gdk_test_build(d_args):
+def _gdk_test_hyphen_e2e_build(d_args):
     test.build(d_args)

--- a/gdk/commands/test/BuildCommand.py
+++ b/gdk/commands/test/BuildCommand.py
@@ -16,8 +16,8 @@ class BuildCommand(Command):
         self._test_config = self._gdk_project.test_config
         self.test_directory = utils.get_current_directory().joinpath(consts.E2E_TESTS_DIR_NAME)
         self.recipe_file_name = self._gdk_project.recipe_file.name
-        self._gg_build_uat_dir = self._gdk_project.gg_build_dir.joinpath(consts.E2E_TESTS_DIR_NAME)
-        self.should_create_uat_recipe = False
+        self._gg_build_e2e_test_dir = self._gdk_project.gg_build_dir.joinpath(consts.E2E_TESTS_DIR_NAME)
+        self.should_create_e2e_test_recipe = False
 
     def run(self):
         """
@@ -30,36 +30,36 @@ class BuildCommand(Command):
         5. Build the UAT module.
         """
         build_recipe_file = self._gdk_project.gg_build_recipes_dir.joinpath(self.recipe_file_name)
-        uat_recipe_file = self._gdk_project.gg_build_recipes_dir.joinpath("uat_" + self.recipe_file_name)
-        self._clean_uat_build_dir()
-        self._copy_uat_dir_to_build()
-        self.update_feature_files(build_recipe_file, uat_recipe_file)
-        self.create_uat_recipe_file(build_recipe_file, uat_recipe_file)
-        self.build_uat_module()
+        e2e_test_recipe_file = self._gdk_project.gg_build_recipes_dir.joinpath("e2e_test_" + self.recipe_file_name)
+        self._clean_e2e_test_build_dir()
+        self._copy_e2e_test_dir_to_build()
+        self.update_feature_files(build_recipe_file, e2e_test_recipe_file)
+        self.create_e2e_test_recipe_file(build_recipe_file, e2e_test_recipe_file)
+        self.build_e2e_test_module()
 
-    def _clean_uat_build_dir(self):
-        if self._gg_build_uat_dir.exists():
+    def _clean_e2e_test_build_dir(self):
+        if self._gg_build_e2e_test_dir.exists():
             logging.debug("Removing the UAT module from greengrass-build directory")
-            shutil.rmtree(self._gg_build_uat_dir)
+            shutil.rmtree(self._gg_build_e2e_test_dir)
 
-    def build_uat_module(self):
+    def build_e2e_test_module(self):
         logging.info("Building the UAT module")
         build_system = UATBuildSystem.get(self._test_config.test_build_system)
-        build_system.build(self._gg_build_uat_dir)
+        build_system.build(self._gg_build_e2e_test_dir)
 
-    def _copy_uat_dir_to_build(self):
+    def _copy_e2e_test_dir_to_build(self):
         logging.debug("Copying the UAT module to greengrass-build directory")
-        shutil.copytree(self.test_directory, self._gg_build_uat_dir)
+        shutil.copytree(self.test_directory, self._gg_build_e2e_test_dir)
 
-    def update_feature_files(self, build_recipe_file: Path, uat_recipe_file: Path):
+    def update_feature_files(self, build_recipe_file: Path, e2e_test_recipe_file: Path):
         """
         Update .feature files that have GDK_COMPONENT_NAME and/or GDK_COMPONENT_RECIPE_FILE variables with the component name
-        and uat_recipe file path respectively.
+        and e2e_test_recipe file path respectively.
 
         If a feature file contains GDK_COMPONENT_RECIPE_FILE variable, the component must be built before building the test
         module or an exception is thrown.
         """
-        feature_files = list(self._gg_build_uat_dir.rglob("*.feature"))
+        feature_files = list(self._gg_build_e2e_test_dir.rglob("*.feature"))
         for feature_file in feature_files:
             with open(feature_file, "r", encoding="utf-8") as f:
                 feature_file_content = f.read()
@@ -77,19 +77,21 @@ class BuildCommand(Command):
                         " module."
                     )
                 else:
-                    self.should_create_uat_recipe = True
-                    feature_file_content = feature_file_content.replace("GDK_COMPONENT_RECIPE_FILE", uat_recipe_file.as_uri())
+                    self.should_create_e2e_test_recipe = True
+                    feature_file_content = feature_file_content.replace(
+                        "GDK_COMPONENT_RECIPE_FILE", e2e_test_recipe_file.as_uri()
+                    )
             logging.info("Updating feature file: %s", feature_file.as_uri())
             with open(feature_file, "w", encoding="utf-8") as f:
                 f.write(feature_file_content)
 
-    def create_uat_recipe_file(self, build_recipe_file: Path, uat_recipe_file: Path) -> None:
+    def create_e2e_test_recipe_file(self, build_recipe_file: Path, e2e_test_recipe_file: Path) -> None:
         """
         When the component is built using `gdk component build` command gdk creates a build recipe file. This method uses that
-        build recipe file and creates a uat_recipe file in the greengrass-build/recipes folder by replacing the s3 artifact
+        build recipe file and creates a e2e_test_recipe file in the greengrass-build/recipes folder by replacing the s3 artifact
         URIs with their absolute file paths.
         """
-        if not self.should_create_uat_recipe:
+        if not self.should_create_e2e_test_recipe:
             return
 
         _recipe = CaseInsensitiveRecipeFile().read(build_recipe_file)
@@ -103,5 +105,5 @@ class BuildCommand(Command):
                     logging.debug("Artifact %s does not exist in the build directory", artifact_uri)
                     continue
                 artifact.update_value("Uri", artifact_path.as_uri())
-        logging.info("Creating the UAT recipe file: %s", uat_recipe_file.resolve())
-        CaseInsensitiveRecipeFile().write(uat_recipe_file, _recipe)
+        logging.info("Creating the UAT recipe file: %s", e2e_test_recipe_file.resolve())
+        CaseInsensitiveRecipeFile().write(e2e_test_recipe_file, _recipe)

--- a/gdk/commands/test/BuildCommand.py
+++ b/gdk/commands/test/BuildCommand.py
@@ -6,6 +6,7 @@ import gdk.common.utils as utils
 import shutil
 import logging
 from gdk.common.CaseInsensitive import CaseInsensitiveRecipeFile
+import gdk.common.consts as consts
 
 
 class BuildCommand(Command):
@@ -13,9 +14,9 @@ class BuildCommand(Command):
         super().__init__(command_args, "build")
         self._gdk_project = GDKProject()
         self._test_config = self._gdk_project.test_config
-        self.test_directory = utils.get_current_directory().joinpath("uat-features")
+        self.test_directory = utils.get_current_directory().joinpath(consts.E2E_TESTS_DIR_NAME)
         self.recipe_file_name = self._gdk_project.recipe_file.name
-        self._gg_build_uat_dir = self._gdk_project.gg_build_dir.joinpath("uat-features")
+        self._gg_build_uat_dir = self._gdk_project.gg_build_dir.joinpath(consts.E2E_TESTS_DIR_NAME)
         self.should_create_uat_recipe = False
 
     def run(self):

--- a/gdk/commands/test/BuildCommand.py
+++ b/gdk/commands/test/BuildCommand.py
@@ -1,6 +1,6 @@
 from gdk.commands.Command import Command
 from gdk.common.config.GDKProject import GDKProject
-from gdk.build_system.UATBuildSystem import UATBuildSystem
+from gdk.build_system.E2ETestBuildSystem import E2ETestBuildSystem
 from pathlib import Path
 import gdk.common.utils as utils
 import shutil
@@ -23,11 +23,11 @@ class BuildCommand(Command):
         """
         This method is called when customer runs the `gdk test build` command.
 
-        1. Remove the UAT module from greengrass-build if it exists.
-        2. Copy the UAT folder to the greengrass-build directory and perform the following steps:
-        3. Update the feature files with component name and UAT recipe file path.
-        4. Create the UAT recipe file in the greengrass-build folder.
-        5. Build the UAT module.
+        1. Remove the e2e module from greengrass-build if it exists.
+        2. Copy the e2e folder to the greengrass-build directory and perform the following steps:
+        3. Update the feature files with component name and e2e recipe file path.
+        4. Create the e2e recipe file in the greengrass-build folder.
+        5. Build the e2e test module.
         """
         build_recipe_file = self._gdk_project.gg_build_recipes_dir.joinpath(self.recipe_file_name)
         e2e_test_recipe_file = self._gdk_project.gg_build_recipes_dir.joinpath("e2e_test_" + self.recipe_file_name)
@@ -39,16 +39,16 @@ class BuildCommand(Command):
 
     def _clean_e2e_test_build_dir(self):
         if self._gg_build_e2e_test_dir.exists():
-            logging.debug("Removing the UAT module from greengrass-build directory")
+            logging.debug("Removing the E2E testing module from greengrass-build directory")
             shutil.rmtree(self._gg_build_e2e_test_dir)
 
     def build_e2e_test_module(self):
-        logging.info("Building the UAT module")
-        build_system = UATBuildSystem.get(self._test_config.test_build_system)
+        logging.info("Building the E2E testing module")
+        build_system = E2ETestBuildSystem.get(self._test_config.test_build_system)
         build_system.build(self._gg_build_e2e_test_dir)
 
     def _copy_e2e_test_dir_to_build(self):
-        logging.debug("Copying the UAT module to greengrass-build directory")
+        logging.debug("Copying the E2E testing module to greengrass-build directory")
         shutil.copytree(self.test_directory, self._gg_build_e2e_test_dir)
 
     def update_feature_files(self, build_recipe_file: Path, e2e_test_recipe_file: Path):
@@ -87,9 +87,9 @@ class BuildCommand(Command):
 
     def create_e2e_test_recipe_file(self, build_recipe_file: Path, e2e_test_recipe_file: Path) -> None:
         """
-        When the component is built using `gdk component build` command gdk creates a build recipe file. This method uses that
-        build recipe file and creates a e2e_test_recipe file in the greengrass-build/recipes folder by replacing the s3 artifact
-        URIs with their absolute file paths.
+        When the component is built using `gdk component build` command gdk creates a build recipe file. This method uses
+        that build recipe file and creates a E2E test recipe file in the greengrass-build/recipes folder by replacing the
+        s3 artifact URIs with their absolute file paths.
         """
         if not self.should_create_e2e_test_recipe:
             return
@@ -105,5 +105,5 @@ class BuildCommand(Command):
                     logging.debug("Artifact %s does not exist in the build directory", artifact_uri)
                     continue
                 artifact.update_value("Uri", artifact_path.as_uri())
-        logging.info("Creating the UAT recipe file: %s", e2e_test_recipe_file.resolve())
+        logging.info("Creating the E2E testing recipe file: %s", e2e_test_recipe_file.resolve())
         CaseInsensitiveRecipeFile().write(e2e_test_recipe_file, _recipe)

--- a/gdk/commands/test/InitCommand.py
+++ b/gdk/commands/test/InitCommand.py
@@ -7,13 +7,14 @@ import gdk.common.utils as utils
 from gdk.commands.Command import Command
 from gdk.build_system.UATBuildSystem import UATBuildSystem
 from gdk.common.URLDownloader import URLDownloader
+import gdk.common.consts as consts
 
 
 class InitCommand(Command):
     def __init__(self, command_args) -> None:
         super().__init__(command_args, "init")
         self.template_name = "TestTemplateForCLI"
-        self.test_directory = Path(utils.get_current_directory()).joinpath("uat-features").resolve()
+        self.test_directory = Path(utils.get_current_directory()).joinpath(consts.E2E_TESTS_DIR_NAME).resolve()
         self._gdk_project = GDKProject()
         self._test_config = self._gdk_project.test_config
 
@@ -26,7 +27,9 @@ class InitCommand(Command):
 
     def run(self):
         if self.test_directory.exists():
-            logging.warning("Not downloading the uat template as 'uat-features' already exists in the current directory.")
+            logging.warning(
+                "Not downloading the uat template as '%s' already exists in the current directory.", consts.E2E_TESTS_DIR_NAME
+            )
             return
         URLDownloader(self.template_url).download_and_extract(self.test_directory)
         self.update_testing_module_build_identifiers(self._test_config.test_build_system, self._test_config.otf_version)

--- a/gdk/commands/test/InitCommand.py
+++ b/gdk/commands/test/InitCommand.py
@@ -28,7 +28,8 @@ class InitCommand(Command):
     def run(self):
         if self.test_directory.exists():
             logging.warning(
-                "Not downloading the uat template as '%s' already exists in the current directory.", consts.E2E_TESTS_DIR_NAME
+                "Not downloading the e2e_test template as '%s' already exists in the current directory.",
+                consts.E2E_TESTS_DIR_NAME,
             )
             return
         URLDownloader(self.template_url).download_and_extract(self.test_directory)

--- a/gdk/commands/test/InitCommand.py
+++ b/gdk/commands/test/InitCommand.py
@@ -5,7 +5,7 @@ from gdk.common.config.GDKProject import GDKProject
 
 import gdk.common.utils as utils
 from gdk.commands.Command import Command
-from gdk.build_system.UATBuildSystem import UATBuildSystem
+from gdk.build_system.E2ETestBuildSystem import E2ETestBuildSystem
 from gdk.common.URLDownloader import URLDownloader
 import gdk.common.consts as consts
 
@@ -28,7 +28,7 @@ class InitCommand(Command):
     def run(self):
         if self.test_directory.exists():
             logging.warning(
-                "Not downloading the e2e_test template as '%s' already exists in the current directory.",
+                "Not downloading the E2E testing template as '%s' already exists in the current directory.",
                 consts.E2E_TESTS_DIR_NAME,
             )
             return
@@ -36,14 +36,14 @@ class InitCommand(Command):
         self.update_testing_module_build_identifiers(self._test_config.test_build_system, self._test_config.otf_version)
 
     def update_testing_module_build_identifiers(self, build_system_str, otf_version):
-        build_system = UATBuildSystem.get(build_system_str)
+        build_system = E2ETestBuildSystem.get(build_system_str)
         for identifier in build_system.build_system_identifier:
             build_file = self.test_directory.joinpath(identifier)
 
             if not build_file.exists():
                 continue
 
-            logging.debug("Updating the testing jar version used in the UAT module '%s'", identifier)
+            logging.debug("Updating the testing jar version used in the E2E testing module '%s'", identifier)
             with open(build_file, "r", encoding="utf-8") as f:
                 build_file_content = f.read()
 

--- a/gdk/commands/test/RunCommand.py
+++ b/gdk/commands/test/RunCommand.py
@@ -48,8 +48,8 @@ class RunCommand(Command):
         """
         Return the test build directory
         """
-        uat_build_system = UATBuildSystem.get(self._test_build_system)
-        return self._test_directory.joinpath(*uat_build_system.build_folder).resolve()
+        e2e_test_build_system = UATBuildSystem.get(self._test_build_system)
+        return self._test_directory.joinpath(*e2e_test_build_system.build_folder).resolve()
 
     def _should_download_nucleus_archive(self, _nucleus_path: Path) -> bool:
         """

--- a/gdk/commands/test/RunCommand.py
+++ b/gdk/commands/test/RunCommand.py
@@ -68,11 +68,7 @@ class RunCommand(Command):
         _commands.extend(self._get_options_as_list())
         logging.info("Running test jar with command %s", " ".join(_commands))
 
-        _test_run_proc = sp.run(_commands, check=True, stdout=sp.PIPE, stderr=sp.STDOUT)
-        _cmd_successful = _test_run_proc.returncode == 0
-
-        if not _cmd_successful:
-            raise Exception("Exception occurred while running the test jar.\n " + _test_run_proc.stderr.decode("utf-8"))
+        sp.run(_commands, check=True)
 
     def _identify_testing_jar(self) -> Path:
         """

--- a/gdk/commands/test/RunCommand.py
+++ b/gdk/commands/test/RunCommand.py
@@ -1,6 +1,6 @@
 from gdk.commands.Command import Command
 from gdk.common.config.GDKProject import GDKProject
-from gdk.build_system.UATBuildSystem import UATBuildSystem
+from gdk.build_system.E2ETestBuildSystem import E2ETestBuildSystem
 from gdk.commands.test.config.RunConfiguration import RunConfiguration
 from pathlib import Path
 from gdk.common.URLDownloader import URLDownloader
@@ -28,7 +28,8 @@ class RunCommand(Command):
         """
         if not self._is_test_module_built():
             raise Exception(
-                "UAT module is not built. Please build the test module using `gdk test build`command before running the tests."
+                "E2E testing module is not built. Please build the test module using `gdk test build`command before running"
+                " the tests."
             )
 
         _nucleus_path = Path(self._config.options.get("ggc-archive"))
@@ -48,7 +49,7 @@ class RunCommand(Command):
         """
         Return the test build directory
         """
-        e2e_test_build_system = UATBuildSystem.get(self._test_build_system)
+        e2e_test_build_system = E2ETestBuildSystem.get(self._test_build_system)
         return self._test_directory.joinpath(*e2e_test_build_system.build_folder).resolve()
 
     def _should_download_nucleus_archive(self, _nucleus_path: Path) -> bool:

--- a/gdk/commands/test/RunCommand.py
+++ b/gdk/commands/test/RunCommand.py
@@ -6,13 +6,14 @@ from pathlib import Path
 from gdk.common.URLDownloader import URLDownloader
 import logging
 import subprocess as sp
+import gdk.common.consts as consts
 
 
 class RunCommand(Command):
     def __init__(self, command_args) -> None:
         super().__init__(command_args, "run")
         self._gdk_project = GDKProject()
-        self._test_directory = self._gdk_project.gg_build_dir.joinpath("uat-features").resolve()
+        self._test_directory = self._gdk_project.gg_build_dir.joinpath(consts.E2E_TESTS_DIR_NAME).resolve()
         self._test_build_system = self._gdk_project.test_config.test_build_system
         self._config = RunConfiguration(self._gdk_project, command_args)
         self._nucleus_archive_link = "https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-latest.zip"
@@ -77,12 +78,12 @@ class RunCommand(Command):
         """
         Identify testing jar from the build folder.
 
-        If uat-features-1.0.0.jar is in the build folder and is a testing jar, then return it.
+        If gg-e2e-tests-1.0.0.jar is in the build folder and is a testing jar, then return it.
         Otherwise, find all the *.jar files in the build folder and return the first one that is a testing jar.
         If nothing is found, an exception in thrown.
         """
         _test_build_dir = self._test_build_directory()
-        default_jar_path = _test_build_dir.joinpath("uat-features-1.0.0.jar").resolve()
+        default_jar_path = _test_build_dir.joinpath(f"{consts.E2E_TESTS_DIR_NAME}-1.0.0.jar").resolve()
 
         if default_jar_path.exists() and self._is_testing_jar(default_jar_path):
             return default_jar_path

--- a/gdk/common/consts.py
+++ b/gdk/common/consts.py
@@ -20,6 +20,7 @@ cli_project_config_file = "gdk-config.json"
 greengrass_build_dir = "greengrass-build"
 project_build_system_file = "project_build_system.json"
 project_build_schema_file = "project_build_schema.json"
+E2E_TESTS_DIR_NAME = "gg-e2e-tests"
 
 # URLS
 templates_list_url = (

--- a/gdk/common/parse_args_actions.py
+++ b/gdk/common/parse_args_actions.py
@@ -40,6 +40,7 @@ def call_action_by_name(method_name, d_args):
     -------
       None
     """
+    method_name = method_name.replace("-", "_hyphen_")
     method_to_call = getattr(command_methods, method_name, None)
     if method_to_call:
         logging.debug("Calling '{}'.".format(method_name))

--- a/gdk/static/cli_model.json
+++ b/gdk/static/cli_model.json
@@ -126,7 +126,7 @@
                 },
                 "help": "Initialize, build and publish GreengrassV2 components using this command."
             },
-            "test": {
+            "test-e2e": {
                 "sub-commands": {
                     "init": {
                         "help": "Initialize GDK project with user acceptance testing module"

--- a/gdk/static/cli_model_schema.json
+++ b/gdk/static/cli_model_schema.json
@@ -14,14 +14,14 @@
                 "sub-commands": {
                     "required": [
                         "component",
-                        "test"
+                        "test-e2e"
                     ],
                     "properties": {
                         "component": {
                             "$ref": "#/$defs/component"
                         },
-                        "test": {
-                            "$ref": "#/$defs/test"
+                        "test-e2e": {
+                            "$ref": "#/$defs/test-e2e"
                         }
                     },
                     "additionalProperties": false
@@ -245,7 +245,7 @@
             },
             "additionalProperties": false
         },
-        "test": {
+        "test-e2e": {
             "type": "object",
             "description": "A command of gdk cli tool. This is one of the sub parsers under the top-level parser ('gdk') of the cli.",
             "properties": {
@@ -256,10 +256,10 @@
                     ],
                     "properties": {
                         "init": {
-                            "$ref": "#/$defs/test-init"
+                            "$ref": "#/$defs/test-e2e-init"
                         },
                         "run": {
-                            "$ref": "#/$defs/test-run"
+                            "$ref": "#/$defs/test-e2e-run"
                         }
                     }
                 },
@@ -269,7 +269,7 @@
             },
             "additionalProperties": false
         },
-        "test-init": {
+        "test-e2e-init": {
             "type": "object",
             "description": "Sub command under 'test' command. This is one of the sub-parsers under 'test' parser.",
             "required": [
@@ -282,7 +282,7 @@
             },
             "additionalProperties": false
         },
-        "test-run": {
+        "test-e2e-run": {
             "type": "object",
             "description": "Sub command under 'test' command. This is one of the sub-parsers under 'test' parser.",
             "required": [

--- a/integration_tests/gdk/build_system/test_GDKBuildSystem.py
+++ b/integration_tests/gdk/build_system/test_GDKBuildSystem.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from gdk.build_system.UATBuildSystem import UATBuildSystem
+from gdk.build_system.E2ETestBuildSystem import E2ETestBuildSystem
 from pathlib import Path
 import os
 import shutil
@@ -24,7 +24,7 @@ class GDKBuildSystemTest(TestCase):
         shutil.copytree(source, dest)
         os.chdir(dest)
 
-        build_system = UATBuildSystem.get("maven")
+        build_system = E2ETestBuildSystem.get("maven")
         build_system.build()
 
         target_folder = dest.joinpath("target").joinpath("HelloWorld-1.0.0.jar").resolve()

--- a/integration_tests/gdk/test/test_integ_uat_BuildCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_BuildCommand.py
@@ -21,7 +21,7 @@ class UATBuildCommandTest(TestCase):
         yield
         os.chdir(self.c_dir)
 
-    def test_when_test_module_build_then_update_features_create_uat_recipe(self):
+    def test_when_test_module_build_then_update_features_create_e2e_test_recipe(self):
         self.setup_test_data_config("config.json")
         shutil.copy(
             Path(self.c_dir).joinpath("integration_tests/test_data/recipes/").joinpath("build_recipe.yaml").resolve(),
@@ -36,17 +36,17 @@ class UATBuildCommandTest(TestCase):
         build_command = BuildCommand({})
         build_command.run()
 
-        uat_recipe_file = Path(self.tmpdir).joinpath("greengrass-build/recipes").joinpath("uat_recipe.yaml")
-        uat_features = Path(self.tmpdir).joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}")
+        e2e_test_recipe_file = Path(self.tmpdir).joinpath("greengrass-build/recipes").joinpath("e2e_test_recipe.yaml")
+        e2e_test_features = Path(self.tmpdir).joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}")
 
-        assert uat_recipe_file.exists()
-        assert uat_features.exists()
-        with open(uat_recipe_file, mode="r") as f:
+        assert e2e_test_recipe_file.exists()
+        assert e2e_test_features.exists()
+        with open(e2e_test_recipe_file, mode="r") as f:
             content = f.read()
             assert Path(self.tmpdir).joinpath("greengrass-build/artifacts/abc/NEXT_PATCH").as_uri() in content
-        with open(uat_features.joinpath("src/main/resources/greengrass/features/component.feature"), mode="r") as f:
+        with open(e2e_test_features.joinpath("src/main/resources/greengrass/features/component.feature"), mode="r") as f:
             content = f.read()
-            assert uat_recipe_file.as_uri() in content
+            assert e2e_test_recipe_file.as_uri() in content
 
         with open(
             Path(self.tmpdir).joinpath(
@@ -55,49 +55,49 @@ class UATBuildCommandTest(TestCase):
             mode="r",
         ) as f:
             content = f.read()
-            assert uat_recipe_file.as_uri() not in content
+            assert e2e_test_recipe_file.as_uri() not in content
 
-    def test_when_test_module_build_then_cleanup_if_uat_folder_exists(self):
+    def test_when_test_module_build_then_cleanup_if_e2e_test_folder_exists(self):
         self.setup_test_data_config("config.json")
         shutil.copy(
             Path(self.c_dir).joinpath("integration_tests/test_data/recipes/").joinpath("build_recipe.yaml").resolve(),
             Path(self.tmpdir).joinpath("greengrass-build/recipes").joinpath("recipe.yaml").resolve(),
         )
 
-        uat_build_folder = Path(self.tmpdir).joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}")
-        uat_build_folder.parent.mkdir(parents=True, exist_ok=True)
+        e2e_test_build_folder = Path(self.tmpdir).joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}")
+        e2e_test_build_folder.parent.mkdir(parents=True, exist_ok=True)
 
         self.mocker.patch("shutil.copytree", return_value=None)
         self.mocker.patch.object(BuildCommand, "update_feature_files", return_value=None)
-        self.mocker.patch.object(BuildCommand, "create_uat_recipe_file", return_value=None)
-        self.mocker.patch.object(BuildCommand, "build_uat_module", return_value=None)
+        self.mocker.patch.object(BuildCommand, "create_e2e_test_recipe_file", return_value=None)
+        self.mocker.patch.object(BuildCommand, "build_e2e_test_module", return_value=None)
 
         # Test
         build_command = BuildCommand({})
         build_command.run()
 
-        assert not uat_build_folder.exists()
+        assert not e2e_test_build_folder.exists()
 
-    def test_when_test_module_build_with_no_interpolation_then_do_not_create_uat_recipe_file(self):
+    def test_when_test_module_build_with_no_interpolation_then_do_not_create_e2e_test_recipe_file(self):
         # Setup test data. Update the feature files ahead so the build command has nothing to update.
         self.setup_test_data_config("config.json")
-        uat_features = Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME)
-        with open(uat_features.joinpath("src/main/resources/greengrass/features/component.feature"), mode="r") as f:
+        e2e_test_features = Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME)
+        with open(e2e_test_features.joinpath("src/main/resources/greengrass/features/component.feature"), mode="r") as f:
             content = f.read()
             content = content.replace("GDK_COMPONENT_NAME", "some-component-name").replace(
                 "GDK_COMPONENT_RECIPE_FILE", "some-recipe-file"
             )
 
-        with open(uat_features.joinpath("src/main/resources/greengrass/features/component.feature"), mode="w") as f:
+        with open(e2e_test_features.joinpath("src/main/resources/greengrass/features/component.feature"), mode="w") as f:
             f.write(content)
 
         # Test
         build_command = BuildCommand({})
         build_command.run()
-        uat_recipe_file = Path(self.tmpdir).joinpath("greengrass-build/recipes").joinpath("uat_recipe.yaml")
+        e2e_test_recipe_file = Path(self.tmpdir).joinpath("greengrass-build/recipes").joinpath("e2e_test_recipe.yaml")
 
         assert Path(self.tmpdir).joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}").exists()
-        assert not uat_recipe_file.exists()
+        assert not e2e_test_recipe_file.exists()
 
     def test_when_test_module_build_with_interpolation_and_component_not_built_then_raise_exception(self):
         self.setup_test_data_config("config.json")

--- a/integration_tests/gdk/test/test_integ_uat_BuildCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_BuildCommand.py
@@ -9,7 +9,7 @@ import shutil
 import gdk.common.consts as consts
 
 
-class UATBuildCommandTest(TestCase):
+class E2ETestBuildCommandTest(TestCase):
     @pytest.fixture(autouse=True)
     def __inject_fixtures(self, mocker, tmpdir):
         self.mocker = mocker

--- a/integration_tests/gdk/test/test_integ_uat_BuildCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_BuildCommand.py
@@ -6,6 +6,7 @@ import os
 from gdk.commands.test.BuildCommand import BuildCommand
 from gdk.build_system.Maven import Maven
 import shutil
+import gdk.common.consts as consts
 
 
 class UATBuildCommandTest(TestCase):
@@ -36,7 +37,7 @@ class UATBuildCommandTest(TestCase):
         build_command.run()
 
         uat_recipe_file = Path(self.tmpdir).joinpath("greengrass-build/recipes").joinpath("uat_recipe.yaml")
-        uat_features = Path(self.tmpdir).joinpath("greengrass-build/uat-features")
+        uat_features = Path(self.tmpdir).joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}")
 
         assert uat_recipe_file.exists()
         assert uat_features.exists()
@@ -48,7 +49,10 @@ class UATBuildCommandTest(TestCase):
             assert uat_recipe_file.as_uri() in content
 
         with open(
-            Path(self.tmpdir).joinpath("uat-features/src/main/resources/greengrass/features/component.feature"), mode="r"
+            Path(self.tmpdir).joinpath(
+                f"{consts.E2E_TESTS_DIR_NAME}/src/main/resources/greengrass/features/component.feature"
+            ),
+            mode="r",
         ) as f:
             content = f.read()
             assert uat_recipe_file.as_uri() not in content
@@ -60,7 +64,7 @@ class UATBuildCommandTest(TestCase):
             Path(self.tmpdir).joinpath("greengrass-build/recipes").joinpath("recipe.yaml").resolve(),
         )
 
-        uat_build_folder = Path(self.tmpdir).joinpath("greengrass-build/uat-features")
+        uat_build_folder = Path(self.tmpdir).joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}")
         uat_build_folder.parent.mkdir(parents=True, exist_ok=True)
 
         self.mocker.patch("shutil.copytree", return_value=None)
@@ -77,7 +81,7 @@ class UATBuildCommandTest(TestCase):
     def test_when_test_module_build_with_no_interpolation_then_do_not_create_uat_recipe_file(self):
         # Setup test data. Update the feature files ahead so the build command has nothing to update.
         self.setup_test_data_config("config.json")
-        uat_features = Path(self.tmpdir).joinpath("uat-features")
+        uat_features = Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME)
         with open(uat_features.joinpath("src/main/resources/greengrass/features/component.feature"), mode="r") as f:
             content = f.read()
             content = content.replace("GDK_COMPONENT_NAME", "some-component-name").replace(
@@ -92,7 +96,7 @@ class UATBuildCommandTest(TestCase):
         build_command.run()
         uat_recipe_file = Path(self.tmpdir).joinpath("greengrass-build/recipes").joinpath("uat_recipe.yaml")
 
-        assert Path(self.tmpdir).joinpath("greengrass-build/uat-features").exists()
+        assert Path(self.tmpdir).joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}").exists()
         assert not uat_recipe_file.exists()
 
     def test_when_test_module_build_with_interpolation_and_component_not_built_then_raise_exception(self):
@@ -111,5 +115,5 @@ class UATBuildCommandTest(TestCase):
             Path(self.c_dir).joinpath("integration_tests/test_data/templates/TestTemplateForCLI.zip").resolve(),
             extract_dir=Path(self.tmpdir),
         )
-        shutil.move(Path(self.tmpdir).joinpath("TestTemplateForCLI"), Path(self.tmpdir).joinpath("uat-features"))
+        shutil.move(Path(self.tmpdir).joinpath("TestTemplateForCLI"), Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME))
         Path(self.tmpdir).joinpath("greengrass-build/recipes").mkdir(parents=True)

--- a/integration_tests/gdk/test/test_integ_uat_InitCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_InitCommand.py
@@ -9,7 +9,7 @@ from urllib3.exceptions import HTTPError
 import gdk.common.consts as consts
 
 
-class UATInitCommandTest(TestCase):
+class E2ETestInitCommandTest(TestCase):
     @pytest.fixture(autouse=True)
     def __inject_fixtures(self, mocker, tmpdir):
         self.mocker = mocker

--- a/integration_tests/gdk/test/test_integ_uat_InitCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_InitCommand.py
@@ -6,6 +6,7 @@ import os
 from gdk.commands.test.InitCommand import InitCommand
 import shutil
 from urllib3.exceptions import HTTPError
+import gdk.common.consts as consts
 
 
 class UATInitCommandTest(TestCase):
@@ -32,7 +33,7 @@ class UATInitCommandTest(TestCase):
         self.mocker.patch.object(InitCommand, "update_testing_module_build_identifiers")
         InitCommand({}).run()
         assert self.mock_template_download.call_args_list == [call(self.url_for_template, stream=True, timeout=30)]
-        uat_folder = Path(self.tmpdir).joinpath("uat-features")
+        uat_folder = Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME)
         assert uat_folder.exists()
         assert uat_folder.joinpath("pom.xml") in list(uat_folder.iterdir())
         # Downloaded template has GDK_TESTING_VERSION variable in pom.xml
@@ -43,22 +44,22 @@ class UATInitCommandTest(TestCase):
     def test_init_run_gdk_project_already_initiated(self):
         self.setup_test_data_config("config.json")
         self.mocker.patch.object(InitCommand, "update_testing_module_build_identifiers")
-        # uat-features already exists but is empty
-        Path(self.tmpdir).joinpath("uat-features").mkdir()
+        # consts.E2E_TESTS_DIR_NAME already exists but is empty
+        Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME).mkdir()
 
         InitCommand({}).run()
         assert not self.mock_template_download.called
-        # existing uat-features folder is not overridden
-        assert Path(self.tmpdir).resolve("uat-features").exists()
-        assert list(Path(self.tmpdir).joinpath("uat-features").iterdir()) == []
+        # existing consts.E2E_TESTS_DIR_NAME folder is not overridden
+        assert Path(self.tmpdir).resolve(consts.E2E_TESTS_DIR_NAME).exists()
+        assert list(Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME).iterdir()) == []
 
     def test_init_run_gdk_project_update_otf_version(self):
         self.setup_test_data_config("config.json")
         InitCommand({}).run()
         assert self.mock_template_download.call_args_list == [call(self.url_for_template, stream=True, timeout=30)]
 
-        # existing uat-features folder is not overridden
-        uat_folder = Path(self.tmpdir).joinpath("uat-features")
+        # existing consts.E2E_TESTS_DIR_NAME folder is not overridden
+        uat_folder = Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME)
         assert uat_folder.exists()
         # OTF version is updated in pom.xml
         with open(uat_folder.joinpath("pom.xml"), "r", encoding="utf-8") as f:
@@ -78,7 +79,7 @@ class UATInitCommandTest(TestCase):
             InitCommand({}).run()
             assert self.mock_template_download.call_args_list == [call(self.url_for_template, stream=True, timeout=30)]
             assert "some error" in e.value.args[0]
-        assert not Path(self.tmpdir).joinpath("uat-features").exists()
+        assert not Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME).exists()
 
     def setup_test_data_config(self, config_file):
         # Setup test data

--- a/integration_tests/gdk/test/test_integ_uat_InitCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_InitCommand.py
@@ -33,11 +33,11 @@ class UATInitCommandTest(TestCase):
         self.mocker.patch.object(InitCommand, "update_testing_module_build_identifiers")
         InitCommand({}).run()
         assert self.mock_template_download.call_args_list == [call(self.url_for_template, stream=True, timeout=30)]
-        uat_folder = Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME)
-        assert uat_folder.exists()
-        assert uat_folder.joinpath("pom.xml") in list(uat_folder.iterdir())
+        e2e_test_folder = Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME)
+        assert e2e_test_folder.exists()
+        assert e2e_test_folder.joinpath("pom.xml") in list(e2e_test_folder.iterdir())
         # Downloaded template has GDK_TESTING_VERSION variable in pom.xml
-        with open(uat_folder.joinpath("pom.xml"), "r", encoding="utf-8") as f:
+        with open(e2e_test_folder.joinpath("pom.xml"), "r", encoding="utf-8") as f:
             content = f.read()
             assert "GDK_TESTING_VERSION" in content
 
@@ -59,10 +59,10 @@ class UATInitCommandTest(TestCase):
         assert self.mock_template_download.call_args_list == [call(self.url_for_template, stream=True, timeout=30)]
 
         # existing consts.E2E_TESTS_DIR_NAME folder is not overridden
-        uat_folder = Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME)
-        assert uat_folder.exists()
+        e2e_test_folder = Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME)
+        assert e2e_test_folder.exists()
         # OTF version is updated in pom.xml
-        with open(uat_folder.joinpath("pom.xml"), "r", encoding="utf-8") as f:
+        with open(e2e_test_folder.joinpath("pom.xml"), "r", encoding="utf-8") as f:
             content = f.read()
             assert "GDK_TESTING_VERSION" not in content
             # OTF version set in config file

--- a/integration_tests/gdk/test/test_integ_uat_RunCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_RunCommand.py
@@ -30,7 +30,7 @@ class UATRunCommandTest(TestCase):
         yield
         os.chdir(self.c_dir)
 
-    def test_given_test_module_not_built_when_run_uats_then_raise_an_exception(self):
+    def test_given_test_module_not_built_when_run_e2e_tests_then_raise_an_exception(self):
         self.setup_test_data_config("config_without_test.json")
         run_command = RunCommand({})
         with pytest.raises(Exception) as e:
@@ -40,7 +40,7 @@ class UATRunCommandTest(TestCase):
             + "command before running the tests."
         ) in e.value.args[0]
 
-    def test_given_test_module_and_nucleus_archive_built_when_run_uats_then_run_uats(self):
+    def test_given_test_module_and_nucleus_archive_built_when_run_e2e_tests_then_run_e2e_tests(self):
         # Given
         self.setup_test_data_config("config_without_test.json")
         run_jar = self.mocker.patch("gdk.commands.test.RunCommand.RunCommand.run_testing_jar", return_value=None)
@@ -58,7 +58,7 @@ class UATRunCommandTest(TestCase):
         assert not url_downloader.called
         assert run_jar.called
 
-    def test_given_module_built_and_nucleus_zip_not_exists_when_run_uats_then_download_nucleus_and_run_uats(self):
+    def test_given_module_built_and_nucleus_zip_not_exists_when_run_e2e_tests_then_download_nucleus_and_run_e2e_tests(self):
         # Given
         self.setup_test_data_config("config_without_test.json")
         run_jar = self.mocker.patch("gdk.commands.test.RunCommand.RunCommand.run_testing_jar", return_value=None)
@@ -88,7 +88,7 @@ class UATRunCommandTest(TestCase):
             run_command.run()
         assert "Unable to find testing jar in the build folder" in e.value.args[0]
 
-    def test_given_ggc_archive_config_and_nucleus_zip_not_exists_when_run_uats_then_raise_an_exception(self):
+    def test_given_ggc_archive_config_and_nucleus_zip_not_exists_when_run_e2e_tests_then_raise_an_exception(self):
         # Given
         self.setup_test_data_config("config_without_test.json")
         run_jar = self.mocker.patch("gdk.commands.test.RunCommand.RunCommand.run_testing_jar", return_value=None)
@@ -127,7 +127,7 @@ class UATRunCommandTest(TestCase):
             run_command.run()
         assert "Unable to find testing jar in the build folder" in e.value.args[0]
 
-    def test_given_multiple_jars_and_when_run_uats_then_identify_default_jar_and_run_uats(self):
+    def test_given_multiple_jars_and_when_run_e2e_tests_then_identify_default_jar_and_run_e2e_tests(self):
         # Given
         self.setup_test_data_config("config_without_test.json")
         self.update_pom()
@@ -182,7 +182,7 @@ class UATRunCommandTest(TestCase):
             ]
         )
 
-    def test_given_multiple_jars_and_when_run_uats_with_non_default_jar_and_exception_then_raise_an_exception(self):
+    def test_given_multiple_jars_and_when_run_e2e_tests_with_non_default_jar_and_exception_then_raise_an_exception(self):
         # Given
         self.setup_test_data_config("config_without_test.json")
         self.update_pom()

--- a/integration_tests/gdk/test/test_integ_uat_RunCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_RunCommand.py
@@ -11,7 +11,7 @@ import json
 import gdk.common.consts as consts
 
 
-class UATRunCommandTest(TestCase):
+class E2ETestRunCommandTest(TestCase):
     @pytest.fixture(autouse=True)
     def __inject_fixtures(self, mocker, tmpdir):
         self.mocker = mocker

--- a/integration_tests/gdk/test/test_integ_uat_RunCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_RunCommand.py
@@ -36,7 +36,7 @@ class UATRunCommandTest(TestCase):
         with pytest.raises(Exception) as e:
             run_command.run()
         assert (
-            "UAT module is not built. Please build the test module using `gdk test build`"
+            "E2E testing module is not built. Please build the test module using `gdk test build`"
             + "command before running the tests."
         ) in e.value.args[0]
 
@@ -196,9 +196,13 @@ class UATRunCommandTest(TestCase):
         _nucleus_path.touch()
 
         def _sp_run(self, *args, **kwargs):
-            if set(self) == set(["java", "-jar", str(_non_default_jar), "--help"]):
-                return sp.CompletedProcess(self, returncode=0, stdout="gg-test".encode())
-            return sp.CompletedProcess(self, returncode=1, stderr=b"Error running jar")
+            if "--help" in set(self):
+                if set(self) == set(["java", "-jar", str(_non_default_jar), "--help"]):
+                    return sp.CompletedProcess(self, returncode=0, stdout="gg-test".encode())
+                else:
+                    return sp.CompletedProcess(self, returncode=1, stderr=b"Error running jar")
+            else:
+                raise Exception("Error running jar")
 
         sp_run = self.mocker.patch.object(sp, "run", side_effect=_sp_run)
         run_command = RunCommand({})

--- a/integration_tests/gdk/test/test_integ_uat_RunCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_RunCommand.py
@@ -8,6 +8,7 @@ import shutil
 from gdk.common.URLDownloader import URLDownloader
 import subprocess as sp
 import json
+import gdk.common.consts as consts
 
 
 class UATRunCommandTest(TestCase):
@@ -43,7 +44,7 @@ class UATRunCommandTest(TestCase):
         # Given
         self.setup_test_data_config("config_without_test.json")
         run_jar = self.mocker.patch("gdk.commands.test.RunCommand.RunCommand.run_testing_jar", return_value=None)
-        target_path = self.tmpdir.joinpath("greengrass-build/uat-features/target")
+        target_path = self.tmpdir.joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target")
         _nucleus_path = self.tmpdir.joinpath("greengrass-build/greengrass-nucleus-latest.zip")
         url_downloader = self.mocker.patch.object(URLDownloader, "download", return_value=target_path)
         target_path.mkdir(parents=True)
@@ -61,7 +62,7 @@ class UATRunCommandTest(TestCase):
         # Given
         self.setup_test_data_config("config_without_test.json")
         run_jar = self.mocker.patch("gdk.commands.test.RunCommand.RunCommand.run_testing_jar", return_value=None)
-        target_path = self.tmpdir.joinpath("greengrass-build/uat-features/target")
+        target_path = self.tmpdir.joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target")
         _nucleus_path = self.tmpdir.joinpath("greengrass-build/greengrass-nucleus-latest.zip")
         target_path.mkdir(parents=True)
 
@@ -76,7 +77,7 @@ class UATRunCommandTest(TestCase):
     def test_given_built_module_and_nucleus_zip_when_no_testing_jar_found_then_raise_an_exception(self):
         # Given
         self.setup_test_data_config("config_without_test.json")
-        target_path = self.tmpdir.joinpath("greengrass-build/uat-features/target")
+        target_path = self.tmpdir.joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target")
         _nucleus_path = self.tmpdir.joinpath("greengrass-build/greengrass-nucleus-latest.zip")
         target_path.mkdir(parents=True)
         _nucleus_path.touch()
@@ -97,7 +98,7 @@ class UATRunCommandTest(TestCase):
         with open(Path().joinpath("gdk-config.json"), "w") as f:
             f.write(json.dumps(content))
 
-        target_path = self.tmpdir.joinpath("greengrass-build/uat-features/target")
+        target_path = self.tmpdir.joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target")
         target_path.mkdir(parents=True)
 
         # When and then
@@ -113,11 +114,11 @@ class UATRunCommandTest(TestCase):
     def test_given_multiple_jars_and_when_not_testing_jar_found_then_raise_an_exception(self):
         # Given
         self.setup_test_data_config("config_without_test.json")
-        target_path = self.tmpdir.joinpath("greengrass-build/uat-features/target")
+        target_path = self.tmpdir.joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target")
         _nucleus_path = self.tmpdir.joinpath("greengrass-build/greengrass-nucleus-latest.zip")
         target_path.mkdir(parents=True)
         _nucleus_path.touch()
-        target_path.joinpath("uat-features-1.0.0.jar").touch()
+        target_path.joinpath(f"{consts.E2E_TESTS_DIR_NAME}-1.0.0.jar").touch()
         target_path.joinpath("b.jar").touch()
 
         run_command = RunCommand({})
@@ -132,17 +133,26 @@ class UATRunCommandTest(TestCase):
         self.update_pom()
 
         # Build test module
-        shutil.copytree(self.tmpdir.joinpath("uat-features"), self.tmpdir.joinpath("greengrass-build/uat-features/"))
+        shutil.copytree(
+            self.tmpdir.joinpath(consts.E2E_TESTS_DIR_NAME),
+            self.tmpdir.joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/"),
+        )
 
-        Path().joinpath("greengrass-build/uat-features/target/").mkdir(parents=True)
-        Path().joinpath("greengrass-build/uat-features/target/uat-features-1.0.0.jar").resolve().touch()
-        Path().joinpath("greengrass-build/uat-features/target/b.jar").resolve().touch()
+        Path().joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target/").mkdir(parents=True)
+        Path().joinpath(
+            f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target/{consts.E2E_TESTS_DIR_NAME}-1.0.0.jar"
+        ).resolve().touch()
+        Path().joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target/b.jar").resolve().touch()
 
         # nucleus archive exists
         _nucleus_path = self.tmpdir.joinpath("greengrass-build/greengrass-nucleus-latest.zip")
         _nucleus_path.touch()
 
-        jar = str(Path().joinpath("greengrass-build/uat-features/target/uat-features-1.0.0.jar").resolve())
+        jar = str(
+            Path()
+            .joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target/{consts.E2E_TESTS_DIR_NAME}-1.0.0.jar")
+            .resolve()
+        )
 
         def _sp_run(self, *args, **kwargs):
             if set(self) == set(["java", "-jar", jar, "--help"]):
@@ -177,11 +187,11 @@ class UATRunCommandTest(TestCase):
         self.setup_test_data_config("config_without_test.json")
         self.update_pom()
 
-        Path().joinpath("greengrass-build/uat-features/target/").mkdir(parents=True)
-        Path().joinpath("greengrass-build/uat-features/target/a.jar").resolve().touch()
-        Path().joinpath("greengrass-build/uat-features/target/b.jar").resolve().touch()
+        Path().joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target/").mkdir(parents=True)
+        Path().joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target/a.jar").resolve().touch()
+        Path().joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target/b.jar").resolve().touch()
 
-        _non_default_jar = Path().joinpath("greengrass-build/uat-features/target/a.jar").resolve()
+        _non_default_jar = Path().joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target/a.jar").resolve()
         _nucleus_path = self.tmpdir.joinpath("greengrass-build/greengrass-nucleus-latest.zip")
         _nucleus_path.touch()
 
@@ -213,12 +223,12 @@ class UATRunCommandTest(TestCase):
             Path(self.c_dir).joinpath("integration_tests/test_data/templates/TestTemplateForCLI.zip").resolve(),
             extract_dir=Path(self.tmpdir),
         )
-        shutil.move(Path(self.tmpdir).joinpath("TestTemplateForCLI"), Path(self.tmpdir).joinpath("uat-features"))
+        shutil.move(Path(self.tmpdir).joinpath("TestTemplateForCLI"), Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME))
         Path(self.tmpdir).joinpath("greengrass-build/recipes").mkdir(parents=True)
 
     def update_pom(self):
-        with open(self.tmpdir.joinpath("uat-features/pom.xml"), "r") as f:
+        with open(self.tmpdir.joinpath(f"{consts.E2E_TESTS_DIR_NAME}/pom.xml"), "r") as f:
             content = f.read()
 
-        with open(self.tmpdir.joinpath("uat-features/pom.xml"), "w") as f:
+        with open(self.tmpdir.joinpath(f"{consts.E2E_TESTS_DIR_NAME}/pom.xml"), "w") as f:
             f.write(content.replace("GDK_TESTING_VERSION", "1.0.0-SNAPSHOT"))

--- a/integration_tests/gdk/test_integ_CLIParser.py
+++ b/integration_tests/gdk/test_integ_CLIParser.py
@@ -35,21 +35,21 @@ def test_main_parse_args_list(mocker):
 
 def test_main_parse_args_test_init(mocker):
     mock_test_init = mocker.patch("gdk.commands.test.test.init", return_value=None)
-    args = CLIParser.cli_parser.parse_args(["test", "init"])
+    args = CLIParser.cli_parser.parse_args(["test-e2e", "init"])
     parse_args_actions.run_command(args)
     assert mock_test_init.called
 
 
 def test_main_parse_args_test_run(mocker):
     mock_test_run = mocker.patch("gdk.commands.test.test.run", return_value=None)
-    args = CLIParser.cli_parser.parse_args(["test", "run"])
+    args = CLIParser.cli_parser.parse_args(["test-e2e", "run"])
     parse_args_actions.run_command(args)
     assert mock_test_run.called
 
 
 def test_main_parse_args_test_build(mocker):
     mock_test_build = mocker.patch("gdk.commands.test.test.build", return_value=None)
-    args = CLIParser.cli_parser.parse_args(["test", "build"])
+    args = CLIParser.cli_parser.parse_args(["test-e2e", "build"])
     parse_args_actions.run_command(args)
     assert mock_test_build.called
 
@@ -60,4 +60,6 @@ def test_main_parse_args_gdk(capsys):
     command_output = capsys.readouterr().out
     CLIParser.cli_parser.print_help()
     help_output = capsys.readouterr().out
+    print(command_output)
+    print(help_output)
     assert command_output == help_output

--- a/tests/gdk/build_system/test_UATBuildSystem.py
+++ b/tests/gdk/build_system/test_UATBuildSystem.py
@@ -1,18 +1,18 @@
 from unittest import TestCase
 import pytest
-from gdk.build_system.UATBuildSystem import UATBuildSystem
+from gdk.build_system.E2ETestBuildSystem import E2ETestBuildSystem
 from unittest.mock import call
 import platform
 
 
-class UATBuildSystemTests(TestCase):
+class E2ETestBuildSystemTests(TestCase):
     @pytest.fixture(autouse=True)
     def __inject_fixtures(self, mocker):
         self.mocker = mocker
 
     def test_maven_build_system(self):
         mock_subprocess = self.mocker.patch("subprocess.run")
-        build_system = UATBuildSystem.get("maven")
+        build_system = E2ETestBuildSystem.get("maven")
         build_system.build()
 
         assert build_system.build_folder == ["target"]
@@ -24,7 +24,7 @@ class UATBuildSystemTests(TestCase):
 
     def test_gradle_build_system(self):
         mock_subprocess = self.mocker.patch("subprocess.run")
-        build_system = UATBuildSystem.get("gradle")
+        build_system = E2ETestBuildSystem.get("gradle")
         build_system.build()
 
         assert build_system.build_folder == ["build", "libs"]
@@ -33,7 +33,7 @@ class UATBuildSystemTests(TestCase):
 
     def test_gradle_wrapper_build_system(self):
         mock_subprocess = self.mocker.patch("subprocess.run")
-        build_system = UATBuildSystem.get("gradlew")
+        build_system = E2ETestBuildSystem.get("gradlew")
         build_system.build()
 
         assert build_system.build_folder == ["build", "libs"]
@@ -46,10 +46,10 @@ class UATBuildSystemTests(TestCase):
 
     def test_build_system_not_supported(self):
         with pytest.raises(Exception) as e:
-            UATBuildSystem.get("does-not-exist")
+            E2ETestBuildSystem.get("does-not-exist")
         assert "Build system type 'does-not-exist' is not supported" in e.value.args[0]
 
     def test_build_system_empty_(self):
         with pytest.raises(Exception) as e:
-            UATBuildSystem.get("  ")
+            E2ETestBuildSystem.get("  ")
         assert "Build system not specified" in e.value.args[0]

--- a/tests/gdk/commands/test/test_uat_BuildCommand.py
+++ b/tests/gdk/commands/test/test_uat_BuildCommand.py
@@ -7,6 +7,7 @@ from unittest import mock
 import platform
 from gdk.common.CaseInsensitive import CaseInsensitiveDict, CaseInsensitiveRecipeFile
 import os
+import gdk.common.consts as consts
 
 
 class BuildCommandUnitTest(TestCase):
@@ -191,10 +192,14 @@ class BuildCommandUnitTest(TestCase):
                 call(
                     ["mvn.cmd", "package"],
                     check=True,
-                    cwd=Path().absolute().joinpath("greengrass-build/uat-features").resolve(),
+                    cwd=Path().absolute().joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}").resolve(),
                 )
             ]
         else:
             assert uat_build_cmd.call_args_list == [
-                call(["mvn", "package"], check=True, cwd=Path().absolute().joinpath("greengrass-build/uat-features").resolve())
+                call(
+                    ["mvn", "package"],
+                    check=True,
+                    cwd=Path().absolute().joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}").resolve(),
+                )
             ]

--- a/tests/gdk/commands/test/test_uat_RunCommand.py
+++ b/tests/gdk/commands/test/test_uat_RunCommand.py
@@ -35,7 +35,7 @@ class RunCommandUnitTest(TestCase):
         yield
         os.chdir(self.c_dir)
 
-    def test_given_test_module_not_built_when_run_uats_then_raise_exception(self):
+    def test_given_test_module_not_built_when_run_e2e_tests_then_raise_exception(self):
         def file_exists(self):
             return str(self) != str(Path().resolve().joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target"))
 
@@ -46,7 +46,7 @@ class RunCommandUnitTest(TestCase):
             run_cmd.run()
         assert "UAT module is not built." in e.value.args[0]
 
-    def test_given_nucleus_archive_at_default_path_when_run_uats_then_do_not_download_nucleus(self):
+    def test_given_nucleus_archive_at_default_path_when_run_e2e_tests_then_do_not_download_nucleus(self):
         mock_downloader = self.mocker.patch.object(URLDownloader, "download")
         self.mock_jar = self.mocker.patch("gdk.commands.test.RunCommand.RunCommand.run_testing_jar", return_value=None)
         self.mocker.patch("pathlib.Path.exists", return_value=True)
@@ -55,7 +55,7 @@ class RunCommandUnitTest(TestCase):
 
         assert not mock_downloader.called
 
-    def test_given_nucleus_does_not_exists_at_default_path_when_run_uats_then_download_nucleus(self):
+    def test_given_nucleus_does_not_exists_at_default_path_when_run_e2e_tests_then_download_nucleus(self):
         default_path = Path().resolve().joinpath("greengrass-build/greengrass-nucleus-latest.zip")
         self.mock_jar = self.mocker.patch("gdk.commands.test.RunCommand.RunCommand.run_testing_jar", return_value=None)
 

--- a/tests/gdk/commands/test/test_uat_RunCommand.py
+++ b/tests/gdk/commands/test/test_uat_RunCommand.py
@@ -5,7 +5,7 @@ from gdk.commands.test.RunCommand import RunCommand
 from pathlib import Path
 import os
 from gdk.common.URLDownloader import URLDownloader
-
+import gdk.common.consts as consts
 import subprocess as sp
 
 
@@ -37,7 +37,7 @@ class RunCommandUnitTest(TestCase):
 
     def test_given_test_module_not_built_when_run_uats_then_raise_exception(self):
         def file_exists(self):
-            return str(self) != str(Path().resolve().joinpath("greengrass-build/uat-features/target"))
+            return str(self) != str(Path().resolve().joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target"))
 
         self.mock_jar = self.mocker.patch("gdk.commands.test.RunCommand.RunCommand.run_testing_jar", return_value=None)
         self.mocker.patch.object(Path, "exists", file_exists)
@@ -74,14 +74,20 @@ class RunCommandUnitTest(TestCase):
         _jar_identifier_args = [
             "java",
             "-jar",
-            Path().absolute().joinpath("greengrass-build/uat-features/target/uat-features-1.0.0.jar").__str__(),
+            Path()
+            .absolute()
+            .joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target/{consts.E2E_TESTS_DIR_NAME}-1.0.0.jar")
+            .__str__(),
             "--help",
         ]
 
         _jar_testing_args = [
             "java",
             "-jar",
-            Path().absolute().joinpath("greengrass-build/uat-features/target/uat-features-1.0.0.jar").__str__(),
+            Path()
+            .absolute()
+            .joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target/{consts.E2E_TESTS_DIR_NAME}-1.0.0.jar")
+            .__str__(),
             "--tags=Sample",
             "--ggc-archive=" + Path().absolute().joinpath("greengrass-build/greengrass-nucleus-latest.zip").__str__(),
         ]
@@ -106,7 +112,11 @@ class RunCommandUnitTest(TestCase):
         # self.mocker.patch("pathlib.Path.exists", return_value=True)
 
         def file_exists(self):
-            return str(self) != str(Path().resolve().joinpath("greengrass-build/uat-features/target/uat-features-1.0.0.jar"))
+            return str(self) != str(
+                Path()
+                .resolve()
+                .joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target/{consts.E2E_TESTS_DIR_NAME}-1.0.0.jar")
+            )
 
         def glob(self, _name):
             return [Path().absolute().joinpath("a.jar")]
@@ -148,7 +158,11 @@ class RunCommandUnitTest(TestCase):
 
     def test_given_multiple_jars_when_no_testing_jar_identified_then_raise_Exception(self):
         def file_exists(self):
-            return str(self) != str(Path().resolve().joinpath("greengrass-build/uat-features/target/uat-features-1.0.0.jar"))
+            return str(self) != str(
+                Path()
+                .resolve()
+                .joinpath(f"greengrass-build/{consts.E2E_TESTS_DIR_NAME}/target/{consts.E2E_TESTS_DIR_NAME}-1.0.0.jar")
+            )
 
         def glob(self, _name):
             return ["a.jar", "b.jar"]

--- a/tests/gdk/commands/test/test_uat_RunCommand.py
+++ b/tests/gdk/commands/test/test_uat_RunCommand.py
@@ -44,7 +44,7 @@ class RunCommandUnitTest(TestCase):
         run_cmd = RunCommand({})
         with pytest.raises(Exception) as e:
             run_cmd.run()
-        assert "UAT module is not built." in e.value.args[0]
+        assert "E2E testing module is not built." in e.value.args[0]
 
     def test_given_nucleus_archive_at_default_path_when_run_e2e_tests_then_do_not_download_nucleus(self):
         mock_downloader = self.mocker.patch.object(URLDownloader, "download")

--- a/uat/steps/constants.py
+++ b/uat/steps/constants.py
@@ -6,7 +6,7 @@ GG_RECIPE_YAML = "recipe.yaml"
 GG_CONFIG_JSON = "gdk-config.json"
 GG_BUILD_DIR = "greengrass-build"
 GG_BUILD_ZIP_DIR = "zip-build"
-GDK_TEST_DIR = "uat-features"
+GDK_TEST_DIR = "gg-e2e-tests"
 
 DEFAULT_AWS_REGION = "us-east-1"
 DEFAULT_S3_BUCKET_PREFIX = "gdk-github-workflow-cdk-test-data"

--- a/uat/test_init.feature
+++ b/uat/test_init.feature
@@ -9,5 +9,5 @@ Feature: gdk test init works
         And we change directory to test-dir
         And change component name to com.example.PythonHelloWorld
         And we verify gdk project files
-        When we run gdk test init
+        When we run gdk test-e2e init
         Then we verify gdk test files


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Rename the UAT occurrences to E2E testing in gdk cli commands, class and variables names and tests. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.