### PR TITLE
feat: create json schema for user-input recipe

### DIFF
--- a/gdk/static/user_input_recipe_schema.json
+++ b/gdk/static/user_input_recipe_schema.json
@@ -1,0 +1,353 @@
+{
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "recipeformatversion": {
+            "type": "string",
+            "enum": ["2020-01-25"]
+        },
+        "componentname": {
+            "type": "string",
+            "oneOf": [
+                {"pattern": "^[a-zA-Z0-9-_.]+$"},
+                {"enum": ["{COMPONENT_NAME}"]}
+            ],
+            "maxLength": 128
+        },
+        "componentversion": {
+            "type": "string",
+            "maxLength": 64,
+            "oneOf": [
+                {
+                    "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?"
+                },
+                {
+                    "enum": ["NEXT_PATCH", "{COMPONENT_VERSION}"]
+                }
+            ]
+        },
+        "componentdescription": {
+            "type": "string"
+        },
+        "componentpublisher": {
+            "type": "string"
+        },
+        "componentconfiguration": {
+            "type": "object",
+            "properties": {
+                "defaultconfiguration": {}
+            }
+        },
+        "componentdependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "versionrequirement": {
+                        "type": "string"
+                    },
+                    "dependencytype": {
+                        "type": "string",
+                        "enum": ["SOFT", "HARD"]
+                    }
+                }
+            }
+        },
+        "componenttype": {
+            "type": "string"
+        },
+        "componentsource": {
+            "type": "string",
+            "pattern": "^arn:aws:lambda:.*$"
+        },
+        "manifests": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "platform": {
+                        "type": "object",
+                        "properties": {
+                            "os": {
+                                "type": "string"
+                            },
+                            "architecture": {
+                                "type": "string"
+                            },
+                            "architecture.detail": {
+                                "type": "string"
+                            },
+                            "key": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "lifecycle": {
+                        "type": "object",
+                        "properties": {
+                            "setenv": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
+                            },
+                            "install": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "script": {
+                                                "type": "string"
+                                            },
+                                            "requiresprivilege": {
+                                                "type": "boolean"
+                                            },
+                                            "skipif": {
+                                                "type": "string"
+                                            },
+                                            "timeout": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                            },
+                                            "setenv": {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                ]
+                            },
+                            "run": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "script": {
+                                                "type": "string"
+                                            },
+                                            "requiresprivilege": {
+                                                "type": "boolean"
+                                            },
+                                            "skipif": {
+                                                "type": "string"
+                                            },
+                                            "timeout": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                            },
+                                            "setenv": {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                ]
+                            },
+                            "startup": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "script": {
+                                                "type": "string"
+                                            },
+                                            "requiresPrivilege": {
+                                                "type": "boolean"
+                                            },
+                                            "skipif": {
+                                                "type": "string"
+                                            },
+                                            "timeout": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                            },
+                                            "setenv": {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                ]
+                            },
+                            "shutdown": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "script": {
+                                                "type": "string"
+                                            },
+                                            "requiresprivilege": {
+                                                "type": "boolean"
+                                            },
+                                            "skipif": {
+                                                "type": "string"
+                                            },
+                                            "timeout": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                            },
+                                            "setenv": {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                ]
+                            },
+                            "recover": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "script": {
+                                                "type": "string"
+                                            },
+                                            "requiresprivilege": {
+                                                "type": "boolean"
+                                            },
+                                            "skipif": {
+                                                "type": "string"
+                                            },
+                                            "timeout": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                            },
+                                            "setenv": {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                ]
+                            },
+                            "bootstrap": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "script": {
+                                                "type": "string"
+                                            },
+                                            "requiresprivilege": {
+                                                "type": "boolean"
+                                            },
+                                            "timeout": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                            },
+                                            "setenv": {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                ]
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "selections": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "artifacts": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "uri": {
+                                    "type": "string"
+                                },
+                                "unarchive": {
+                                    "type": "string",
+                                    "enum": [
+                                        "NONE",
+                                        "ZIP"
+                                    ]
+                                },
+                                "permission": {
+                                    "type": "object",
+                                    "properties": {
+                                        "read": {
+                                            "type": "string",
+                                            "enum": [
+                                                "NONE",
+                                                "OWNER",
+                                                "ALL"
+                                            ]
+                                        },
+                                        "execute": {
+                                            "type": "string",
+                                            "enum": [
+                                                "NONE",
+                                                "OWNER",
+                                                "ALL"
+                                            ]
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "digest": {
+                                    "type": "string"
+                                },
+                                "algorithm": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "lifecycle": {
+            "type": "object"
+        }
+    },
+    "required": ["recipeformatversion", "componentname"],
+    "additionalProperties": false
+}

--- a/gdk/static/user_input_recipe_schema.json
+++ b/gdk/static/user_input_recipe_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
         "recipeformatversion": {

--- a/tests/gdk/common/test_RecipeValidator.py
+++ b/tests/gdk/common/test_RecipeValidator.py
@@ -2,6 +2,11 @@ from pathlib import Path
 from unittest import TestCase
 
 import pytest
+import yaml
+import json
+import os
+
+from jsonschema import validate, exceptions
 
 from gdk.common.CaseInsensitive import CaseInsensitiveDict
 from gdk.common.RecipeValidator import RecipeValidator
@@ -17,7 +22,6 @@ class RecipeValidatorTest(TestCase):
             "valid_component_recipe.json").resolve()
         validator = RecipeValidator(json_file)
         recipe_data = validator._load_recipe()
-        print(recipe_data)
         assert isinstance(recipe_data, CaseInsensitiveDict)
         assert "manifests" in recipe_data
         assert "artifacts" in recipe_data["manifests"][0]
@@ -53,3 +57,61 @@ class RecipeValidatorTest(TestCase):
         with pytest.raises(ValueError) as e:
             validator._load_recipe()
         assert "Invalid recipe source type" in e.value.args[0]
+
+
+# =========================== Tests for recipe schema ===========================
+
+# Load the JSON schema
+with open('gdk/static/user_input_recipe_schema.json', 'r') as schema_file:
+    schema = json.load(schema_file)
+
+# Get the list of valid recipe files
+valid_recipe_files_json = [
+    os.path.join('tests/gdk/static/sample_recipes', filename)
+    for filename in os.listdir('tests/gdk/static/sample_recipes')
+    if filename.startswith('recipe') and filename.endswith('.json')
+]
+valid_recipe_files_yaml = [
+    os.path.join('tests/gdk/static/sample_recipes', filename)
+    for filename in os.listdir('tests/gdk/static/sample_recipes')
+    if filename.startswith('recipe') and filename.endswith('.yaml')
+]
+# Get the list of invalid recipe files
+invalid_recipe_files = [
+    os.path.join('tests/gdk/static/sample_recipes', filename)
+    for filename in os.listdir('tests/gdk/static/sample_recipes')
+    if filename.startswith('invalid') and filename.endswith('.json')
+]
+
+
+# Function to recursively convert keys to lowercase
+def convert_keys_to_lowercase(input_dict):
+    if isinstance(input_dict, dict):
+        return {key.lower(): convert_keys_to_lowercase(value) for key, value in input_dict.items()}
+    elif isinstance(input_dict, list):
+        return [convert_keys_to_lowercase(item) for item in input_dict]
+    else:
+        return input_dict
+
+
+# Define the test function
+@pytest.mark.parametrize("recipe_file", valid_recipe_files_json)
+def test_valid_recipes_json(recipe_file):
+    with open(recipe_file, 'r') as recipe_file:
+        recipe_data = json.load(recipe_file)
+        validate(instance=convert_keys_to_lowercase(recipe_data), schema=schema)
+
+
+@pytest.mark.parametrize("recipe_file", valid_recipe_files_yaml)
+def test_valid_recipes_yaml(recipe_file):
+    with open(recipe_file, 'r') as recipe_file:
+        recipe_data = yaml.safe_load(recipe_file)
+        validate(instance=convert_keys_to_lowercase(recipe_data), schema=schema)
+
+
+@pytest.mark.parametrize("recipe_file", invalid_recipe_files)
+def test_invalid_recipes_raise_error(recipe_file):
+    with open(recipe_file, 'r') as recipe_file:
+        recipe_data = json.load(recipe_file)
+        with pytest.raises(exceptions.ValidationError):
+            validate(instance=convert_keys_to_lowercase(recipe_data), schema=schema)

--- a/tests/gdk/static/sample_recipes/invalid_recipe_extra_property.json
+++ b/tests/gdk/static/sample_recipes/invalid_recipe_extra_property.json
@@ -1,0 +1,29 @@
+{
+  "RecipeFormatVersion": "2020-01-25",
+  "ComponentName": "ggV2HelloWorld",
+  "ComponentVersion": "{COMPONENT_VERSION}",
+  "ComponentDescription": "This is simple Hello World component written in Python.",
+  "ComponentPublisher": "{COMPONENT_AUTHOR}",
+  "ComponentConfiguration": {
+    "DefaultConfiguration": {
+      "Message": "World"
+    }
+  },
+  "Manifests": [
+    {
+      "Platform": {
+        "os": "all"
+      },
+      "Artifacts": [
+        {
+          "URI": "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/ggV2HelloWorld.zip",
+          "Unarchive": "ZIP"
+        }
+      ],
+      "Lifecycle": {
+        "run": "python3 -u {artifacts:decompressedPath}/ggV2HelloWorld/main.py {configuration:/Message}"
+      }
+    }
+  ],
+  "NewField": "extra data"
+}

--- a/tests/gdk/static/sample_recipes/invalid_recipe_incorrect_value.json
+++ b/tests/gdk/static/sample_recipes/invalid_recipe_incorrect_value.json
@@ -1,0 +1,28 @@
+{
+  "RecipeFormatVersion": "2020-01-25",
+  "ComponentName": "ggV2HelloWorld",
+  "ComponentVersion": "32.7",
+  "ComponentDescription": "This is simple Hello World component written in Python.",
+  "ComponentPublisher": "{COMPONENT_AUTHOR}",
+  "ComponentConfiguration": {
+    "DefaultConfiguration": {
+      "Message": "World"
+    }
+  },
+  "Manifests": [
+    {
+      "Platform": {
+        "os": "all"
+      },
+      "Artifacts": [
+        {
+          "URI": "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/ggV2HelloWorld.zip",
+          "Unarchive": "ZYP"
+        }
+      ],
+      "Lifecycle": {
+        "run": "python3 -u {artifacts:decompressedPath}/ggV2HelloWorld/main.py {configuration:/Message}"
+      }
+    }
+  ]
+}

--- a/tests/gdk/static/sample_recipes/invalid_recipe_mismatched_type.json
+++ b/tests/gdk/static/sample_recipes/invalid_recipe_mismatched_type.json
@@ -1,0 +1,32 @@
+{
+  "RecipeFormatVersion": "2020-01-25",
+  "ComponentName": 27,
+  "ComponentVersion": "{COMPONENT_VERSION}",
+  "ComponentDescription": "This is simple Hello World component written in Python.",
+  "ComponentPublisher": "{COMPONENT_AUTHOR}",
+  "ComponentConfiguration": {
+    "DefaultConfiguration": {
+      "Message": "World"
+    }
+  },
+  "Manifests": [
+    {
+      "Platform": {
+        "os": "all"
+      },
+      "Artifacts": [
+        {
+          "URI": "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/ggV2HelloWorld.zip",
+          "Unarchive": "ZIP",
+          "Permission": {
+            "read": "OWNER",
+            "execute": "ALL"
+          }
+        }
+      ],
+      "Lifecycle": {
+        "run": "python3 -u {artifacts:decompressedPath}/ggV2HelloWorld/main.py {configuration:/Message}"
+      }
+    }
+  ]
+}

--- a/tests/gdk/static/sample_recipes/invalid_recipe_missing_required_property.json
+++ b/tests/gdk/static/sample_recipes/invalid_recipe_missing_required_property.json
@@ -1,0 +1,27 @@
+{
+  "ComponentName": "ggV2HelloWorld",
+  "ComponentVersion": "{COMPONENT_VERSION}",
+  "ComponentDescription": "This is simple Hello World component written in Python.",
+  "ComponentPublisher": "{COMPONENT_AUTHOR}",
+  "ComponentConfiguration": {
+    "DefaultConfiguration": {
+      "Message": "World"
+    }
+  },
+  "Manifests": [
+    {
+      "Platform": {
+        "os": "all"
+      },
+      "Artifacts": [
+        {
+          "URI": "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/ggV2HelloWorld.zip",
+          "Unarchive": "ZIP"
+        }
+      ],
+      "Lifecycle": {
+        "run": "python3 -u {artifacts:decompressedPath}/ggV2HelloWorld/main.py {configuration:/Message}"
+      }
+    }
+  ]
+}

--- a/tests/gdk/static/sample_recipes/invalid_recipe_misspelling_property.json
+++ b/tests/gdk/static/sample_recipes/invalid_recipe_misspelling_property.json
@@ -1,0 +1,28 @@
+{
+  "RecipeFormatVersion": "2020-01-25",
+  "ComponentMeme": "ggV2HelloWorld",
+  "ComponentVersion": "{COMPONENT_VERSION}",
+  "ComponentDescription": "This is simple Hello World component written in Python.",
+  "ComponentPublisher": "{COMPONENT_AUTHOR}",
+  "ComponentConfiguration": {
+    "DefaultConfiguration": {
+      "Message": "World"
+    }
+  },
+  "Manifests": [
+    {
+      "Platform": {
+        "os": "all"
+      },
+      "Artifacts": [
+        {
+          "URI": "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/ggV2HelloWorld.zip",
+          "Unarchive": "ZIP"
+        }
+      ],
+      "Lifecycle": {
+        "run": "python3 -u {artifacts:decompressedPath}/ggV2HelloWorld/main.py {configuration:/Message}"
+      }
+    }
+  ]
+}

--- a/tests/gdk/static/sample_recipes/recipe_case_insensitive.json
+++ b/tests/gdk/static/sample_recipes/recipe_case_insensitive.json
@@ -1,0 +1,32 @@
+{
+  "recipeFormatVersion": "2020-01-25",
+  "cOmPonentName": "ggV2HelloWorld",
+  "ComponentVersion": "{COMPONENT_VERSION}",
+  "ComponentDescription": "This is simple Hello World component written in Python.",
+  "ComponentPublisher": "{COMPONENT_AUTHOR}",
+  "ComponentConfiguration": {
+    "DefaultCONfiguration": {
+      "MessaGe": "World"
+    }
+  },
+  "ManifestS": [
+    {
+      "PLATFORM": {
+        "os": "all"
+      },
+      "ArtIfacts": [
+        {
+          "uRi": "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/ggV2HelloWorld.zip",
+          "uNarchive": "ZIP",
+          "Permission": {
+            "read": "OWNER",
+            "execute": "ALL"
+          }
+        }
+      ],
+      "LifeCycle": {
+        "run": "python3 -u {artifacts:decompressedPath}/ggV2HelloWorld/main.py {configuration:/Message}"
+      }
+    }
+  ]
+}

--- a/tests/gdk/static/sample_recipes/recipe_case_insensitive.yaml
+++ b/tests/gdk/static/sample_recipes/recipe_case_insensitive.yaml
@@ -1,0 +1,21 @@
+recipeFormatVersion: '2020-01-25'
+cOmPonentName: ggV2HelloWorld
+ComponentVersion: '{COMPONENT_VERSION}'
+ComponentDesCription: This is simple Hello World component written in Python.
+ComponentPubLISher: '{COMPONENT_AUTHOR}'
+ComponentConFIGuration:
+  DefaultCONfiguration:
+    MessaGe: World
+ManifestS:
+  - PLATFORM:
+      oS: all
+    ArtIfacts:
+      - uRi: 's3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/ggV2HelloWorld.zip'
+        uNarchive: ZIP
+        PermisSion:
+          rEad: OWNER
+          execuTe: ALL
+    LifeCycle:
+      ruN: >-
+        python3 -u {artifacts:decompressedPath}/ggV2HelloWorld/main.py
+        {configuration:/Message}

--- a/tests/gdk/static/sample_recipes/recipe_gg_client_device_auth.json
+++ b/tests/gdk/static/sample_recipes/recipe_gg_client_device_auth.json
@@ -1,0 +1,27 @@
+{
+  "RecipeFormatVersion": "2020-01-25",
+  "ComponentName": "{COMPONENT_NAME}",
+  "ComponentVersion": "{COMPONENT_VERSION}",
+  "ComponentType": "aws.greengrass.plugin",
+  "ComponentDescription": "The client device auth component authenticates client devices and authorizes client device actions, so client devices can connect to your Greengrass core device. This component creates the certificate vended by the local MQTT broker.",
+  "ComponentPublisher": "{COMPONENT_PUBLISHER}",
+  "ComponentDependencies": {
+    "aws.greengrass.Nucleus": {
+      "VersionRequirement": ">=2.2.0 <2.10.0",
+      "DependencyType": "SOFT"
+    }
+  },
+  "Manifests": [
+    {
+      "Platform": {
+        "os": "*"
+      },
+      "Lifecycle": {},
+      "Artifacts": [
+        {
+          "URI": "s3://aws.greengrass.clientdevices.Auth.jar"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/gdk/static/sample_recipes/recipe_gg_disk_spooler.json
+++ b/tests/gdk/static/sample_recipes/recipe_gg_disk_spooler.json
@@ -1,0 +1,27 @@
+{
+  "RecipeFormatVersion": "2020-01-25",
+  "ComponentName": "{COMPONENT_NAME}",
+  "ComponentVersion": "{COMPONENT_VERSION}",
+  "ComponentType": "aws.greengrass.plugin",
+  "ComponentDescription": "The Disk Spooler component stores MQTT messages destined for AWS IoT Core in a database, as opposed to in memory, when offline.",
+  "ComponentPublisher": "{COMPONENT_PUBLISHER}",
+  "ComponentDependencies": {
+    "aws.greengrass.Nucleus": {
+      "VersionRequirement": ">=2.2.0 <2.11.0",
+      "DependencyType": "SOFT"
+    }
+  },
+  "Manifests": [
+    {
+      "Platform": {
+        "os": "*"
+      },
+      "Lifecycle": {},
+      "Artifacts": [
+        {
+          "URI": "s3://aws.greengrass.DiskSpooler.jar"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/gdk/static/sample_recipes/recipe_gg_nucleus.yaml
+++ b/tests/gdk/static/sample_recipes/recipe_gg_nucleus.yaml
@@ -1,0 +1,62 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: aws.greengrass.Nucleus
+ComponentType: aws.greengrass.nucleus
+ComponentDescription: Core functionality for device side orchestration of deployments and lifecycle management for execution of Greengrass components and applications. This includes features such as starting, stopping, and monitoring execution of components and apps, inter-process communication server for communication between components, component installation and configuration management. This is a fundamental cornerstone of open-sourcing Greengrass, providing documentation and ability to debug Greengrass Core.
+ComponentPublisher: AWS
+ComponentVersion: '2.12.0'
+ComponentConfiguration:
+  DefaultConfiguration:
+    iotDataEndpoint: ""
+    iotCredEndpoint: ""
+    greengrassDataPlanePort: 8443
+    awsRegion: ""
+    iotRoleAlias: ""
+    mqtt: {}
+    networkProxy: {}
+    runWithDefault: {}
+    deploymentPollingFrequencySeconds: 15
+    componentStoreMaxSizeBytes: 10000000000
+    platformOverride: {}
+Manifests:
+  - Platform:
+      os: darwin
+    Lifecycle:
+      bootstrap:
+        RequiresPrivilege: true
+        script: |-
+
+          set -eu
+          KERNEL_ROOT="{kernel:rootPath}"
+          UNPACK_DIR="{artifacts:decompressedPath}/aws.greengrass.nucleus"
+          rm -r "$KERNEL_ROOT"/alts/current/*
+          echo "{configuration:/jvmOptions}" > "$KERNEL_ROOT/alts/current/launch.params"
+          ln -sf "$UNPACK_DIR" "$KERNEL_ROOT/alts/current/distro"
+          exit 100
+
+  - Platform:
+      os: linux
+    Lifecycle:
+      bootstrap:
+        RequiresPrivilege: true
+        script: |-
+
+          set -eu
+          KERNEL_ROOT="{kernel:rootPath}"
+          UNPACK_DIR="{artifacts:decompressedPath}/aws.greengrass.nucleus"
+          rm -r "$KERNEL_ROOT"/alts/current/*
+          echo "{configuration:/jvmOptions}" > "$KERNEL_ROOT/alts/current/launch.params"
+          ln -sf "$UNPACK_DIR" "$KERNEL_ROOT/alts/current/distro"
+          exit 100
+  - Platform:
+      os: windows
+    Lifecycle:
+      bootstrap:
+        RequiresPrivilege: true
+        script: >-
+          copy "{kernel:rootPath}\alts\current\distro\bin\greengrass.xml" "{artifacts:decompressedPath}\aws.greengrass.nucleus\bin\greengrass.xml"& del /q "{kernel:rootPath}\alts\current\*"&& for /d %x in ("{kernel:rootPath}\alts\current\*") do @rd /s /q "%x"&& echo {configuration:/jvmOptions} > "{kernel:rootPath}\alts\current\launch.params"&& mklink /d "{kernel:rootPath}\alts\current\distro" "{artifacts:decompressedPath}\aws.greengrass.nucleus"&& exit 100

--- a/tests/gdk/static/sample_recipes/recipe_gg_secret_manager.yaml
+++ b/tests/gdk/static/sample_recipes/recipe_gg_secret_manager.yaml
@@ -1,0 +1,13 @@
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: aws.greengrass.SecretManager
+ComponentDescription: AWS Greengrass Secret Manager
+ComponentPublisher: AWS
+ComponentVersion: '0.0.0'
+ComponentType: 'aws.greengrass.plugin'
+ComponentConfiguration:
+  DefaultConfiguration:
+    cloudSecrets: []
+Manifests:
+  - Artifacts:
+      - URI: s3://gg-dev-artifacts-$stage/$componentName/$version/aws.greengrass.SecretManager.jar


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
I have added a JSON schema file that defines the user-input recipe format and structure. The schema is based on the existing recipe definition in its Java package and its documentation, which allows for further semantic validation. 

**Why is this change necessary:**
The JSON schema is essential for validating user-input recipes and ensuring they conform to the expected format. By using the schema, we can enforce constraints on the recipe properties and catch any potential errors or invalid input early in the process.

**How was this change tested:**
I have tested the JSON schema by validating it against various recipes manually. And all unit tests (including newly added tests) and integration tests passed successfully.

**Any additional information or context required to review the change:**
One important aspect to consider is the naming convention for recipe properties. While the recipe follows the CamelCase naming convention for properties in its documentation, hands-on experimentation has revealed that the recipe properties can be case-insensitive when specified. To accommodate this behavior, I have deliberately made all property names in the JSON schema lowercase. During the validation process, the property names will be converted to lowercase in the data object before applying the schema. This approach ensures that the validation process is case-insensitive and can handle variations in property casing.

**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.