### PR TITLE
feat: add otf_version arg to the test-e2e init command

### DIFF
--- a/gdk/commands/test/InitCommand.py
+++ b/gdk/commands/test/InitCommand.py
@@ -1,8 +1,7 @@
 import logging
 from pathlib import Path
 
-from gdk.common.config.GDKProject import GDKProject
-
+from gdk.commands.test.config.InitConfiguration import InitConfiguration
 import gdk.common.utils as utils
 from gdk.commands.Command import Command
 from gdk.build_system.E2ETestBuildSystem import E2ETestBuildSystem
@@ -15,8 +14,8 @@ class InitCommand(Command):
         super().__init__(command_args, "init")
         self.template_name = "TestTemplateForCLI"
         self.test_directory = Path(utils.get_current_directory()).joinpath(consts.E2E_TESTS_DIR_NAME).resolve()
-        self._gdk_project = GDKProject()
-        self._test_config = self._gdk_project.test_config
+        self._init_config = InitConfiguration(command_args)
+        self._test_config = self._init_config.test_config
 
     @property
     def template_url(self):
@@ -33,7 +32,7 @@ class InitCommand(Command):
             )
             return
         URLDownloader(self.template_url).download_and_extract(self.test_directory)
-        self.update_testing_module_build_identifiers(self._test_config.test_build_system, self._test_config.otf_version)
+        self.update_testing_module_build_identifiers(self._test_config.test_build_system, self._init_config.otf_version)
 
     def update_testing_module_build_identifiers(self, build_system_str, otf_version):
         build_system = E2ETestBuildSystem.get(build_system_str)

--- a/gdk/commands/test/config/InitConfiguration.py
+++ b/gdk/commands/test/config/InitConfiguration.py
@@ -1,0 +1,15 @@
+from gdk.common.config.GDKProject import GDKProject
+
+
+class InitConfiguration(GDKProject):
+    def __init__(self, _args) -> None:
+        super().__init__()
+        self._args = _args
+        self.otf_version = self._get_otf_version()
+
+    def _get_otf_version(self):
+        _version_arg = self._args.get("otf_version", None)
+        if _version_arg:
+            return _version_arg.strip()
+        else:
+            return self.test_config.otf_version

--- a/gdk/static/cli_model.json
+++ b/gdk/static/cli_model.json
@@ -129,7 +129,16 @@
             "test-e2e": {
                 "sub-commands": {
                     "init": {
-                        "help": "Initialize GDK project with user acceptance testing module"
+                        "help": "Initialize GDK project with user acceptance testing module",
+                        "arguments": {
+                            "otf_version": {
+                                "name": [
+                                    "-ov",
+                                    "--otf-version"
+                                ],
+                                "help": "Version of the testing jar."
+                            }
+                        }
                     },
                     "build": {
                         "help": "Build user acceptance testing module."

--- a/gdk/static/cli_model_schema.json
+++ b/gdk/static/cli_model_schema.json
@@ -276,6 +276,17 @@
                 "help"
             ],
             "properties": {
+                "arguments": {
+                    "description": "List of all the arguments that can be passed with the test-e2e init command.",
+                    "required": [
+                        "otf_version"
+                    ],
+                    "properties": {
+                        "otf_version": {
+                            "$ref": "#/$defs/argument"
+                        }
+                    }
+                },
                 "help": {
                     "$ref": "#/$defs/help"
                 }

--- a/integration_tests/gdk/test/test_integ_uat_InitCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_InitCommand.py
@@ -68,6 +68,21 @@ class E2ETestInitCommandTest(TestCase):
             # OTF version set in config file
             assert "<otf.version>1.2.0</otf.version>" in content
 
+    def test_GIVEN_gdk_project_WHEN_test_init_with_otf_version_arg_THEN_version_is_arg_is_used(self):
+        self.setup_test_data_config("config.json")
+        InitCommand({"otf_version": "1.3.0"}).run()
+        assert self.mock_template_download.call_args_list == [call(self.url_for_template, stream=True, timeout=30)]
+
+        # existing consts.E2E_TESTS_DIR_NAME folder is not overridden
+        e2e_test_folder = Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME)
+        assert e2e_test_folder.exists()
+        # OTF version is updated in pom.xml
+        with open(e2e_test_folder.joinpath("pom.xml"), "r", encoding="utf-8") as f:
+            content = f.read()
+            assert "GDK_TESTING_VERSION" not in content
+            # OTF version set in config file
+            assert "<otf.version>1.3.0</otf.version>" in content
+
     def test_init_run_error_downloading_template(self):
         self.setup_test_data_config("config.json")
         mock_response = self.mocker.Mock(


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Add a new arg `otf_version` that can be passed with `gdk test-e2e init` command. This command overrides the OTF version provided in the config. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.