### PR TITLE
fix(zip): use the component name as the archive name

### DIFF
--- a/gdk/build_system/Zip.py
+++ b/gdk/build_system/Zip.py
@@ -39,16 +39,14 @@ class Zip:
                             ignore=shutil.ignore_patterns(*self.get_ignored_file_patterns()))
 
             # Get build file name without extension. This will be used as name of the archive.
-            archive_file = utils.current_directory.name
+            archive_file = self.project_config["component_name"]
             logging.debug(
                 "Creating an archive named '{}.zip' in '{}' folder with the files in '{}' folder.".format(
                     archive_file, zip_build.name, artifacts_zip_build.name
                 )
             )
-            archive_file_name = Path(zip_build).joinpath(
-                archive_file).resolve()
-            shutil.make_archive(archive_file_name, "zip",
-                                root_dir=artifacts_zip_build)
+            archive_file_name = Path(zip_build).joinpath(archive_file).resolve()
+            shutil.make_archive(archive_file_name, "zip", root_dir=artifacts_zip_build)
             logging.debug("Archive complete.")
 
         except Exception:

--- a/gdk/build_system/Zip.py
+++ b/gdk/build_system/Zip.py
@@ -39,7 +39,13 @@ class Zip:
                             ignore=shutil.ignore_patterns(*self.get_ignored_file_patterns()))
 
             # Get build file name without extension. This will be used as name of the archive.
-            archive_file = self.project_config["component_name"]
+            archive_file = utils.current_directory.name
+            zip_name_setting = self._get_build_options().get("zip_name", None)
+            if zip_name_setting is not None:
+                if len(zip_name_setting):
+                    archive_file = zip_name_setting
+                else:
+                    archive_file = self.project_config["component_name"]
             logging.debug(
                 "Creating an archive named '{}.zip' in '{}' folder with the files in '{}' folder.".format(
                     archive_file, zip_build.name, artifacts_zip_build.name

--- a/gdk/static/config_schema.json
+++ b/gdk/static/config_schema.json
@@ -84,6 +84,9 @@
                                                         "type": "array",
                                                         "description": "regex patterns of files to exclude",
                                                         "minItems": 1
+                                                    },
+                                                    "zip_name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "additionalProperties": false

--- a/tests/gdk/commands/component/test_BuildCommand.py
+++ b/tests/gdk/commands/component/test_BuildCommand.py
@@ -262,7 +262,7 @@ class BuildCommandTest(TestCase):
 
         mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, ignore=ANY)
         assert mock_make_archive.called
-        zip_build_file = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
+        zip_build_file = Path(zip_build_path).joinpath("component_name").resolve()
         mock_make_archive.assert_called_with(zip_build_file, "zip", root_dir=zip_artifacts_path)
         assert mock_get_supported_component_builds.call_count == 1
 
@@ -301,7 +301,7 @@ class BuildCommandTest(TestCase):
 
         mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, ignore=ANY)
         assert mock_make_archive.called
-        zip_build_file = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
+        zip_build_file = Path(zip_build_path).joinpath("component_name").resolve()
         mock_make_archive.assert_called_with(zip_build_file, "zip", root_dir=zip_artifacts_path)
 
         assert mock_get_supported_component_builds.call_count == 1

--- a/tests/gdk/commands/component/test_BuildCommand.py
+++ b/tests/gdk/commands/component/test_BuildCommand.py
@@ -252,6 +252,7 @@ class BuildCommandTest(TestCase):
         )
         build = BuildCommand({})
         build.project_config["component_build_config"]["build_system"] = "zip"
+        build.project_config["component_build_config"]["options"] = {"zip_name": ""}
         build._build_system_zip()
 
         assert not mock_subprocess_run.called
@@ -301,7 +302,7 @@ class BuildCommandTest(TestCase):
 
         mock_copytree.assert_called_with(curr_dir, zip_artifacts_path, ignore=ANY)
         assert mock_make_archive.called
-        zip_build_file = Path(zip_build_path).joinpath("component_name").resolve()
+        zip_build_file = Path(zip_build_path).joinpath(utils.current_directory.name).resolve()
         mock_make_archive.assert_called_with(zip_build_file, "zip", root_dir=zip_artifacts_path)
 
         assert mock_get_supported_component_builds.call_count == 1

--- a/uat/component_build.feature
+++ b/uat/component_build.feature
@@ -9,10 +9,11 @@ Feature: gdk component build works
     And command was successful
     And we verify gdk project files
     And change component name to com.example.PythonHelloWorld
+    And change artifact uri for all platform from HelloWorld to ${context.last_component}
     When we run gdk component build
     Then command was successful
     And we verify component zip build files
-    And we verify build artifact named HelloWorld.zip
+    And we verify build artifact named ${context.last_component}.zip
 
   @version(min='1.0.0')
   @change_cwd
@@ -126,11 +127,12 @@ Feature: gdk component build works
     And command was successful
     And we verify gdk project files
     And change component name to com.example.PythonHelloWorld
+    And change artifact uri for all platform from HelloWorld to ${context.last_component}
     And change build options to {"excludes":["main.py"]}
     When we run gdk component build
     Then command was successful
     And we verify component zip build files
-    And we verify build artifact named HelloWorld.zip
-    And we verify the following files in HelloWorld.zip
+    And we verify build artifact named ${context.last_component}.zip
+    And we verify the following files in ${context.last_component}.zip
       | excluded    | included  |
       | ["main.py"] | ["tests"] |

--- a/uat/component_build.feature
+++ b/uat/component_build.feature
@@ -9,7 +9,22 @@ Feature: gdk component build works
     And command was successful
     And we verify gdk project files
     And change component name to com.example.PythonHelloWorld
+    When we run gdk component build
+    Then command was successful
+    And we verify component zip build files
+    And we verify build artifact named HelloWorld.zip
+
+  @version(min='1.0.0')
+  @change_cwd
+  Scenario: build template zip using component name as zip name
+    Given we have cli installed
+    And we make directory HelloWorld
+    And we run gdk component init -t HelloWorld -l python
+    And command was successful
+    And we verify gdk project files
+    And change component name to com.example.PythonHelloWorld
     And change artifact uri for all platform from HelloWorld to ${context.last_component}
+    And change build options to {"zip_name": ""}
     When we run gdk component build
     Then command was successful
     And we verify component zip build files
@@ -127,12 +142,11 @@ Feature: gdk component build works
     And command was successful
     And we verify gdk project files
     And change component name to com.example.PythonHelloWorld
-    And change artifact uri for all platform from HelloWorld to ${context.last_component}
     And change build options to {"excludes":["main.py"]}
     When we run gdk component build
     Then command was successful
     And we verify component zip build files
-    And we verify build artifact named ${context.last_component}.zip
-    And we verify the following files in ${context.last_component}.zip
+    And we verify build artifact named HelloWorld.zip
+    And we verify the following files in HelloWorld.zip
       | excluded    | included  |
       | ["main.py"] | ["tests"] |

--- a/uat/component_publish.feature
+++ b/uat/component_publish.feature
@@ -9,11 +9,11 @@ Feature: gdk component publish works
     And command was successful
     And we verify gdk project files
     And change component name to com.example.PythonHelloWorld
-    And change artifact uri for all platform from HelloWorld to ${context.last_component}
+    And change artifact uri for all platform from HelloWorld to helloworld
     And we run gdk component build
     And command was successful
     And we verify component zip build files
-    And we verify build artifact named ${context.last_component}.zip
+    And we verify build artifact named helloworld.zip
     When we run gdk component publish
     And command was successful
 
@@ -26,11 +26,10 @@ Feature: gdk component publish works
     And we change directory to HelloWorld
     And we verify gdk project files
     And change component name to com.example.PythonHelloWorld
-    And change artifact uri for all platform from HelloWorld to ${context.last_component}
     And we run gdk component build
     And command was successful
     And we verify component zip build files
-    And we verify build artifact named ${context.last_component}.zip
+    And we verify build artifact named HelloWorld.zip
     When we run gdk component publish
     And command was successful
 
@@ -43,12 +42,11 @@ Feature: gdk component publish works
     And we change directory to HelloWorld
     And we verify gdk project files
     And change component name to com.example.PythonHelloWorld
-    And change artifact uri for all platform from HelloWorld to ${context.last_component}
     And we get s3 bucket name
     When we run gdk component publish -b <last_s3_bucket>
     And command was successful
     And we verify component zip build files
-    And we verify build artifact named ${context.last_component}.zip
+    And we verify build artifact named HelloWorld.zip
 
   @version(gt='1.1.0')
   @change_cwd

--- a/uat/component_publish.feature
+++ b/uat/component_publish.feature
@@ -9,11 +9,11 @@ Feature: gdk component publish works
     And command was successful
     And we verify gdk project files
     And change component name to com.example.PythonHelloWorld
-    And change artifact uri for all platform from HelloWorld to helloworld
+    And change artifact uri for all platform from HelloWorld to ${context.last_component}
     And we run gdk component build
     And command was successful
     And we verify component zip build files
-    And we verify build artifact named helloworld.zip
+    And we verify build artifact named ${context.last_component}.zip
     When we run gdk component publish
     And command was successful
 
@@ -26,10 +26,11 @@ Feature: gdk component publish works
     And we change directory to HelloWorld
     And we verify gdk project files
     And change component name to com.example.PythonHelloWorld
+    And change artifact uri for all platform from HelloWorld to ${context.last_component}
     And we run gdk component build
     And command was successful
     And we verify component zip build files
-    And we verify build artifact named HelloWorld.zip
+    And we verify build artifact named ${context.last_component}.zip
     When we run gdk component publish
     And command was successful
 
@@ -42,11 +43,12 @@ Feature: gdk component publish works
     And we change directory to HelloWorld
     And we verify gdk project files
     And change component name to com.example.PythonHelloWorld
+    And change artifact uri for all platform from HelloWorld to ${context.last_component}
     And we get s3 bucket name
     When we run gdk component publish -b <last_s3_bucket>
     And command was successful
     And we verify component zip build files
-    And we verify build artifact named HelloWorld.zip
+    And we verify build artifact named ${context.last_component}.zip
 
   @version(gt='1.1.0')
   @change_cwd


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add `zip_name` option to the zip build system. Setting zip_name to `""` will have it automatically use the component name (ideally this would become the default over time). If zip_name isn't specified, the current behavior of using the current directory name will be used.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.