### PR TITLE
fix: use test-e2e instead of test in config

### DIFF
--- a/gdk/common/config/GDKProject.py
+++ b/gdk/common/config/GDKProject.py
@@ -12,7 +12,7 @@ class GDKProject:
     def __init__(self):
         self._config = configuration.get_configuration()
         self._component = self._config.get("component")
-        self._test = self._config.get("test", {})
+        self._test = self._config.get("test-e2e", {})
         self._project_dir = utils.get_current_directory()
 
         self.component_name = next(iter(self._component))

--- a/gdk/static/cli_model.json
+++ b/gdk/static/cli_model.json
@@ -147,7 +147,7 @@
                         "arguments": {
                             "otf_options": {
                                 "name": [
-                                    "-t",
+                                    "-oo",
                                     "--otf-options"
                                 ],
                                 "help": "OTF configuration options used when running the E2E tests. This argument needs to be a valid json string or file path to a JSON file containing the config options. This argument overrides the options provided in the gdk configuration."

--- a/integration_tests/gdk/test/test_integ_uat_RunCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_RunCommand.py
@@ -97,7 +97,7 @@ class E2ETestRunCommandTest(TestCase):
         run_jar = self.mocker.patch("gdk.commands.test.RunCommand.RunCommand.run_testing_jar", return_value=None)
         with open(Path().joinpath("gdk-config.json"), "r") as f:
             content = json.loads(f.read())
-            content["test"] = {"otf_options": {"ggc-archive": "/doesn/not/exis/nucleus.zip"}}
+            content["test-e2e"] = {"otf_options": {"ggc-archive": "/doesn/not/exis/nucleus.zip"}}
         with open(Path().joinpath("gdk-config.json"), "w") as f:
             f.write(json.dumps(content))
 

--- a/integration_tests/test_data/config/config.json
+++ b/integration_tests/test_data/config/config.json
@@ -12,7 +12,7 @@
             }
         }
     },
-    "test": {
+    "test-e2e": {
         "otf_version": "1.2.0",
         "otf_options": {
             "tags": "testtags"

--- a/tests/gdk/commands/test/config/test_RunConfiguration.py
+++ b/tests/gdk/commands/test/config/test_RunConfiguration.py
@@ -34,7 +34,7 @@ class RunConfigurationUnitTest(TestCase):
     def test_GIVEN_gdk_config_with_tags_WHEN_run_with_tag_args_THEN_use_tags_from_args(self):
         config = self._get_config(
             {
-                "test": {
+                "test-e2e": {
                     "otf_options": {"tags": "some-tags", "ggc-version": "1.0.0"},
                 }
             }
@@ -55,7 +55,7 @@ class RunConfigurationUnitTest(TestCase):
     def test_GIVEN_gdk_config_with_three_options_WHEN_run_with_two_overriding_args_THEN_merge_args(self):
         config = self._get_config(
             {
-                "test": {
+                "test-e2e": {
                     "otf_options": {
                         "tags": "some-tags",
                         "ggc-install-root": "some-install-root",
@@ -83,7 +83,7 @@ class RunConfigurationUnitTest(TestCase):
     def test_GIVEN_gdk_config_with_three_options_WHEN_run_with_two_overriding_args_from_file_THEN_merge_args(self):
         config = self._get_config(
             {
-                "test": {
+                "test-e2e": {
                     "otf_options": {
                         "tags": "some-tags",
                         "ggc-install-root": "some-install-root",
@@ -114,7 +114,7 @@ class RunConfigurationUnitTest(TestCase):
     def test_given_gdk_config_with_tags_when_get_test_run_configuration_tags_then_return_given_tags(self):
         config = self._get_config(
             {
-                "test": {
+                "test-e2e": {
                     "otf_options": {"tags": "some-tags", "ggc-version": "1.0.0"},
                 }
             }
@@ -135,7 +135,7 @@ class RunConfigurationUnitTest(TestCase):
     def test_given_gdk_config_with_empty_tags_when_get_test_run_configuration_tags_then_raise_exception(self):
         config = self._get_config(
             {
-                "test": {
+                "test-e2e": {
                     "otf_options": {"tags": "", "ggc-version": "1.0.0"},
                 }
             }
@@ -153,7 +153,7 @@ class RunConfigurationUnitTest(TestCase):
     ):
         config = self._get_config(
             {
-                "test": {
+                "test-e2e": {
                     "otf_options": {"ggc-archive": "some-path.zip"},
                 }
             }
@@ -172,7 +172,7 @@ class RunConfigurationUnitTest(TestCase):
     def test_given_gdk_config_with_nucleus_archive_path_when_path_not_exists_then_raise_exception(self):
         config = self._get_config(
             {
-                "test": {
+                "test-e2e": {
                     "otf_options": {"ggc-archive": "some-path.zip"},
                 }
             }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Replace occurrences of `test` with `test-e2e` in the implementation and as well as tests. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.