### PR TITLE
feat: add otf_options args to the test-e2e run command

### DIFF
--- a/gdk/commands/test/RunCommand.py
+++ b/gdk/commands/test/RunCommand.py
@@ -1,5 +1,4 @@
 from gdk.commands.Command import Command
-from gdk.common.config.GDKProject import GDKProject
 from gdk.build_system.E2ETestBuildSystem import E2ETestBuildSystem
 from gdk.commands.test.config.RunConfiguration import RunConfiguration
 from pathlib import Path
@@ -12,10 +11,9 @@ import gdk.common.consts as consts
 class RunCommand(Command):
     def __init__(self, command_args) -> None:
         super().__init__(command_args, "run")
-        self._gdk_project = GDKProject()
-        self._test_directory = self._gdk_project.gg_build_dir.joinpath(consts.E2E_TESTS_DIR_NAME).resolve()
-        self._test_build_system = self._gdk_project.test_config.test_build_system
-        self._config = RunConfiguration(self._gdk_project, command_args)
+        self._run_config = RunConfiguration(command_args)
+        self._test_directory = self._run_config.gg_build_dir.joinpath(consts.E2E_TESTS_DIR_NAME).resolve()
+        self._test_build_system = self._run_config.test_config.test_build_system
         self._nucleus_archive_link = "https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-latest.zip"
 
     def run(self):
@@ -32,7 +30,7 @@ class RunCommand(Command):
                 " the tests."
             )
 
-        _nucleus_path = Path(self._config.options.get("ggc-archive"))
+        _nucleus_path = Path(self._run_config.options.get("ggc-archive"))
         if self._should_download_nucleus_archive(_nucleus_path):
             logging.info("Downloading latest nucleus archive from url %s", self._nucleus_archive_link)
             URLDownloader(self._nucleus_archive_link).download(_nucleus_path)
@@ -57,7 +55,7 @@ class RunCommand(Command):
         If ggc-archive path is set to default path and if it doesn't already exist at this path, then download the latest
         nucleus archive from url.
         """
-        return _nucleus_path == Path(self._config.default_nucleus_archive_path).resolve() and not _nucleus_path.exists()
+        return _nucleus_path == Path(self._run_config.default_nucleus_archive_path).resolve() and not _nucleus_path.exists()
 
     def run_testing_jar(self) -> None:
         """
@@ -108,4 +106,4 @@ class RunCommand(Command):
         """
         Return options as list of arguments to the jar
         """
-        return [f"--{opt}={val}" for opt, val in self._config.options.items()]
+        return [f"--{opt}={val}" for opt, val in self._run_config.options.items()]

--- a/gdk/commands/test/config/RunConfiguration.py
+++ b/gdk/commands/test/config/RunConfiguration.py
@@ -1,25 +1,27 @@
 from gdk.common.config.GDKProject import GDKProject
 from pathlib import Path
+import json
+import logging
 
 
-class RunConfiguration:
-    def __init__(self, _gdk_project: GDKProject, _args) -> None:
+class RunConfiguration(GDKProject):
+    def __init__(self, _args) -> None:
+        super().__init__()
         self._args = _args
-        self._gdk_project = _gdk_project
-        self._test_options_from_config = self._gdk_project.test_config.otf_options
+        self._test_options_from_config = self.test_config.otf_options
         self._default_tags = "Sample"
-        self.default_nucleus_archive_path = self._gdk_project.gg_build_dir.joinpath("greengrass-nucleus-latest.zip").resolve()
-        self.options = {}
-        self._update_options()
+        self.default_nucleus_archive_path = self.gg_build_dir.joinpath("greengrass-nucleus-latest.zip").resolve()
+        self.options = self._get_options()
 
-    def _update_options(self) -> None:
+    def _get_options_from_config(self) -> dict:
         """
         Read otf_options provided in the gdk-config.json. Validate and update only `tags` and `ggc-archive` for now as these
         are required options. Use rest of the options as they're provided in the test config.
         """
-        self.options = self._test_options_from_config.copy()
-        self.options["ggc-archive"] = str(self._get_archive_path())
-        self.options["tags"] = self._get_tags()
+        options = self._test_options_from_config.copy()
+        options["ggc-archive"] = str(self._get_archive_path())
+        options["tags"] = self._get_tags()
+        return options
 
     def _get_archive_path(self) -> Path:
         """
@@ -47,3 +49,32 @@ class RunConfiguration:
         if not tags:
             raise Exception("Test tags provided in the config are invalid. Please check 'tags' in the test config")
         return tags
+
+    def _get_options(self) -> dict:
+        _options_args = self._args.get("otf_options", "")
+        _options_from_config = self._get_options_from_config()
+        if not _options_args:
+            return _options_from_config
+        try:
+            if _options_args.endswith(".json"):
+                _options_args_json = self._read_options_from_file(_options_args)
+            else:
+                _options_args_json = json.loads(_options_args)
+        except json.decoder.JSONDecodeError as err:
+            raise Exception(
+                "JSON string provided in the test commandis incorrectly formatted.\nError:\t" + str(err),
+            )
+        # Merge the options provided in the gdk-config.json with the ones provided as args in test command.
+        # Options in args override the config.
+        logging.debug("Overriding the E2E testing options provided in the config with the ones provided as args")
+        _merged_dict = {**_options_from_config, **_options_args_json}
+        return _merged_dict
+
+    def _read_options_from_file(self, file: str) -> str:
+        file_path = Path(file).resolve()
+        if not file_path.exists():
+            raise Exception("Cannot find the E2E testing options file at the given path %s.", file)
+
+        logging.debug("Reading E2E testing options from file %s", file)
+        with open(file_path, "r", encoding="utf-8") as f:
+            return json.loads(f.read())

--- a/gdk/static/cli_model.json
+++ b/gdk/static/cli_model.json
@@ -135,6 +135,15 @@
                         "help": "Build user acceptance testing module."
                     },
                     "run": {
+                        "arguments": {
+                            "otf_options": {
+                                "name": [
+                                    "-t",
+                                    "--otf-options"
+                                ],
+                                "help": "OTF configuration options used when running the E2E tests. This argument needs to be a valid json string or file path to a JSON file containing the config options. This argument overrides the options provided in the gdk configuration."
+                            }
+                        },
                         "help": "Run user acceptance tests on GreengrassV2 components."
                     }
                 },

--- a/gdk/static/cli_model_schema.json
+++ b/gdk/static/cli_model_schema.json
@@ -289,6 +289,17 @@
                 "help"
             ],
             "properties": {
+                "arguments": {
+                    "description": "List of all the arguments that can be passed with the test-e2e run command.",
+                    "required": [
+                        "otf_options"
+                    ],
+                    "properties": {
+                        "otf_options": {
+                            "$ref": "#/$defs/argument"
+                        }
+                    }
+                },
                 "help": {
                     "$ref": "#/$defs/help"
                 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Adds a new arg `otf_options` that can be passed with the `gdk test-e2e run` command . 
- This option takes a JSON string or a JSON file containing the options supported by OTF testing jar. 
- When this arg is specified, options specified in the gdk config are merged with the ones specified in the arguments. If an option is specified in both the places, the ones in arguments take precedence over the ones in config. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.