### PR TITLE
fix: raise exc if the test module is missing before build

### DIFF
--- a/gdk/commands/test/BuildCommand.py
+++ b/gdk/commands/test/BuildCommand.py
@@ -50,6 +50,11 @@ class BuildCommand(Command):
         build_system.build(path=self._gg_build_e2e_test_dir)
 
     def _copy_e2e_test_dir_to_build(self):
+        if not self.test_directory.exists():
+            raise Exception(
+                "Could not find 'gg-e2e-tests' in the current directory. Please initialize the project with testing module"
+                " using `gdk test-e2e init` command before building it."
+            )
         logging.debug("Copying the E2E testing module to greengrass-build directory")
         shutil.copytree(self.test_directory, self._gg_build_e2e_test_dir)
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
If a component builder using GDK runs `gdk test-e2e build `command before the project is initialized, an exception is raised with a proper message. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.