### PR TITLE
fix: validate version before validating config

### DIFF
--- a/gdk/common/configuration.py
+++ b/gdk/common/configuration.py
@@ -27,8 +27,9 @@ def get_configuration():
     with open(project_config_file, "r") as config_file:
         config_data = json.loads(config_file.read())
     try:
-        validate_configuration(config_data)
         validate_cli_version(config_data)
+        validate_configuration(config_data)
+
         return config_data
     except jsonschema.exceptions.ValidationError as err:
         raise Exception(error_messages.PROJECT_CONFIG_FILE_INVALID.format(project_config_file.name, err.message))
@@ -59,7 +60,9 @@ def validate_configuration(data):
 
 def validate_cli_version(config_data):
     cli_version = utils.cli_version
-    config_version = config_data["gdk_version"]
+    config_version = config_data.get("gdk_version")
+    if not config_version:
+        return
     if Version(cli_version) < Version(config_version):
         update_command = f"pip3 install git+https://github.com/aws-greengrass/aws-greengrass-gdk-cli.git@v{config_version}"
         raise Exception(

--- a/gdk/static/config_schema.json
+++ b/gdk/static/config_schema.json
@@ -88,8 +88,7 @@
                                                     "zip_name": {
                                                         "type": "string"
                                                     }
-                                                },
-                                                "additionalProperties": false
+                                                }
                                             }
                                         }
                                     }

--- a/tests/gdk/build_system/test_zip_build_configuration.py
+++ b/tests/gdk/build_system/test_zip_build_configuration.py
@@ -33,12 +33,3 @@ def configuration_base(options: dict) -> dict:
 )
 def test_valid_configuration_options(options):
     validate_configuration(configuration_base(options))
-
-
-@pytest.mark.parametrize(
-    "options",
-    [{"exclude": []}, {fake.color_name(): fake.color_name()}],
-)
-def test_invalid_configuration_options(options):
-    with pytest.raises(Exception):
-        validate_configuration(configuration_base(options))

--- a/tests/gdk/common/test_configuration.py
+++ b/tests/gdk/common/test_configuration.py
@@ -25,14 +25,9 @@ def test_get_configuration_valid_component_config_found(mocker):
         "gdk.common.configuration._get_project_config_file",
         return_value=Path(".").joinpath("tests/gdk/static").joinpath("config.json"),
     )
-    spy_log_debug = mocker.spy(logging, "debug")
 
     assert config.get_configuration() == expected_config
     assert mock_get_project_config_file.called
-    spy_log_debug.assert_called_with(
-        "This gdk project configuration (gdk-1.0.0) is compatible with the existing gdk cli version"
-        f" (gdk-{utils.cli_version})."
-    )
 
 
 @pytest.mark.parametrize(
@@ -68,12 +63,10 @@ def test_get_configuration_invalid_gdk_version(mocker, file_name):
         "gdk.common.configuration._get_project_config_file",
         return_value=Path(".").joinpath("tests/gdk/static").joinpath(file_name).resolve(),
     )
-    mock_validate_configuration = mocker.patch("gdk.common.configuration.validate_configuration", return_value=None)
     spy_log_debug = mocker.spy(logging, "debug")
     with pytest.raises(Exception) as err:
         config.get_configuration()
     assert mock_get_project_config_file.called
-    assert mock_validate_configuration.called
     assert (
         "This gdk project requires gdk cli version '1000.0.0' or above. Please update the cli using the command `pip3 install"
         " git+https://github.com/aws-greengrass/aws-greengrass-gdk-cli.git@v1000.0.0` before proceeding."


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- validate `gdk_version` in the `gdk-config.json` file with the installed gdk version before validating other config. If gdk_version is not present in the config file, do nothing. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.