### PR TITLE
test: add 2 scenarios for test-e2e build cmd

### DIFF
--- a/uat/steps/test_e2e.py
+++ b/uat/steps/test_e2e.py
@@ -1,7 +1,7 @@
 import os
 from behave import step
 from pathlib import Path
-from constants import GDK_TEST_DIR
+from constants import GDK_TEST_DIR, GG_BUILD_DIR
 
 
 @step("we verify gdk test files")
@@ -18,3 +18,13 @@ def verify_test_framework_version(context, version):
     with open(build_system_file, "r") as f:
         content = f.read()
         assert f"<otf.version>{version}</otf.version>" in content, f"OTF version {version} is not used."
+
+
+@step("we verify the test build files")
+def verify_test_build_files(context):
+    cwd = context.cwd if "cwd" in context else os.getcwd()
+    test_build_file = Path(cwd).joinpath(GG_BUILD_DIR, GDK_TEST_DIR, "target", "uat-features-1.0.0.jar")
+    test_recipe_file = Path(cwd).joinpath(GG_BUILD_DIR, "recipes", "e2e_test_recipe.yaml")
+
+    assert test_build_file.resolve().exists(), f"{test_build_file} does not exist"
+    assert test_recipe_file.resolve().exists(), f"{test_recipe_file} does not exist"

--- a/uat/t_setup.py
+++ b/uat/t_setup.py
@@ -12,6 +12,7 @@ class ProcessOutput:
     def __init__(self, exit_code, output) -> None:
         self.returncode = exit_code
         self.output = output
+        print(output)
 
 
 class GdkProcess:

--- a/uat/test_build.feature
+++ b/uat/test_build.feature
@@ -1,0 +1,30 @@
+Feature: As a component builder, I can run `gdk test-e2e build` command to build the testing module using GDK config and command arguments.
+
+    @version(min='1.3.0')
+    @change_cwd
+    Scenario: test-e2e-build-1: As a component builder, when I run the test-e2e build command, test feature files are updated and then the module is built.
+        Given we have cli installed
+        When we run gdk component init -t HelloWorld -l python -n HelloWorld
+        Then command was successful
+        And we change directory to HelloWorld
+        And change component name to com.example.PythonHelloWorld
+        And we verify gdk project files
+        When we run gdk component build
+        When we run gdk test-e2e init
+        Then we verify gdk test files
+        When we run gdk test-e2e build
+        Then we verify the test build files
+
+    @version(min='1.3.0')
+    @change_cwd
+    Scenario: test-e2e-build-2: As a component builder, when I run the test-e2e build command without building the component, the command exits with an error
+        Given we have cli installed
+        When we run gdk component init -t HelloWorld -l python -n HelloWorld
+        Then command was successful
+        And we change directory to HelloWorld
+        And change component name to com.example.PythonHelloWorld
+        And we verify gdk project files
+        When we run gdk test-e2e init
+        Then we verify gdk test files
+        When we run gdk test-e2e build
+        Then cli exited with error


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add 2 new UAT scenarios for testing `gdk test-e2e build` command. 
- As a component builder, when I run the test-e2e build command, test feature files are updated and then the module is built. 
- As a component builder, when I run the test-e2e build command without building the component, the command exits with an error. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.