### PR TITLE
fix: validate region in build during s3 client creation

### DIFF
--- a/gdk/commands/component/config/ComponentBuildConfiguration.py
+++ b/gdk/commands/component/config/ComponentBuildConfiguration.py
@@ -15,6 +15,4 @@ class ComponentBuildConfiguration(GDKProject):
     def _get_region(self):
         _publish_config = self.component_config.get("publish", {})
         _region = _publish_config.get("region", "")
-        if _region == "":
-            raise ValueError("Region cannot be empty. Please provide a valid region.")
         return _region


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Validate region config in build command right during s3 client creation. Do not validate it before as it is not a required option and is only needed in the cases when one or more components artifacts are already on s3. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.