### PR TITLE
fix: verify if test dir exists and is not empty before exiting

### DIFF
--- a/gdk/commands/test/InitCommand.py
+++ b/gdk/commands/test/InitCommand.py
@@ -25,9 +25,9 @@ class InitCommand(Command):
         )
 
     def run(self):
-        if self.test_directory.exists():
+        if self.test_directory.exists() and len(list(self.test_directory.iterdir())) > 0:
             logging.warning(
-                "Not downloading the E2E testing template as '%s' already exists in the current directory.",
+                "Not downloading the E2E testing template as '%s' already exists in the current directory and is not empty.",
                 consts.E2E_TESTS_DIR_NAME,
             )
             return


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- GDK exits without downloading the test template during test-e2e init if the directory already contains gg-e2e-tests folder. This change checks not only for the folder existence but also if it is empty.
- Updated integration tests accordingly. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.