### PR TITLE
fix: validate component version before uploading the artifacts

### DIFF
--- a/gdk/aws_clients/Greengrassv2Client.py
+++ b/gdk/aws_clients/Greengrassv2Client.py
@@ -1,5 +1,6 @@
 import logging
 import boto3
+from botocore.exceptions import ClientError
 
 
 class Greengrassv2Client:
@@ -47,3 +48,16 @@ class Greengrassv2Client:
             except Exception:
                 logging.error("Failed to create a private version of the component using the recipe at '%s'.", file_path)
                 raise
+
+    def component_version_exists(self, component_arn) -> bool:
+        """
+        Checks if the component version exists in the account. Returns True if the component exists else False.
+        """
+        try:
+            self.client.get_component(arn=component_arn)
+            return True
+        except ClientError as exc:
+            error_code = exc.response["Error"]["Code"]
+            if error_code == "ResourceNotFoundException":
+                return False
+            raise exc

--- a/integration_tests/gdk/components/transformer/test_integ_PublishRecipeTransformer.py
+++ b/integration_tests/gdk/components/transformer/test_integ_PublishRecipeTransformer.py
@@ -72,6 +72,7 @@ class ComponentPublishRecipeTransformerIntegTest(TestCase):
                 "nextToken": "string",
             },
         )
+        self.gg_client_stub.add_client_error("get_component", service_error_code="ResourceNotFoundException")
 
     def test_transform_publish_recipe_artifact_in_build_json(self):
         recipe = self.c_dir.joinpath("tests/gdk/static/project_utils").joinpath("valid_component_recipe.json").resolve()

--- a/tests/gdk/commands/component/test_PublishCommand.py
+++ b/tests/gdk/commands/component/test_PublishCommand.py
@@ -48,6 +48,7 @@ class PublishCommandTest(TestCase):
         boto3_ses = Mock()
         boto3_ses.get_partition_for_region.return_value = "aws"
         self.mocker.patch("boto3.Session", return_value=boto3_ses)
+        self.gg_client_stub.add_client_error("get_component", service_error_code="ResourceNotFoundException")
 
     def test_upload_artifacts_with_no_artifacts(self):
         publish = PublishCommand({})

--- a/tests/gdk/commands/component/transformer/test_PublishRecipeTransformer.py
+++ b/tests/gdk/commands/component/transformer/test_PublishRecipeTransformer.py
@@ -53,6 +53,7 @@ class PublishRecipeTransformerTest(TestCase):
                 "nextToken": "string",
             },
         )
+        self.gg_client_stub.add_client_error("get_component", service_error_code="ResourceNotFoundException")
 
     def test_publish_recipe_transformer_instantiate(self):
         pc = ComponentPublishConfiguration({})


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
If a version other than `NEXT_PATCH` is provided in the config, it is never validated until the end of the command execution. i.e if the component version provided in the config already exists, built artifacts are uploaded to s3, recipe is created and then the component creation fails as the version already exists. 

This change validates if the component version already exists by using `get_component` API at the beginning of the `gdk component publish` command execution. 


This change requires the customers to add a new permission `GetComponent` to their existing role. 
**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.