### PR TITLE
refactor: use ComponentBuildConfiguration instead of dictionary

### DIFF
--- a/gdk/commands/component/config/ComponentBuildConfiguration.py
+++ b/gdk/commands/component/config/ComponentBuildConfiguration.py
@@ -1,0 +1,18 @@
+from gdk.common.config.GDKProject import GDKProject
+
+
+class ComponentBuildConfiguration(GDKProject):
+    def __init__(self, _args) -> None:
+        super().__init__()
+        self._args = _args
+        self.build_config = self.component_config.get("build", {})
+        self.build_system = self.build_config.get("build_system", "")
+        self.build_options = self.build_config.get("options", {})
+        self.component_version = self.component_config.get("version", "NEXT_PATCH")
+        self.publisher = self.component_config.get("component_author", "")
+        self.region = self._get_region()
+
+    def _get_region(self):
+        _publish_config = self.component_config.get("publish", {})
+        _region = _publish_config.get("region", "")
+        return _region

--- a/gdk/commands/component/transformer/BuildRecipeTransformer.py
+++ b/gdk/commands/component/transformer/BuildRecipeTransformer.py
@@ -6,26 +6,25 @@ from gdk.common.CaseInsensitive import CaseInsensitiveRecipeFile, CaseInsensitiv
 import gdk.commands.component.project_utils as project_utils
 import gdk.common.consts as consts
 import gdk.common.utils as utils
+from gdk.commands.component.config.ComponentBuildConfiguration import ComponentBuildConfiguration
 
 
 class BuildRecipeTransformer:
-    def __init__(self, project_config) -> None:
+    def __init__(self, project_config: ComponentBuildConfiguration) -> None:
         self.project_config = project_config
 
     def transform(self, build_folders):
-        component_recipe = CaseInsensitiveRecipeFile().read(self.project_config["component_recipe_file"])
+        component_recipe = CaseInsensitiveRecipeFile().read(self.project_config.recipe_file)
         self.update_component_recipe_file(component_recipe, build_folders)
         self.create_build_recipe_file(component_recipe)
 
     def update_component_recipe_file(self, parsed_component_recipe: CaseInsensitiveDict, build_folders):
         logging.debug(
-            "Updating component recipe with the 'component' configuration provided in '{}'.".format(
-                consts.cli_project_config_file
-            )
+            "Updating component recipe with the 'component' configuration provided in '%s'.", consts.cli_project_config_file
         )
-        parsed_component_recipe.update_value("ComponentName", self.project_config["component_name"])
-        parsed_component_recipe.update_value("ComponentVersion", self.project_config["component_version"])
-        parsed_component_recipe.update_value("ComponentPublisher", self.project_config["component_author"])
+        parsed_component_recipe.update_value("ComponentName", self.project_config.component_name)
+        parsed_component_recipe.update_value("ComponentVersion", self.project_config.component_version)
+        parsed_component_recipe.update_value("ComponentPublisher", self.project_config.publisher)
         self.update_artifact_uris(parsed_component_recipe, build_folders)
 
     def update_artifact_uris(self, parsed_component_recipe, build_folders: list) -> None:
@@ -58,7 +57,7 @@ class BuildRecipeTransformer:
                     continue
                 if not self.is_artifact_in_build(artifact, build_folders):
                     if not s3_client:
-                        s3_client = project_utils.create_s3_client(self.project_config["region"])
+                        s3_client = project_utils.create_s3_client(self.project_config.region)
                     if not self.is_artifact_in_s3(s3_client, artifact["URI"]):
                         raise Exception(
                             "Could not find artifact with URI '{}' on s3 or inside the build folders.".format(artifact["URI"])
@@ -79,28 +78,27 @@ class BuildRecipeTransformer:
 
         """
         artifact_uri = f"{utils.s3_prefix}BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION"
-        gg_build_component_artifacts_dir = self.project_config["gg_build_component_artifacts_dir"]
+        gg_build_component_artifacts_dir = self.project_config.gg_build_component_artifacts_dir
         artifact_file_name = Path(artifact["URI"]).name
         # If the artifact is present in build system specific build folder, copy it to greengrass artifacts build folder
         for build_folder in build_folders:
             artifact_file = Path(build_folder).joinpath(artifact_file_name).resolve()
             if artifact_file.is_file():
                 logging.debug(
-                    "Copying file '{}' from '{}' to '{}'.".format(
-                        artifact_file_name, build_folder, gg_build_component_artifacts_dir
-                    )
+                    "Copying file '%s' from '%s' to '%s'.", artifact_file_name, build_folder, gg_build_component_artifacts_dir
                 )
+
                 shutil.copy(artifact_file, gg_build_component_artifacts_dir)
-                logging.debug("Updating artifact URI of '{}' in the recipe file.".format(artifact_file_name))
-                # artifact["URI"] = f"{artifact_uri}/{artifact_file_name}"
+                logging.debug("Updating artifact URI of '%s' in the recipe file.", artifact_file_name)
                 artifact.update_value("Uri", f"{artifact_uri}/{artifact_file_name}")
                 return True
             else:
                 logging.debug(
-                    f"Could not find the artifact file specified in the recipe '{artifact_file_name}' inside the build folder"
-                    f" '{build_folder}'."
+                    "Could not find the artifact file specified in the recipe '%s' inside the build folder '%s'.",
+                    artifact_file_name,
+                    build_folder,
                 )
-        logging.warning(f"Could not find the artifact file '{artifact_file_name}' in the build folder '{build_folders}'.")
+        logging.warning("Could not find the artifact file '%s' in the build folder '%s'.", artifact_file_name, build_folders)
         return False
 
     def is_artifact_in_s3(self, s3_client, artifact_uri) -> bool:
@@ -131,8 +129,8 @@ class BuildRecipeTransformer:
             None
 
         """
-
-        component_recipe_file_name = self.project_config["component_recipe_file"].name
-        gg_build_recipe_file = Path(self.project_config["gg_build_recipes_dir"]).joinpath(component_recipe_file_name).resolve()
+        gg_build_recipe_file = self.project_config.gg_build_recipes_dir.joinpath(
+            self.project_config.recipe_file.name
+        ).resolve()
         logging.debug("Creating component recipe at '%s'.", gg_build_recipe_file)
         CaseInsensitiveRecipeFile().write(gg_build_recipe_file, parsed_component_recipe)

--- a/integration_tests/gdk/components/transformer/test_integ_BuildRecipeTransformer.py
+++ b/integration_tests/gdk/components/transformer/test_integ_BuildRecipeTransformer.py
@@ -4,22 +4,13 @@ from gdk.commands.component.transformer.BuildRecipeTransformer import BuildRecip
 
 import pytest
 import tempfile
-import gdk.common.consts as consts
 import gdk.common.utils as utils
 import boto3
+from gdk.commands.component.config.ComponentBuildConfiguration import ComponentBuildConfiguration
+import os
+import shutil
 
 gradle_build_command = ["gradle", "clean", "build"]
-
-
-@pytest.fixture()
-def supported_build_system(mocker):
-    builds_file = utils.get_static_file_path(consts.project_build_system_file)
-    with open(builds_file, "r") as f:
-        data = json.loads(f.read())
-    mock_get_supported_component_builds = mocker.patch(
-        "gdk.commands.component.project_utils.get_supported_component_builds", return_value=data
-    )
-    return mock_get_supported_component_builds
 
 
 @pytest.fixture()
@@ -34,107 +25,96 @@ def rglob_build_file(mocker):
 
 
 def test_transform_build_recipe_artifact_in_build(mocker):
-    pc = project_config()
-    with tempfile.TemporaryDirectory() as newDir:
-        pc["component_recipe_file"] = (
-            Path(".").joinpath("tests/gdk/static/project_utils").joinpath("valid_component_recipe.json").resolve()
-        )
-        pc["gg_build_directory"] = Path(newDir).joinpath("greengrass-build").resolve()
-        pc["gg_build_component_artifacts_dir"] = (
-            pc["gg_build_directory"]
-            .joinpath("artifacts")
-            .joinpath(pc["component_name"])
-            .joinpath(pc["component_version"])
-            .resolve()
-        )
-        pc["gg_build_recipes_dir"] = pc["gg_build_directory"].joinpath("recipes").resolve()
+    mocker.patch(
+        "gdk.common.configuration.get_configuration",
+        return_value=config(),
+    )
+    curr_dir = Path(".").resolve()
+    recipe = Path(".").joinpath("tests/gdk/static/project_utils").joinpath("valid_component_recipe.json").resolve()
 
+    with tempfile.TemporaryDirectory() as newDir:
+        os.chdir(newDir)
+        shutil.copy(recipe, Path(newDir).joinpath("recipe.json").resolve())
+        bconfig = ComponentBuildConfiguration({})
         zip_build_directory = Path(newDir).joinpath("zip-build").resolve()
         artifact_file = Path(zip_build_directory).joinpath("hello_world.py").resolve()
         zip_build_directory.mkdir(parents=True)
         artifact_file.touch(exist_ok=True)
-        pc["gg_build_component_artifacts_dir"].mkdir(parents=True)
-        pc["gg_build_recipes_dir"].mkdir(parents=True)
+        bconfig.gg_build_component_artifacts_dir.mkdir(parents=True)
+        bconfig.gg_build_recipes_dir.mkdir(parents=True)
 
-        brg = BuildRecipeTransformer(pc)
+        brg = BuildRecipeTransformer(bconfig)
         brg.transform([zip_build_directory])
 
-        assert pc["gg_build_component_artifacts_dir"].joinpath("hello_world.py").is_file()
-        assert pc["gg_build_recipes_dir"].joinpath("valid_component_recipe.json").is_file()
+        assert bconfig.gg_build_component_artifacts_dir.joinpath("hello_world.py").is_file()
+        assert bconfig.gg_build_recipes_dir.joinpath("recipe.json").is_file()
 
-        with open(pc["gg_build_recipes_dir"].joinpath("valid_component_recipe.json"), "r") as f:
+        with open(bconfig.gg_build_recipes_dir.joinpath("recipe.json"), "r") as f:
             recipe = json.loads(f.read())
             # Artifact URI is updated
             assert (
                 recipe["Manifests"][0]["Artifacts"][0]["URI"]
                 == "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/hello_world.py"
             )
+    os.chdir(curr_dir)
 
 
 def test_transform_build_recipe_artifact_in_s3(mocker):
-    pc = project_config()
-
+    mocker.patch(
+        "gdk.common.configuration.get_configuration",
+        return_value=config(),
+    )
+    curr_dir = Path(".").resolve()
+    recipe = Path(".").joinpath("tests/gdk/static/project_utils").joinpath("valid_component_recipe.json").resolve()
     mocker.patch(
         "gdk.commands.component.project_utils.create_s3_client",
         return_value=mocker.patch("boto3.client", return_value=boto3.client("s3")),
     )
     mock_s3_head_object = mocker.patch("boto3.client.head_object", return_value={"ResponseMetadata": {"HTTPStatusCode": 200}})
     with tempfile.TemporaryDirectory() as newDir:
-        pc["component_recipe_file"] = (
-            Path(".").joinpath("tests/gdk/static/project_utils").joinpath("valid_component_recipe.json").resolve()
-        )
-        pc["gg_build_directory"] = Path(newDir).joinpath("greengrass-build").resolve()
-        pc["gg_build_component_artifacts_dir"] = (
-            pc["gg_build_directory"]
-            .joinpath("artifacts")
-            .joinpath(pc["component_name"])
-            .joinpath(pc["component_version"])
-            .resolve()
-        )
-        pc["gg_build_recipes_dir"] = pc["gg_build_directory"].joinpath("recipes").resolve()
+        os.chdir(newDir)
+        shutil.copy(recipe, Path(newDir).joinpath("recipe.json").resolve())
+        bconfig = ComponentBuildConfiguration({})
 
         zip_build_directory = Path(newDir).joinpath("zip-build").resolve()
         zip_build_directory.mkdir(parents=True)
-        pc["gg_build_component_artifacts_dir"].mkdir(parents=True)
-        pc["gg_build_recipes_dir"].mkdir(parents=True)
+        bconfig.gg_build_component_artifacts_dir.mkdir(parents=True)
+        bconfig.gg_build_recipes_dir.mkdir(parents=True)
 
-        brg = BuildRecipeTransformer(pc)
+        brg = BuildRecipeTransformer(bconfig)
         brg.transform([zip_build_directory])
 
-        assert not pc["gg_build_component_artifacts_dir"].joinpath("hello_world.py").is_file()
-        assert pc["gg_build_recipes_dir"].joinpath("valid_component_recipe.json").is_file()
+        assert not bconfig.gg_build_component_artifacts_dir.joinpath("hello_world.py").is_file()
+        assert bconfig.gg_build_recipes_dir.joinpath("recipe.json").is_file()
         assert mock_s3_head_object.assert_called_once
-        with open(pc["gg_build_recipes_dir"].joinpath("valid_component_recipe.json"), "r") as f:
+        with open(bconfig.gg_build_recipes_dir.joinpath("recipe.json"), "r") as f:
             recipe = json.loads(f.read())
             # Artifact URI is not updated
             assert (
                 recipe["Manifests"][0]["Artifacts"][0]["URI"]
                 == "s3://DOC-EXAMPLE-BUCKET/artifacts/com.example.HelloWorld/1.0.0/hello_world.py"
             )
+    os.chdir(curr_dir)
 
 
-def test_transform_build_recipe_artifact_not_found():
-    pc = project_config()
+def test_transform_build_recipe_artifact_not_found(mocker):
+    mocker.patch(
+        "gdk.common.configuration.get_configuration",
+        return_value=config(),
+    )
+    curr_dir = Path(".").resolve()
+    recipe = Path(".").joinpath("tests/gdk/static/project_utils").joinpath("valid_component_recipe.json").resolve()
+
     with tempfile.TemporaryDirectory() as newDir:
-        pc["component_recipe_file"] = (
-            Path(".").joinpath("tests/gdk/static/project_utils").joinpath("valid_component_recipe.json").resolve()
-        )
-        pc["gg_build_directory"] = Path(newDir).joinpath("greengrass-build").resolve()
-        pc["gg_build_component_artifacts_dir"] = (
-            pc["gg_build_directory"]
-            .joinpath("artifacts")
-            .joinpath(pc["component_name"])
-            .joinpath(pc["component_version"])
-            .resolve()
-        )
-        pc["gg_build_recipes_dir"] = pc["gg_build_directory"].joinpath("recipes").resolve()
-
+        os.chdir(newDir)
+        shutil.copy(recipe, Path(newDir).joinpath("recipe.json").resolve())
+        bconfig = ComponentBuildConfiguration({})
         zip_build_directory = Path(newDir).joinpath("zip-build").resolve()
         zip_build_directory.mkdir(parents=True)
-        pc["gg_build_component_artifacts_dir"].mkdir(parents=True)
-        pc["gg_build_recipes_dir"].mkdir(parents=True)
+        bconfig.gg_build_component_artifacts_dir.mkdir(parents=True)
+        bconfig.gg_build_recipes_dir.mkdir(parents=True)
 
-        brg = BuildRecipeTransformer(pc)
+        brg = BuildRecipeTransformer(bconfig)
         with pytest.raises(Exception) as e:
             brg.transform([zip_build_directory])
 
@@ -143,19 +123,18 @@ def test_transform_build_recipe_artifact_not_found():
             " on s3 or inside the build folders."
             in e.value.args[0]
         )
+    os.chdir(curr_dir)
 
 
-def project_config():
+def config():
     return {
-        "component_name": "component_name",
-        "component_build_config": {"build_system": "zip"},
-        "component_version": "1.0.0",
-        "component_author": "abc",
-        "bucket": "default",
-        "region": "us-east-1",
-        "gg_build_directory": Path("/src/GDK-CLI-Internal/greengrass-build"),
-        "gg_build_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts"),
-        "gg_build_recipes_dir": Path("/src/GDK-CLI-Internal/greengrass-build/recipes"),
-        "gg_build_component_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts/component_name/1.0.0"),
-        "component_recipe_file": Path("/src/GDK-CLI-Internal/tests/gdk/static/build_command/valid_component_recipe.json"),
+        "component": {
+            "component_name": {
+                "author": "abc",
+                "version": "1.0.0",
+                "build": {"build_system": "zip"},
+                "publish": {"bucket": "default", "region": "us-east-1"},
+            }
+        },
+        "gdk_version": "1.0.0",
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Create new `ComponentBuildConfiguration` class that reads build command config. 
- Remove using project configuration as dictionary object. 
- Update tests. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.