### PR TITLE
fix: min version in uat and logging

### DIFF
--- a/gdk/commands/test/config/InitConfiguration.py
+++ b/gdk/commands/test/config/InitConfiguration.py
@@ -14,9 +14,9 @@ class InitConfiguration(GDKProject):
     def _get_otf_version(self):
         _version_arg = self._args.get("otf_version", None)
         if _version_arg:
-            logging.info("Using the OTF version specified in the command argument: %s", _version_arg)
+            logging.info("Using the OTF version provided in the command %s", _version_arg)
             return self._validated_otf_version(_version_arg)
-        logging.info("Using the OTF version specified in the GDK test config %s", self.test_config.otf_version)
+        logging.info("Using the OTF version provided in the GDK test config %s", self.test_config.otf_version)
         return self._validated_otf_version(self.test_config.otf_version)
 
     def _validated_otf_version(self, version) -> str:

--- a/gdk/commands/test/config/RunConfiguration.py
+++ b/gdk/commands/test/config/RunConfiguration.py
@@ -36,7 +36,7 @@ class RunConfiguration(GDKProject):
 
         _nucleus_archive_path = Path(_nucleus_archive).resolve()
         if not _nucleus_archive_path.exists():
-            raise Exception(
+            raise ValueError(
                 f"Cannot find nucleus archive at path {_nucleus_archive}. Please check 'ggc-archive' in the test config"
             )
         return _nucleus_archive_path
@@ -47,7 +47,7 @@ class RunConfiguration(GDKProject):
         """
         tags = self._test_options_from_config.get("tags", self._default_tags)
         if not tags:
-            raise Exception("Test tags provided in the config are invalid. Please check 'tags' in the test config")
+            raise ValueError("Test tags provided in the config are invalid. Please check 'tags' in the test config")
         return tags
 
     def _get_options(self) -> dict:
@@ -61,19 +61,19 @@ class RunConfiguration(GDKProject):
             else:
                 _options_args_json = json.loads(_options_args)
         except json.decoder.JSONDecodeError as err:
-            raise Exception(
-                "JSON string provided in the test commandis incorrectly formatted.\nError:\t" + str(err),
-            )
+            raise ValueError(
+                "JSON string provided in the test command is incorrectly formatted.\nError:\t" + str(err),
+            ) from err
         # Merge the options provided in the gdk-config.json with the ones provided as args in test command.
         # Options in args override the config.
-        logging.debug("Overriding the E2E testing options provided in the config with the ones provided as args")
+        logging.info("Overriding the E2E testing options provided in the config with the ones provided as args")
         _merged_dict = {**_options_from_config, **_options_args_json}
         return _merged_dict
 
     def _read_options_from_file(self, file: str) -> str:
         file_path = Path(file).resolve()
         if not file_path.exists():
-            raise Exception("Cannot find the E2E testing options file at the given path %s.", file)
+            raise ValueError(f"Cannot find the E2E testing options file at the given path {file}.")
 
         logging.debug("Reading E2E testing options from file %s", file)
         with open(file_path, "r", encoding="utf-8") as f:

--- a/gdk/common/config/GDKProject.py
+++ b/gdk/common/config/GDKProject.py
@@ -61,5 +61,5 @@ class GDKProject:
             raise Exception(error_messages.PROJECT_RECIPE_FILE_NOT_FOUND)
 
         recipe_file = (json_file + yaml_file)[0].resolve()
-        logging.info("Found component recipe file '{}' in the  project directory.".format(recipe_file.name))
+        logging.debug("Found component recipe file '{}' in the project directory.".format(recipe_file.name))
         return recipe_file

--- a/uat/component_build.feature
+++ b/uat/component_build.feature
@@ -14,7 +14,7 @@ Feature: gdk component build works
     And we verify component zip build files
     And we verify build artifact named HelloWorld.zip
 
-  @version(min='1.0.0')
+  @version(min='1.3.0')
   @change_cwd
   Scenario: build template zip using component name as zip name
     Given we have cli installed


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Update minimum version of GDK for the UAT with zip name feature. 
- Update logging. Raise `ValueError` instead of generic `Exception` and change log levels. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.