### PR TITLE
refactor: use ComponentPublishConfiguration instead of dictionary

### DIFF
--- a/gdk/commands/component/PublishCommand.py
+++ b/gdk/commands/component/PublishCommand.py
@@ -1,143 +1,54 @@
-import json
 import logging
-from pathlib import Path
 from gdk.commands.component.transformer.PublishRecipeTransformer import PublishRecipeTransformer
-import boto3
+
 import gdk.commands.component.component as component
-import gdk.commands.component.project_utils as project_utils
 import gdk.common.utils as utils
 from gdk.aws_clients.Greengrassv2Client import Greengrassv2Client
 from gdk.aws_clients.S3Client import S3Client
 from gdk.commands.Command import Command
-from gdk.common.exceptions.CommandError import InvalidArgumentsError
+from gdk.commands.component.config.ComponentPublishConfiguration import ComponentPublishConfiguration
 
 
 class PublishCommand(Command):
     def __init__(self, command_args) -> None:
         super().__init__(command_args, "publish")
 
-        self.project_config = project_utils.get_project_config_values()
-        self.boto3_session = boto3.Session()
-        self.service_clients = project_utils.get_service_clients(self._get_region())
-        self.s3_client = S3Client(self._get_region())
-        self.greengrass_client = Greengrassv2Client(self._get_region())
+        self.project_config = ComponentPublishConfiguration(command_args)
+        self.s3_client = S3Client(self.project_config.region)
+        self.greengrass_client = Greengrassv2Client(self.project_config.region)
 
     def run(self):
         try:
             self.try_build()
-            self._update_project_config_values()
-            component_name = self.project_config["component_name"]
-            component_version = self.project_config["component_version"]
-            self._publish_component_version(component_name, component_version)
+            self._publish_component_version(self.project_config.component_name, self.project_config.component_version)
         except Exception:
-            logging.error("Failed to publish new version of the component '{}'".format(self.project_config["component_name"]))
+            logging.error(
+                "Failed to publish a new version '%s' of the component '%s'.",
+                self.project_config.component_version,
+                self.project_config.component_name,
+            )
             raise
 
     def try_build(self):
         # TODO: This method should just warn and proceed. It should not build the component.
-        component_name = self.project_config["component_name"]
-        logging.debug(f"Checking if the component '{component_name}' is built.")
-        if not utils.dir_exists(self.project_config["gg_build_component_artifacts_dir"]):
+        component_name = self.project_config.component_name
+        logging.debug("Checking if the component '%s' is built.", component_name)
+        if not utils.dir_exists(self.project_config.gg_build_component_artifacts_dir):
             logging.warning(
-                f"The component '{component_name}' is not built.\nSo, building the component before publishing it."
+                "The component '%s' is not built.\nSo, building the component before publishing it.", component_name
             )
             component.build({})
 
-    def _update_project_config_values(self):
-        """
-        Resolve the publish configuration provided in the gdk config file with the CLI arguments passed to the publish command.
-        Arguments provided in the `gdk component publish` commands take precedence over the gdk-config values.
-
-        Parameters
-        ----------
-            None
-
-        Returns
-        -------
-            None
-        """
-        self._update_account_number()
-        self._override_config_with_command_args()
-        self._update_component_version()
-
-    def _update_account_number(self):
-        self.project_config["account_number"] = self.get_account_number()
-
-    def _override_config_with_command_args(self):
-        logging.debug("Overridig gdk configuration with the command arguments")
-        self._update_region()
-        self._update_bucket()
-        self._update_options()
-
-    def _update_bucket(self):
-        if self.arguments.get("bucket"):
-            self.project_config["bucket"] = self.arguments["bucket"]
-        else:
-            self.project_config["bucket"] = "{}-{}-{}".format(
-                self.project_config["bucket"], self.project_config["region"], self.project_config["account_number"]
-            )
-
-    def _update_options(self):
-        if self.arguments.get("options"):
-            try:
-                self.project_config["options"] = self._read_options(self.arguments["options"])
-            except Exception:
-                logging.error("Please provide a valid json file path or a json string as the options argument.")
-                raise
-
-    def _read_options(self, options):
-        try:
-            if not options.endswith(".json"):
-                return json.loads(options)
-            return self._read_from_file(options)
-        except json.decoder.JSONDecodeError as err:
-            raise InvalidArgumentsError(
-                options,
-                "JSON string is incorrectly formatted.\nError:\t" + str(err),
-            )
-
-    def _read_from_file(self, options):
-        logging.debug("Reading options from the json file provided in the publish command")
-        file_path = Path(options).resolve()
-        if not utils.file_exists(file_path):
-            raise InvalidArgumentsError(
-                options,
-                "The json file path provided in the command does not exist",
-            )
-        with open(file_path, "r") as o_file:
-            return json.loads(o_file.read())
-
-    def _get_region(self) -> str:
-        if self.arguments.get("region"):
-            return self.arguments["region"]
-        return self.project_config["region"]
-
-    def _update_region(self):
-        self.project_config["region"] = self._get_region()
-
-    def _update_component_version(self):
-        self.project_config["component_version"] = self.get_component_version_from_config()
-        self._update_publish_recipe_file_path()
-
-    def _update_publish_recipe_file_path(self):
-        ext = self.project_config["component_recipe_file"].name.split(".")[-1]
-        publish_recipe_file_name = "{}-{}.{}".format(
-            self.project_config["component_name"], self.project_config["component_version"], ext
-        )  # Eg. HelloWorld-1.0.0.yaml
-        self.project_config["publish_recipe_file"] = (
-            Path(self.project_config["gg_build_recipes_dir"]).joinpath(publish_recipe_file_name).resolve()
-        )
-
     def _publish_component_version(self, component_name, component_version):
-        logging.info(f"Publishing the component '{component_name}' with the given project configuration.")
+        logging.info("Publishing the component '%s' with the given project configuration.", component_name)
         logging.info("Uploading the component built artifacts to s3 bucket.")
         self.upload_artifacts_s3()
 
-        logging.info(f"Updating the component recipe {component_name}-{component_version}.")
+        logging.info("Updating the component recipe %s-%s.", component_name, component_version)
         PublishRecipeTransformer(self.project_config).transform()
 
-        logging.info(f"Creating a new greengrass component {component_name}-{component_version}")
-        self.greengrass_client.create_gg_component(self.project_config["publish_recipe_file"])
+        logging.info("Creating a new greengrass component %s-%s.", component_name, component_version)
+        self.greengrass_client.create_gg_component(self.project_config.publish_recipe_file)
 
     def upload_artifacts_s3(self) -> None:
         """
@@ -145,9 +56,9 @@ class PublishCommand(Command):
 
         Raises an exception when the request is not successful.
         """
-        _bucket = self.project_config["bucket"]
+        _bucket = self.project_config.bucket
 
-        build_component_artifacts = list(self.project_config["gg_build_component_artifacts_dir"].iterdir())
+        build_component_artifacts = list(self.project_config.gg_build_component_artifacts_dir.iterdir())
 
         if not build_component_artifacts:
             logging.info("No artifacts found in the component build folder. Skipping the artifact upload step")
@@ -165,105 +76,12 @@ class PublishCommand(Command):
 
         self.s3_client.create_bucket(_bucket)
 
-        component_name = self.project_config["component_name"]
-        component_version = self.project_config["component_version"]
-        options = self.project_config["options"]
-        s3_upload_file_args = options.get("file_upload_args", dict())
+        component_name = self.project_config.component_name
+        component_version = self.project_config.component_version
+        options = self.project_config.options
+        s3_upload_file_args = options.get("file_upload_args", {})
 
         for artifact in build_component_artifacts:
             s3_file_path = f"{component_name}/{component_version}/{artifact.name}"
             logging.debug("Uploading artifact '%s' to the bucket '%s'.", artifact.resolve(), _bucket)
             self.s3_client.upload_artifact(artifact, _bucket, s3_file_path, s3_upload_file_args)
-
-    def get_next_version(self):
-        """
-        Calculates the next patch version of the component if it already exists in the account. Otherwise, it uses 1.0.0 as
-        the fallback version.
-
-        Parameters
-        ----------
-            None
-
-        Returns
-        -------
-            version(string): Version of the component to create.
-        """
-        fallback_version = "1.0.0"
-        logging.debug("Fetching private components from the account.")
-        try:
-            c_name = self.project_config["component_name"]
-            region = self.project_config["region"]
-            account_num = self.project_config["account_number"]
-            partition = self.boto3_session.get_partition_for_region(region_name=region)
-            component_arn = f"arn:{partition}:greengrass:{region}:{account_num}:components:{c_name}"
-
-            c_next_patch_version = self.greengrass_client.get_highest_cloud_component_version(component_arn)
-            if not c_next_patch_version:
-                logging.info(
-                    "No private version of the component '{}' exist in the account. Using '{}' as the next version to create."
-                    .format(c_name, fallback_version)
-                )
-                return fallback_version
-            logging.debug(
-                "Found latest version '{}' of the component '{}' in the account.".format(c_next_patch_version, c_name)
-            )
-            next_version = utils.get_next_patch_version(c_next_patch_version)
-            logging.info("Using '{}' as the next version of the component '{}' to create.".format(next_version, c_name))
-            return next_version
-        except Exception:
-            logging.error("Failed to calculate the next version of the component during publish.")
-            raise
-
-    def get_account_number(self):
-        """
-        Uses STS client to get account number from the credentials provided using AWS cli.
-
-        Raises an exception when the request is unsuccessful.
-
-        Parameters
-        ----------
-            None
-
-        Returns
-        -------
-            account_num: Returns account number.
-        """
-        try:
-            caller_identity_response = self.service_clients["sts_client"].get_caller_identity()
-            account_num = caller_identity_response["Account"]
-            logging.debug("Identified account number as '{}'.".format(account_num))
-            return account_num
-        except Exception:
-            logging.error("Error while fetching account number from credentials.")
-            raise
-
-    def get_component_version_from_config(self):
-        """
-        Returns component version based on the project configuration.
-
-        If component version is set to NEXT_PATCH, patch version of the latest component version is calculated. Otherwise,
-        exact version specified will be used as the component version during creation of the component.
-
-        Parameters
-        ----------
-            None
-
-        Returns
-        -------
-            None
-        """
-        try:
-            component_name = self.project_config["component_name"]
-            if self.project_config["component_version"] == "NEXT_PATCH":
-                logging.debug(
-                    "Component version set to 'NEXT_PATCH' in the config file. Calculating next version of the component '{}'"
-                    .format(self.project_config["component_name"])
-                )
-                return self.get_next_version()
-            logging.info("Using the version set for the component '{}' in the config file.".format(component_name))
-            return self.project_config["component_version"]
-        except Exception as e:
-            logging.error(
-                "Failed to calculate the version of component '{}' based on the configuration.".format(component_name)
-            )
-            raise (e)

--- a/gdk/commands/component/config/ComponentBuildConfiguration.py
+++ b/gdk/commands/component/config/ComponentBuildConfiguration.py
@@ -9,7 +9,7 @@ class ComponentBuildConfiguration(GDKProject):
         self.build_system = self.build_config.get("build_system", "")
         self.build_options = self.build_config.get("options", {})
         self.component_version = self.component_config.get("version", "NEXT_PATCH")
-        self.publisher = self.component_config.get("component_author", "")
+        self.publisher = self.component_config.get("author", "")
         self.region = self._get_region()
 
     def _get_region(self):

--- a/gdk/commands/component/config/ComponentPublishConfiguration.py
+++ b/gdk/commands/component/config/ComponentPublishConfiguration.py
@@ -1,0 +1,142 @@
+from gdk.common.config.GDKProject import GDKProject
+import json
+from pathlib import Path
+from gdk.common.exceptions.CommandError import InvalidArgumentsError
+import logging
+import gdk.common.utils as utils
+import gdk.commands.component.project_utils as proj_utils
+from gdk.aws_clients.Greengrassv2Client import Greengrassv2Client
+import boto3
+
+
+class ComponentPublishConfiguration(GDKProject):
+    def __init__(self, _args) -> None:
+        super().__init__()
+        self._args = _args
+        self._publish_config = self.component_config.get("publish", {})
+        self.boto3_session = boto3.Session()
+        self.region = self._get_region()
+        self.options = self._get_options()
+        self.account_num = self.get_account_number()
+        self.bucket = self._get_bucket(self.region, self.account_num)
+        self.component_version = self.get_component_version(self.region)
+        self.publisher = self.component_config.get("author", "")
+        self.publish_recipe_file = self.gg_build_recipes_dir.joinpath(
+            f"{self.component_name}-{self.component_version}.{self.recipe_file.name.split('.')[-1]}"
+        )
+
+    def _get_region(self):
+        _region = ""
+        _region_args = self._args.get("region")
+        if _region_args:
+            _region = _region_args
+        else:
+            _region = self._publish_config.get("region", "")
+
+        return _region
+
+    def _get_bucket(self, _region, _account):
+        _bucket = ""
+        _bucket_args = self._args.get("bucket")
+        if _bucket_args:
+            _bucket = _bucket_args
+        else:
+            _bucket_config = self._publish_config.get("bucket", "")
+            if _bucket_config:
+                _bucket = _bucket_config.strip() + "-" + _region + "-" + _account
+
+        if not _bucket:
+            raise ValueError("Bucket cannot be empty. Please provide a valid bucket.")
+
+        return _bucket
+
+    def _get_options(self):
+        _options_args = self._args.get("options")
+        if _options_args:
+            return self._read_options_as_dict(_options_args)
+        else:
+            return self._publish_config.get("options", {})
+
+    def _read_options_as_dict(self, _options: str):
+        try:
+            if _options.endswith(".json"):
+                _options = self._read_from_file(Path(_options))
+            else:
+                _options = json.loads(_options)
+        except json.decoder.JSONDecodeError as err:
+            raise InvalidArgumentsError(
+                _options,
+                "JSON string is incorrectly formatted.\nError:\t" + str(err),
+            ) from err
+        return _options
+
+    def _read_from_file(self, _opts_path: Path):
+        if not _opts_path.is_file():
+            raise ValueError("JSON file path provided in the command does not exist. Please provide a valid JSON file.")
+
+        with open(_opts_path.resolve(), "r", encoding="utf-8") as file:
+            return json.loads(file.read())
+
+    def get_component_version(self, _region):
+        _version = self.component_config.get("version")
+        if not _version:
+            raise ValueError("Version cannot be empty. Please provide a valid version.")
+
+        if _version == "NEXT_PATCH":
+            logging.debug(
+                "Component version set to %s in the config file. Calculating next version of the component '%s'",
+                _version,
+                self.component_name,
+            )
+            return self._get_next_version(_region)
+        logging.info("Using the version %s set for the component '%s' in the config file.", _version, self.component_name)
+        return _version
+
+    def _get_next_version(self, _region) -> str:
+        """
+        Calculates the next patch version of the component if it already exists in the account. Otherwise, it uses 1.0.0 as
+        the fallback version.
+        """
+        fallback_version = "1.0.0"
+        logging.debug("Fetching private components from the account.")
+        try:
+            c_name = self.component_name
+            component_arn = self._get_component_arn(_region)
+            c_next_patch_version = Greengrassv2Client(_region).get_highest_cloud_component_version(component_arn)
+            if not c_next_patch_version:
+                logging.info(
+                    "No private version of the component '%s' exist in the account. Using '%s' as the next version to create.",
+                    c_name,
+                    fallback_version,
+                )
+
+                return fallback_version
+            logging.debug("Found latest version '%s' of the component '%s' in the account.", c_next_patch_version, c_name)
+
+            next_version = utils.get_next_patch_version(c_next_patch_version)
+            logging.info("Using '%s' as the next version of the component '%s' to create.", next_version, c_name)
+            return next_version
+        except Exception:
+            logging.error("Failed to calculate the next version of the component during publish.")
+            raise
+
+    def _get_component_arn(self, _region):
+        partition = self._get_aws_partition(_region)
+        return f"arn:{partition}:greengrass:{_region}:{self.account_num}:components:{self.component_name}"
+
+    def _get_aws_partition(self, _region):
+        return self.boto3_session.get_partition_for_region(region_name=_region)
+
+    def get_account_number(self) -> str:
+        """
+        Uses STS client to get account number from the credentials provided using AWS cli.
+        Raises an exception when the request is unsuccessful.
+        """
+        try:
+            _sts_client = proj_utils.create_sts_client()
+            account_num = _sts_client.get_caller_identity().get("Account")
+            logging.debug("Identified account number as '%s'.", account_num)
+            return account_num
+        except Exception:
+            logging.error("Error while fetching account number from credentials.")
+            raise

--- a/integration_tests/gdk/components/test_integ_PublishCommand.py
+++ b/integration_tests/gdk/components/test_integ_PublishCommand.py
@@ -239,14 +239,9 @@ class ComponentPublishCommandIntegTest(TestCase):
             },
         )
         self.tmpdir.joinpath("greengrass-build/artifacts/abc/NEXT_PATCH/somefile").touch()
-        account_num = "123456789012"
-        self.sts_client_stub.add_response("get_caller_identity", {"Account": account_num}, {})
-
-        pc = PublishCommand({"options": str(self.tmpdir.joinpath("options.json").resolve())})
         with pytest.raises(Exception) as e:
-            pc.run()
-        assert "JSON string is incorrectly formatted." in str(e)
-        self.sts_client_stub.assert_no_pending_responses()
+            PublishCommand({"options": str(self.tmpdir.joinpath("options.json").resolve())})
+        assert "JSON string is incorrectly formatted." in e.value.args[0]
 
     def zip_test_data(self):
         shutil.copy(

--- a/tests/gdk/commands/component/config/test_ComponentPublishConfiguration.py
+++ b/tests/gdk/commands/component/config/test_ComponentPublishConfiguration.py
@@ -1,0 +1,149 @@
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch, mock_open, Mock
+import pytest
+
+
+from gdk.commands.component.config.ComponentPublishConfiguration import ComponentPublishConfiguration
+import boto3
+from botocore.stub import Stubber
+
+
+class ComponentPublishConfigurationTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker):
+        self.mocker = mocker
+        self.mock_get_proj_config = self.mocker.patch(
+            "gdk.common.configuration.get_configuration",
+            return_value=config(),
+        )
+        self.mock_component_recipe = self.mocker.patch(
+            "gdk.commands.component.project_utils.get_recipe_file",
+            return_value=Path("some-recipe.json"),
+        )
+
+        self.gg_client = boto3.client("greengrassv2", region_name="region")
+        self.sts_client = boto3.client("sts", region_name="region")
+
+        def _clients(*args, **kwargs):
+            if args[0] == "greengrassv2":
+                return self.gg_client
+            elif args[0] == "sts":
+                return self.sts_client
+
+        self.mocker.patch("boto3.client", side_effect=_clients)
+        self.gg_client_stub = Stubber(self.gg_client)
+        self.sts_client_stub = Stubber(self.sts_client)
+        self.gg_client_stub.activate()
+        self.sts_client_stub.activate()
+        self.sts_client_stub.add_response("get_caller_identity", {"Account": "123456789012"})
+        boto3_ses = Mock()
+        boto3_ses.get_partition_for_region.return_value = "aws"
+        self.mocker.patch("boto3.Session", return_value=boto3_ses)
+
+    def test_GIVEN_config_with_no_arguments_WHEN_read_publish_config_THEN_read_from_config(self):
+        pconfig = ComponentPublishConfiguration({})
+        assert pconfig.publisher == "author"
+        assert pconfig.component_version == "1.0.0"
+        assert pconfig.bucket == "default-region-123456789012"
+
+    def test_GIVEN_NEXT_PATCH_for_version_with_no_previous_versions_WHEN_get_next_version_THEN_get_fallback_version(self):
+        conf = config()
+        conf["component"]["com.example.HelloWorld"]["version"] = "NEXT_PATCH"
+        self.mock_get_proj_config = self.mocker.patch(
+            "gdk.common.configuration.get_configuration",
+            return_value=conf,
+        )
+        response = {"componentVersions": []}
+        self.gg_client_stub.add_response("list_component_versions", response)
+        pconfig = ComponentPublishConfiguration({})
+        assert pconfig.publisher == "author"
+        assert pconfig.component_version == "1.0.0"
+        assert pconfig.bucket == "default-region-123456789012"
+
+    def test_GIVEN_NEXT_PATCH_for_version_with_previous_versions_WHEN_get_version_THEN_calculate_next_version(self):
+        conf = config()
+        conf["component"]["com.example.HelloWorld"]["version"] = "NEXT_PATCH"
+        self.mock_get_proj_config = self.mocker.patch(
+            "gdk.common.configuration.get_configuration",
+            return_value=conf,
+        )
+        response = {"componentVersions": [{"componentVersion": "1.0.4"}, {"componentVersion": "1.0.1"}]}
+        self.gg_client_stub.add_response("list_component_versions", response)
+        pconfig = ComponentPublishConfiguration({})
+        assert pconfig.publisher == "author"
+        assert pconfig.component_version == "1.0.5"
+        assert pconfig.bucket == "default-region-123456789012"
+
+    def test_GIVEN_config_with_bucket_args_WHEN_get_bucket_THEN_get_bucket_from_args(self):
+        pconfig = ComponentPublishConfiguration({"bucket": "my-bucket"})
+        assert pconfig.publisher == "author"
+        assert pconfig.component_version == "1.0.0"
+        assert pconfig.bucket == "my-bucket"
+
+    def test_GIVEN_config_with_region_args_WHEN_get_region_THEN_get_region_from_args(self):
+        pconfig = ComponentPublishConfiguration({"region": "us-east-1"})
+        assert pconfig.publisher == "author"
+        assert pconfig.component_version == "1.0.0"
+        assert pconfig.bucket == "default-us-east-1-123456789012"
+
+    def test_GIVEN_config_with_options_args_WHEN_get_options_THEN_get_options_from_args(self):
+        opts = '{"metadata": "test"}'
+        pconfig = ComponentPublishConfiguration({"options": opts})
+        assert pconfig.publisher == "author"
+        assert pconfig.component_version == "1.0.0"
+        assert pconfig.bucket == "default-region-123456789012"
+        assert pconfig.options == {"metadata": "test"}
+
+    def test_GIVEN_config_with_invalid_options_args_WHEN_get_options_THEN_raise_exception(self):
+        opts = '{"metadata: "test"}'
+        with pytest.raises(Exception) as e:
+            pconfig = ComponentPublishConfiguration({"options": opts})
+            assert pconfig.publisher == "author"
+            assert pconfig.component_version == "1.0.0"
+            assert pconfig.bucket == "default-region-123456789012"
+            assert pconfig.options == {"metadata": "test"}
+        assert "JSON string is incorrectly formatted." in e.value.args[0]
+
+    def test_GIVEN_config_with_file_options_args_and_path_not_exists_WHEN_get_options_THEN_raise_exception(self):
+        opts = "file_does_not_exist.json"
+        with pytest.raises(Exception) as e:
+            pconfig = ComponentPublishConfiguration({"options": opts})
+            assert pconfig.publisher == "author"
+            assert pconfig.component_version == "1.0.0"
+            assert pconfig.bucket == "default-region-123456789012"
+        assert "JSON file path provided in the command does not exist. Please provide a valid JSON file." in e.value.args[0]
+
+    def test_GIVEN_config_with_file_options_args_WHEN_get_options_THEN_read_opts_from_file(self):
+        opts = "some_file.json"
+        valid_json_string = '{"metadata": "test"}'
+        self.mocker.patch("pathlib.Path.is_file", return_value=True)
+        with patch("builtins.open", mock_open(read_data=valid_json_string)):
+            pconfig = ComponentPublishConfiguration({"options": opts})
+            assert pconfig.publisher == "author"
+            assert pconfig.component_version == "1.0.0"
+            assert pconfig.bucket == "default-region-123456789012"
+            assert pconfig.options == {"metadata": "test"}
+
+    def test_GIVEN_config_with_invalid_file_options_args_WHEN_get_options_THEN_raise_exception(self):
+        opts = "some_file.json"
+        invalid_json_string = "invalid_json"
+        self.mocker.patch("pathlib.Path.is_file", return_value=True)
+        with patch("builtins.open", mock_open(read_data=invalid_json_string)):
+            with pytest.raises(Exception) as e:
+                ComponentPublishConfiguration({"options": opts})
+        assert "JSON string is incorrectly formatted." in e.value.args[0]
+
+
+def config():
+    return {
+        "component": {
+            "com.example.HelloWorld": {
+                "author": "author",
+                "version": "1.0.0",
+                "build": {"build_system": "zip"},
+                "publish": {"bucket": "default", "region": "region"},
+            }
+        },
+        "gdk_version": "1.0.0",
+    }

--- a/tests/gdk/commands/component/test_PublishCommand.py
+++ b/tests/gdk/commands/component/test_PublishCommand.py
@@ -1,14 +1,15 @@
 from pathlib import Path
 from unittest import TestCase
-from unittest.mock import call, patch, mock_open
+from unittest.mock import call
 from gdk.commands.component.transformer.PublishRecipeTransformer import PublishRecipeTransformer
 
 import pytest
-from urllib3.exceptions import HTTPError
 
 from gdk.aws_clients.Greengrassv2Client import Greengrassv2Client
 from gdk.aws_clients.S3Client import S3Client
 from gdk.commands.component.PublishCommand import PublishCommand
+from botocore.stub import Stubber
+import boto3
 
 
 class PublishCommandTest(TestCase):
@@ -16,114 +17,31 @@ class PublishCommandTest(TestCase):
     def __inject_fixtures(self, mocker):
         self.mocker = mocker
         self.mock_get_proj_config = self.mocker.patch(
-            "gdk.commands.component.project_utils.get_project_config_values",
-            return_value=project_config(),
+            "gdk.common.configuration.get_configuration",
+            return_value=config(),
         )
-
-    def test_get_component_version_from_config(self):
-        mock_get_next_version = self.mocker.patch.object(PublishCommand, "get_next_version", return_value="")
-        publish = PublishCommand({})
-        version = publish.get_component_version_from_config()
-        assert version == self.mock_get_proj_config.return_value["component_version"]
-        assert not mock_get_next_version.called
-
-    def test_get_component_version_from_config_next_patch(self):
-        publish = PublishCommand({})
-        publish.project_config = {
-            "component_name": "component_name",
-            "component_version": "NEXT_PATCH",
-            "component_author": "abc",
-            "bucket": "default",
-            "region": "default",
-        }
-        mock_get_next_version = self.mocker.patch.object(PublishCommand, "get_next_version", return_value="1.0.1")
-        version = publish.get_component_version_from_config()
-        assert version == mock_get_next_version.return_value
-        assert mock_get_next_version.called
-
-    def test_get_component_version_from_config_exception_next_patch(self):
-        mock_get_next_version = self.mocker.patch.object(
-            PublishCommand, "get_next_version", side_effect=HTTPError("some error")
+        self.mock_component_recipe = self.mocker.patch(
+            "gdk.commands.component.project_utils.get_recipe_file",
+            return_value=Path("some-recipe.json"),
         )
-        publish = PublishCommand({})
-        publish.project_config["component_version"] = "NEXT_PATCH"
-        publish.project_config["account_number"] = "1234"
+        self.gg_client = boto3.client("greengrassv2", region_name="region")
+        self.sts_client = boto3.client("sts", region_name="region")
 
-        with pytest.raises(Exception) as e:
-            publish.get_component_version_from_config()
+        def _clients(*args, **kwargs):
+            if args[0] == "greengrassv2":
+                return self.gg_client
+            elif args[0] == "sts":
+                return self.sts_client
 
-        assert mock_get_next_version.call_count == 1
-        assert e.value.args[0] == "some error"
-
-    def test_get_next_version_component_not_exists(self):
-        mock_get_next_patch_component_version = self.mocker.patch.object(
-            Greengrassv2Client, "get_highest_cloud_component_version", return_value=None
-        )
-        publish = PublishCommand({})
-        publish.project_config["account_number"] = "1234"
-        version = publish.get_next_version()
-        assert version == "1.0.0"  # Fallback version
-        assert mock_get_next_patch_component_version.call_args_list == [
-            call("arn:aws:greengrass:us-east-1:1234:components:component_name")
-        ]
-
-    def test_get_next_version_component_already_exists(self):
-        publish = PublishCommand({})
-        mock_get_next_patch_component_version = self.mocker.patch.object(
-            Greengrassv2Client, "get_highest_cloud_component_version", return_value="1.0.6"
-        )
-        publish.project_config["account_number"] = "12345"
-        version = publish.get_next_version()
-        assert version == "1.0.7"
-        assert mock_get_next_patch_component_version.call_count == 1
-
-    def test_client_built_with_correct_region(self):
-        self.mocker.patch.object(PublishCommand, "get_account_number", return_value="1234")
-        self.mocker.patch.object(PublishCommand, "get_component_version_from_config", return_value=None)
-        self.mocker.patch.object(PublishCommand, "upload_artifacts_s3", return_value=None)
-        self.mocker.patch.object(PublishRecipeTransformer, "transform")
-        self.mocker.patch("gdk.common.utils.dir_exists", return_value=False)
-        self.mocker.patch("gdk.commands.component.component.build", return_value=None)
-        self.mocker.patch.object(Greengrassv2Client, "create_gg_component", return_value=None)
-
-        publish = PublishCommand({"region": "ca-central-1"})
-        publish.run()
-
-        # NOTE: This test is testing implementation details. It should be improved but for now it will
-        # give us the confidence that the client is getting created with the correct region
-        assert publish.project_config["region"] == "ca-central-1"
-        assert publish.service_clients["s3_client"].meta.config.region_name == "ca-central-1"
-        assert publish.service_clients["sts_client"].meta.config.region_name == "ca-central-1"
-        assert publish.service_clients["greengrass_client"].meta.config.region_name == "ca-central-1"
-
-    def test_get_next_version_component_already_exists_semver(self):
-        publish = PublishCommand({})
-        publish.project_config["account_number"] = "1234"
-        mock_get_next_patch_component_version = self.mocker.patch.object(
-            Greengrassv2Client, "get_highest_cloud_component_version", return_value="1.0.6-x-y-z"
-        )
-        version = publish.get_next_version()
-        assert version == "1.0.7"
-        assert mock_get_next_patch_component_version.call_count == 1
-
-    def test_get_next_version_component_exception(self):
-        publish = PublishCommand({})
-        publish.project_config["account_number"] = "1234"
-        mock_get_next_patch_component_version = self.mocker.patch.object(
-            Greengrassv2Client, "get_highest_cloud_component_version", side_effect=HTTPError("some error")
-        )
-        with pytest.raises(Exception) as e:
-            publish.get_next_version()
-        assert mock_get_next_patch_component_version.call_count == 1
-        assert e.value.args[0] == "some error"
+        self.mocker.patch("boto3.client", side_effect=_clients)
+        self.gg_client_stub = Stubber(self.gg_client)
+        self.sts_client_stub = Stubber(self.sts_client)
+        self.gg_client_stub.activate()
+        self.sts_client_stub.activate()
+        self.sts_client_stub.add_response("get_caller_identity", {"Account": "123456789012"})
 
     def test_upload_artifacts_with_no_artifacts(self):
         publish = PublishCommand({})
-        publish.project_config = {
-            "bucket": "test-bucket",
-            "region": "test-region",
-            "gg_build_component_artifacts_dir": Path("some-build-dir"),
-        }
         publish.service_clients = {"s3_client": self.mocker.patch("boto3.client", return_value=None)}
         publish.s3_client = S3Client("test-region")
         self.mocker.patch("pathlib.Path.iterdir", return_value=[])
@@ -132,10 +50,7 @@ class PublishCommandTest(TestCase):
         assert not mock_create_bucket.called
 
     def test_upload_artifacts(self):
-        publish = PublishCommand({})
-        publish.project_config["bucket"] = "test-bucket"
-        publish.project_config["region"] = "test-region"
-        publish.service_clients = {"s3_client": self.mocker.patch("boto3.client", return_value=None)}
+        publish = PublishCommand({"bucket": "test-bucket"})
         self.mocker.patch.object(S3Client, "upload_artifact", return_value=None)
 
         publish.s3_client = S3Client("test-region")
@@ -145,10 +60,6 @@ class PublishCommandTest(TestCase):
         assert mock_create_bucket.call_args_list == [call("test-bucket")]
 
     def test_publish_run_not_build(self):
-        mock_get_account_num = self.mocker.patch.object(PublishCommand, "get_account_number", return_value="1234")
-        mock_get_component_version_from_config = self.mocker.patch.object(
-            PublishCommand, "get_component_version_from_config", return_value=None
-        )
         mock_upload_artifacts_s3 = self.mocker.patch.object(PublishCommand, "upload_artifacts_s3", return_value=None)
         mock_transform = self.mocker.patch.object(PublishRecipeTransformer, "transform")
         mock_dir_exists = self.mocker.patch("gdk.common.utils.dir_exists", return_value=False)
@@ -158,22 +69,13 @@ class PublishCommandTest(TestCase):
             {"bucket": None, "region": "us-west-2", "options": '{"file_upload_args":{"Metadata": {"key": "value"}}}'}
         )
         publish.run()
-        assert publish.project_config["account_number"] == "1234"
-        assert publish.project_config["bucket"] == "default-us-west-2-1234"
-        assert publish.project_config["options"] == {"file_upload_args": {"Metadata": {"key": "value"}}}
         assert mock_dir_exists.call_count == 1
         assert mock_build.call_count == 1
-        assert mock_get_account_num.call_count == 1
-        assert mock_get_component_version_from_config.call_count == 1
         assert mock_upload_artifacts_s3.call_count == 1
         assert mock_transform.call_count == 1
         assert mock_create_gg_component.call_count == 1
 
     def test_publish_run_not_build_command_bucket(self):
-        mock_get_account_num = self.mocker.patch.object(PublishCommand, "get_account_number", return_value="1234")
-        mock_get_component_version_from_config = self.mocker.patch.object(
-            PublishCommand, "get_component_version_from_config", return_value=None
-        )
         mock_upload_artifacts_s3 = self.mocker.patch.object(PublishCommand, "upload_artifacts_s3", return_value=None)
         mock_transform = self.mocker.patch.object(PublishRecipeTransformer, "transform")
         mock_dir_exists = self.mocker.patch("gdk.common.utils.dir_exists", return_value=False)
@@ -181,144 +83,36 @@ class PublishCommandTest(TestCase):
         mock_create_gg_component = self.mocker.patch.object(Greengrassv2Client, "create_gg_component", return_value=None)
         publish = PublishCommand({"bucket": "exact-bucket", "region": None, "options": None})
         publish.run()
-        assert publish.project_config["account_number"] == "1234"
-        assert publish.project_config["bucket"] == "exact-bucket"
         assert mock_dir_exists.call_count == 1
         assert mock_build.call_count == 1
-        assert mock_get_account_num.call_count == 1
-        assert mock_get_component_version_from_config.call_count == 1
         assert mock_upload_artifacts_s3.call_count == 1
         assert mock_transform.call_count == 1
         assert mock_create_gg_component.call_count == 1
 
     def test_publish_run_build(self):
-        mock_get_account_num = self.mocker.patch.object(PublishCommand, "get_account_number", return_value="1234")
-        mock_get_component_version_from_config = self.mocker.patch.object(
-            PublishCommand, "get_component_version_from_config", return_value=None
-        )
         mock_upload_artifacts_s3 = self.mocker.patch.object(PublishCommand, "upload_artifacts_s3", return_value=None)
         mock_transform = self.mocker.patch.object(PublishRecipeTransformer, "transform")
         mock_dir_exists = self.mocker.patch("gdk.common.utils.dir_exists", return_value=True)
         mock_build = self.mocker.patch("gdk.commands.component.component.build", return_value=None)
         publish = PublishCommand({"bucket": None, "region": None, "options": None})
-        publish.project_config["bucket"] = "default"
         mock_create_gg_component = self.mocker.patch.object(Greengrassv2Client, "create_gg_component", return_value=None)
         publish.run()
-        assert publish.project_config["account_number"] == "1234"
-        assert publish.project_config["bucket"] == "default-us-east-1-1234"
         assert mock_dir_exists.call_count == 1
         assert not mock_build.called
-        assert mock_get_account_num.call_count == 1
-        assert mock_get_component_version_from_config.call_count == 1
         assert mock_upload_artifacts_s3.call_count == 1
         assert mock_transform.call_count == 1
         assert mock_create_gg_component.call_count == 1
 
-    def test_publish_run_override_command_args_with_options(self):
-        valid_json_string = '{"metadata": "test"}'
-        publish = PublishCommand({"bucket": "my-bucket", "region": None, "options": valid_json_string})
-        publish.project_config["bucket"] = "default"
-        publish.project_config["account_number"] = "1234"
-        publish.project_config["component_version"] = "1.0.0"
-        publish._override_config_with_command_args()
-        assert publish.project_config["bucket"] == "my-bucket"
-        assert publish.project_config["options"] == {"metadata": "test"}
 
-    def test_publish_run_override_command_args_with_invalid_options(self):
-        incorrect_json_string = '{"metadata: "test"}'
-        publish = PublishCommand({"bucket": None, "region": "us-west-2", "options": incorrect_json_string})
-        publish.project_config["bucket"] = "default"
-        publish.project_config["account_number"] = "1234"
-        publish.project_config["component_version"] = "1.0.0"
-        with pytest.raises(Exception) as e:
-            publish._override_config_with_command_args()
-        assert "JSON string is incorrectly formatted" in e.value.args[0]
-
-    def test_publish_run_override_command_args_with_options_from_file_not_exists(self):
-        publish = PublishCommand({"bucket": None, "region": "us-west-2", "options": "file_not_exists.json"})
-        publish.project_config["bucket"] = "default"
-        publish.project_config["account_number"] = "1234"
-        publish.project_config["component_version"] = "1.0.0"
-        with pytest.raises(Exception) as e:
-            self.mocker.patch("gdk.common.utils.file_exists", return_value=False)
-            publish._override_config_with_command_args()
-        assert "The json file path provided in the command does not exist" in e.value.args[0]
-
-    def test_publish_run_override_command_args_with_options_from_a_valid_file(self):
-        self.mocker.patch("gdk.common.utils.file_exists", return_value=True)
-        publish = PublishCommand({"bucket": None, "region": None, "options": "valid_file.json"})
-        publish.project_config["bucket"] = "default"
-        publish.project_config["account_number"] = "1234"
-        publish.project_config["component_version"] = "1.0.0"
-        valid_json_string = '{"metadata": "test"}'
-        with patch("builtins.open", mock_open(read_data=valid_json_string)):
-            publish._override_config_with_command_args()
-        assert publish.project_config["options"] == {"metadata": "test"}
-
-    def test_publish_run_override_command_args_with_options_from_an_invalid_file(self):
-        self.mocker.patch("gdk.common.utils.file_exists", return_value=True)
-        publish = PublishCommand({"bucket": None, "region": None, "options": "valid_file.json"})
-        publish.project_config["bucket"] = "default"
-        publish.project_config["account_number"] = "1234"
-        publish.project_config["component_version"] = "1.0.0"
-        incorrect_json_string = '{"metadata: "test"}'
-        with patch("builtins.open", mock_open(read_data=incorrect_json_string)):
-            with pytest.raises(Exception) as e:
-                publish._override_config_with_command_args()
-        assert "JSON string is incorrectly formatted" in e.value.args[0]
-
-    def test_publish_run_exception(self):
-        mock_get_account_num = self.mocker.patch.object(PublishCommand, "get_account_number", return_value="1234")
-        mock_get_component_version_from_config = self.mocker.patch.object(
-            PublishCommand,
-            "get_component_version_from_config",
-            return_value=None,
-            side_effect=HTTPError("some error"),
-        )
-        mock_project_built = self.mocker.patch.object(PublishCommand, "try_build", return_value=None)
-        publish = PublishCommand({"bucket": None, "region": None, "options": None})
-        publish.project_config["bucket"] = "default"
-        with pytest.raises(Exception) as e:
-            publish.run()
-        assert mock_project_built.call_count == 1
-        assert publish.project_config["account_number"] == "1234"
-        assert publish.project_config["bucket"] == "default-us-east-1-1234"
-        assert e.value.args[0] == "some error"
-        assert mock_get_account_num.call_count == 1
-        assert mock_get_component_version_from_config.call_count == 1
-
-    def test_get_account_number_exception(self):
-        mock_client = self.mocker.patch("boto3.client", return_value=None)
-        publish = PublishCommand({})
-        publish.service_clients = {"sts_client": mock_client}
-        mock_get_caller_identity = self.mocker.patch("boto3.client.get_caller_identity", side_effect=HTTPError("some error"))
-        with pytest.raises(Exception) as e:
-            publish.get_account_number()
-        assert mock_get_caller_identity.call_count == 1
-        assert "some error" in e.value.args[0]
-
-    def test_get_account_number(self):
-        mock_client = self.mocker.patch("boto3.client", return_value=None)
-        publish = PublishCommand({})
-        publish.service_clients = {"sts_client": mock_client}
-        mock_get_caller_identity = self.mocker.patch("boto3.client.get_caller_identity", return_value={"Account": 124})
-        num = publish.get_account_number()
-        assert mock_get_caller_identity.call_count == 1
-        assert num == 124
-
-
-def project_config():
+def config():
     return {
-        "component_name": "component_name",
-        "component_build_config": {"build_system": "zip"},
-        "component_version": "1.0.0",
-        "component_author": "abc",
-        "bucket": "default",
-        "region": "us-east-1",
-        "options": {},
-        "gg_build_directory": Path("/src/GDK-CLI-Internal/greengrass-build"),
-        "gg_build_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts"),
-        "gg_build_recipes_dir": Path("/src/GDK-CLI-Internal/greengrass-build/recipes"),
-        "gg_build_component_artifacts_dir": Path("/src/GDK-CLI-Internal/greengrass-build/artifacts/component_name/1.0.0"),
-        "component_recipe_file": Path("/src/GDK-CLI-Internal/tests/gdk/static/build_command/valid_component_recipe.json"),
+        "component": {
+            "com.example.HelloWorld": {
+                "author": "<PLACEHOLDER_AUTHOR>",
+                "version": "1.0.0",
+                "build": {"build_system": "zip"},
+                "publish": {"bucket": "default", "region": "region"},
+            }
+        },
+        "gdk_version": "1.0.0",
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Create a new class object `ComponentPublishConfiguration` to hold project configuration in the publish command instead of project config dictionary object.
- Update tests. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.