### PR TITLE
fix: validate OTF version before downloading the template

### DIFF
--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -1,0 +1,31 @@
+
+** semver3;  -- https://semver.org 
+©2023, Kostiantyn Rybnikov and all.
+
+Copyright (c) 2013, Konstantine Rybnikov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+  Neither the name of the {organization} nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/gdk/commands/test/InitCommand.py
+++ b/gdk/commands/test/InitCommand.py
@@ -31,6 +31,9 @@ class InitCommand(Command):
                 consts.E2E_TESTS_DIR_NAME,
             )
             return
+
+        logging.info("Downloading the E2E testing template from GitHub into %s directory...", consts.E2E_TESTS_DIR_NAME)
+
         URLDownloader(self.template_url).download_and_extract(self.test_directory)
         self.update_testing_module_build_identifiers(self._test_config.test_build_system, self._init_config.otf_version)
 
@@ -46,7 +49,7 @@ class InitCommand(Command):
             with open(build_file, "r", encoding="utf-8") as f:
                 build_file_content = f.read()
 
-            build_file_content = build_file_content.replace("GDK_TESTING_VERSION", otf_version)
+            build_file_content = build_file_content.replace("GDK_TESTING_VERSION", otf_version + "-SNAPSHOT")
 
             with open(build_file, "w", encoding="utf-8") as f:
                 f.write(build_file_content)

--- a/gdk/commands/test/config/InitConfiguration.py
+++ b/gdk/commands/test/config/InitConfiguration.py
@@ -1,4 +1,6 @@
+import semver
 from gdk.common.config.GDKProject import GDKProject
+import logging
 
 
 class InitConfiguration(GDKProject):
@@ -10,6 +12,23 @@ class InitConfiguration(GDKProject):
     def _get_otf_version(self):
         _version_arg = self._args.get("otf_version", None)
         if _version_arg:
-            return _version_arg.strip()
-        else:
-            return self.test_config.otf_version
+            logging.info("Using the OTF version specified in the command argument: %s", _version_arg)
+            return self._validated_otf_version(_version_arg)
+        logging.info("Using the OTF version specified in the GDK test config %s", self.test_config.otf_version)
+        return self._validated_otf_version(self.test_config.otf_version)
+
+    def _validated_otf_version(self, version) -> str:
+        _version = version.strip()
+
+        if not _version:
+            raise ValueError(
+                "OTF version cannot be empty. Please specify a valid OTF version in the GDK config or in the command argument."
+            )
+
+        if not semver.Version.is_valid(_version):
+            raise ValueError(
+                f"OTF version {_version} is not a valid semver. Please specify a valid OTF version in the GDK config or in"
+                " the command argument."
+            )
+
+        return _version

--- a/gdk/commands/test/config/InitConfiguration.py
+++ b/gdk/commands/test/config/InitConfiguration.py
@@ -1,12 +1,14 @@
 import semver
 from gdk.common.config.GDKProject import GDKProject
 import logging
+import requests
 
 
 class InitConfiguration(GDKProject):
     def __init__(self, _args) -> None:
         super().__init__()
         self._args = _args
+        self._otf_releases_url = "https://github.com/aws-greengrass/aws-greengrass-testing/releases"
         self.otf_version = self._get_otf_version()
 
     def _get_otf_version(self):
@@ -31,4 +33,15 @@ class InitConfiguration(GDKProject):
                 " the command argument."
             )
 
+        if not self._otf_version_exists(_version):
+            raise ValueError(
+                f"The specified Open Test Framework (OTF) version '{_version}' does not exist. Please"
+                f" provide a valid OTF version from the releases here: {self._otf_releases_url}"
+            )
+
         return _version
+
+    def _otf_version_exists(self, _version) -> bool:
+        _testing_jar_url = "https://github.com/aws-greengrass/aws-greengrass-testing/releases/tag/v" + _version
+        head_response = requests.head(_testing_jar_url, timeout=10)
+        return head_response.status_code == 200

--- a/gdk/common/config/TestConfiguration.py
+++ b/gdk/common/config/TestConfiguration.py
@@ -1,7 +1,7 @@
 class TestConfiguration:
     def __init__(self, test_config):
         self.test_build_system = "maven"
-        self.otf_version = "1.1.0-SNAPSHOT"  # TODO: Default value should be the latest version of otf testing standalone jar.
+        self.otf_version = "1.1.0"  # TODO: Default value should be the latest version of otf testing standalone jar.
         self.otf_options = {}
 
         self._set_test_config(test_config)

--- a/integration_tests/gdk/common/config/test_GDKProject.py
+++ b/integration_tests/gdk/common/config/test_GDKProject.py
@@ -30,7 +30,7 @@ class GDKProjectTest(TestCase):
 
         gdk_config = GDKProject()
         assert gdk_config.component_name == "abc"
-        assert gdk_config.test_config.otf_version == "1.1.0-SNAPSHOT"
+        assert gdk_config.test_config.otf_version == "1.1.0"
         assert gdk_config.test_config.test_build_system == "maven"
         assert gdk_config.test_config.otf_options == {}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jsonschema
 PyYAML
 requests
 packaging
+semver

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,3 +14,4 @@ pytest-mock
 behave
 behave-html-formatter
 Faker
+semver

--- a/tests/gdk/commands/test/config/test_InitConfiguration.py
+++ b/tests/gdk/commands/test/config/test_InitConfiguration.py
@@ -1,0 +1,108 @@
+import pytest
+from unittest import TestCase
+from pathlib import Path
+import os
+from gdk.commands.test.config.InitConfiguration import InitConfiguration
+from gdk.common.config.GDKProject import GDKProject
+
+
+class InitConfigurationUnitTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker, tmpdir):
+        self.mocker = mocker
+        self.tmpdir = tmpdir
+        self.c_dir = Path(".").resolve()
+        self.mocker.patch.object(GDKProject, "_get_recipe_file", return_value=Path(".").joinpath("recipe.json").resolve())
+        os.chdir(tmpdir)
+        yield
+        os.chdir(self.c_dir)
+
+    def test_given_gdk_config_with_no_test_when_get_test_init_configuration_then_return_default_configuration(self):
+        config = self._get_config()
+
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+        init_config = InitConfiguration({})
+        assert init_config.otf_version == "1.1.0-SNAPSHOT"
+
+    def test_GIVEN_gdk_config_with_otf_version_WHEN_test_init_THEN_use_version_from_config(self):
+        config = self._get_config(
+            {
+                "test-e2e": {
+                    "otf_version": "1.2.3",
+                }
+            }
+        )
+
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+
+        init_config = InitConfiguration({})
+
+        assert init_config.otf_version == "1.2.3"
+
+    def test_GIVEN_gdk_config_with_invalid_otf_version_WHEN_test_init_THEN_raise_exc(self):
+        config = self._get_config(
+            {
+                "test-e2e": {
+                    "otf_version": "1.a.b",
+                }
+            }
+        )
+
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+
+        with pytest.raises(ValueError) as e:
+            InitConfiguration({})
+
+        assert (
+            "OTF version 1.a.b is not a valid semver. Please specify a valid OTF version in the GDK config or in the command"
+            " argument."
+            in str(e.value)
+        )
+
+    def test_GIVEN_gdk_config_WHEN_test_init_with_otf_version_arg_THEN_use_version_from_arg(self):
+        config = self._get_config()
+
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+        init_config = InitConfiguration({"otf_version": "1.1.0+12-build"})
+        assert init_config.otf_version == "1.1.0+12-build"
+
+    def test_GIVEN_gdk_config_WHEN_test_init_with_invalid_otf_version_arg_THEN_raise_exc(self):
+        config = self._get_config()
+
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+        with pytest.raises(ValueError) as e:
+            InitConfiguration({"otf_version": "1.a.b"})
+
+        assert (
+            "OTF version 1.a.b is not a valid semver. Please specify a valid OTF version in the GDK config or in the command"
+            " argument."
+            in str(e.value)
+        )
+
+    def test_GIVEN_gdk_config_with_otf_version_WHEN_test_init_with__otf_version_arg_THEN_use_version_from_arg(self):
+        config = self._get_config(
+            {
+                "test-e2e": {
+                    "otf_version": "1.a.b",
+                }
+            }
+        )
+
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+        init_config = InitConfiguration({"otf_version": "1.2.3"})
+        assert init_config.otf_version == "1.2.3"
+
+    def _get_config(self, value=None):
+        config = {
+            "component": {
+                "abc": {
+                    "author": "abc",
+                    "version": "1.0.0",
+                    "build": {"build_system": "zip"},
+                    "publish": {"bucket": "default", "region": "us-east-1"},
+                }
+            }
+        }
+        if value:
+            config.update(value)
+        return config

--- a/uat/steps/test_e2e.py
+++ b/uat/steps/test_e2e.py
@@ -17,7 +17,7 @@ def verify_test_framework_version(context, version):
 
     with open(build_system_file, "r") as f:
         content = f.read()
-        assert f"<otf.version>{version}</otf.version>" in content, f"OTF version {version} is not used."
+        assert f"<otf.version>{version}-SNAPSHOT</otf.version>" in content, f"OTF version {version} is not used."
 
 
 @step("we verify the test build files")

--- a/uat/test_init.feature
+++ b/uat/test_init.feature
@@ -1,8 +1,8 @@
-Feature: gdk test init works
+Feature: As a component builder, I can run `gdk test-e2e init` command to initialize an existing GDK project with the testing module that uses OTF.
 
     @version(min='1.3.0')
     @change_cwd
-    Scenario: init test in an existing gdk project
+    Scenario: test-e2e-init-1: Initialize a GDK project with an e2e testing module with default configuration and no commmand args
         Given we have cli installed
         When we run gdk component init -t HelloWorld -l python -n test-dir
         Then command was successful
@@ -22,9 +22,9 @@ Feature: gdk test init works
         And we change directory to test-dir
         And change component name to com.example.PythonHelloWorld
         And we verify gdk project files
-        When we run gdk test-e2e init --otf-version 1.2.0
+        When we run gdk test-e2e init --otf-version 1.0.0
         Then we verify gdk test files
-        Then we verify that the OTF version used is 1.2.0
+        Then we verify that the OTF version used is 1.0.0
 
     @version(min='1.3.0')
     @change_cwd
@@ -35,7 +35,21 @@ Feature: gdk test init works
         And we change directory to test-dir
         And change component name to com.example.PythonHelloWorld
         And we verify gdk project files
-        When we run gdk test-e2e init --otf-version 1.2.0
+        When we run gdk test-e2e init --otf-version 1.1.0
         Then we verify gdk test files
-        When we run gdk test-e2e init --otf-version 1.3.0
-        Then we verify that the OTF version used is 1.2.0
+        When we run gdk test-e2e init --otf-version 1.0.0
+        Then we verify that the OTF version used is 1.1.0
+
+
+    @version(min='1.3.0')
+    @change_cwd
+    Scenario: test-e2e-init-4: When I initialize a GDK project with an e2e testing module using a version of OTF that doesn't exist, the command exits with an error
+        Given we have cli installed
+        When we run gdk component init -t HelloWorld -l python -n test-dir
+        Then command was successful
+        And we change directory to test-dir
+        And change component name to com.example.PythonHelloWorld
+        And we verify gdk project files
+        When we run gdk test-e2e init --otf-version 10.0.0
+        Then command was unsuccessful
+        Then command output contains "'10.0.0' does not exist"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Validate the OTF version provided in the config and the command arguments using `semver` library before downloading the template from GitHub. 
- Update third party licenses.
- Add unit tests for the same. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.