### PR TITLE
fix: wizard bug fix

### DIFF
--- a/gdk/wizard/ConfigEnum.py
+++ b/gdk/wizard/ConfigEnum.py
@@ -19,10 +19,10 @@ class ConfigEnum(Enum):
     BUILD = ConfigEnumDefault("build", default={})
     BUILD_SYSTEM = ConfigEnumDefault("build_system", "zip")
     CUSTOM_BUILD_COMMAND = ConfigEnumDefault("custom_build_command")
-    BUILD_OPTIONS = ConfigEnumDefault("options", "{}")
+    BUILD_OPTIONS = ConfigEnumDefault("options", default={})
 
     PUBLISH = ConfigEnumDefault("publish", default={})
     BUCKET = ConfigEnumDefault("bucket", default="gg-component-bucket")
     REGION = ConfigEnumDefault("region", default="us-east-1")
-    PUBLISH_OPTIONS = ConfigEnumDefault("options", "{}")
+    PUBLISH_OPTIONS = ConfigEnumDefault("options", default={})
     GDK_VERSION = ConfigEnumDefault("gdk_version", default="1.0.0")

--- a/gdk/wizard/WizardChecker.py
+++ b/gdk/wizard/WizardChecker.py
@@ -85,13 +85,11 @@ class WizardChecker:
             return len(input_value) > 0
 
     def is_valid_build_options(self, input_value):
-        # empty dictionary is valid
-        if input_value == "{}":
-            return True
-
+        # empty dictionaries are valid
         try:
             # Convert the input string to a dictionary (object)
-            input_obj = json.loads(input_value)
+            formatted_input = input_value.replace("'", '"')
+            input_obj = json.loads(formatted_input)
         except json.JSONDecodeError:
             return False
 
@@ -124,7 +122,8 @@ class WizardChecker:
         # input_value will always be a string so must try to convert it to a dict
 
         try:
-            input_object = json.loads(input_value)
+            formatted_input = input_value.replace("'", '"')
+            input_object = json.loads(formatted_input)
         except json.JSONDecodeError:
             return False
 

--- a/gdk/wizard/WizardData.py
+++ b/gdk/wizard/WizardData.py
@@ -1,4 +1,6 @@
 from gdk.wizard.ConfigEnum import ConfigEnum
+import json
+import ast
 
 
 class Model:
@@ -106,28 +108,38 @@ class WizardData:
         )
 
     def set_author(self, value):
-        if value:
+        if value is not None:
             self.component_config[ConfigEnum.AUTHOR.value.key] = value
 
     def set_version(self, value):
-        if value:
+        if value is not None:
             self.component_config[ConfigEnum.VERSION.value.key] = value
 
     def _set_build_config_values(self, field, value):
-        if value:
+        if value is not None:
             self.component_config[ConfigEnum.BUILD.value.key][field.key] = value
 
     def set_build_system(self, value):
         self._set_build_config_values(ConfigEnum.BUILD_SYSTEM.value, value)
 
     def set_custom_build_command(self, value):
-        self._set_build_config_values(ConfigEnum.CUSTOM_BUILD_COMMAND.value, value)
+        # value can be a list in string form or a string
+        new_value = value
+        try:
+            input_list = ast.literal_eval(value)
+            if isinstance(input_list, list):
+                new_value = input_list
+        except Exception:
+            pass
+        self._set_build_config_values(ConfigEnum.CUSTOM_BUILD_COMMAND.value, new_value)
 
     def set_build_options(self, value):
-        self._set_build_config_values(ConfigEnum.BUILD_OPTIONS.value, value)
+        formatted_input = value.replace("'", '"')
+        new_value = json.loads(formatted_input) if isinstance(value, str) else value
+        self._set_build_config_values(ConfigEnum.BUILD_OPTIONS.value, new_value)
 
     def _set_publish_config_values(self, field, value):
-        if value:
+        if value is not None:
             self.component_config[ConfigEnum.PUBLISH.value.key][field.key] = value
 
     def set_bucket(self, value):
@@ -137,8 +149,11 @@ class WizardData:
         self._set_publish_config_values(ConfigEnum.REGION.value, value)
 
     def set_publish_options(self, value):
-        self._set_publish_config_values(ConfigEnum.PUBLISH_OPTIONS.value, value)
+        # value can be a dict object or a string
+        formatted_input = value.replace("'", '"')
+        new_value = json.loads(formatted_input) if isinstance(value, str) else value
+        self._set_publish_config_values(ConfigEnum.PUBLISH_OPTIONS.value, new_value)
 
     def set_gdk_version(self, value):
-        if value:
+        if value is not None:
             self.field_dict[ConfigEnum.GDK_VERSION.value.key] = value

--- a/tests/gdk/wizard/test_WizardData.py
+++ b/tests/gdk/wizard/test_WizardData.py
@@ -78,7 +78,7 @@ class TestWizardModel(TestCase):  # Inherit from unittest.TestCase
 
     def test_set_build_options(self):
         data = WizardData(self.field_dict)
-        data.set_build_options({"bar": "foo"})
+        data.set_build_options('{"bar": "foo"}')
         self.assertEqual(data.get_build_options(), {"bar": "foo"})
 
     def test_set_bucket(self):
@@ -93,7 +93,7 @@ class TestWizardModel(TestCase):  # Inherit from unittest.TestCase
 
     def test_set_publish_options(self):
         data = WizardData(self.field_dict)
-        data.set_publish_options({"bar": "foo"})
+        data.set_publish_options('{"bar": "foo"}')
         self.assertEqual(data.get_publish_options(), {"bar": "foo"})
 
     def test_set_gdk_version(self):

--- a/tests/gdk/wizard/test_WizardData.py
+++ b/tests/gdk/wizard/test_WizardData.py
@@ -38,7 +38,7 @@ class TestWizardModel(TestCase):  # Inherit from unittest.TestCase
 
     def test_get_build_options(self):
         data = WizardData(self.field_dict)
-        self.assertEqual(data.get_build_options(), "{}")
+        self.assertEqual(data.get_build_options(), {})
 
     def test_get_bucket(self):
         data = WizardData(self.field_dict)
@@ -50,7 +50,7 @@ class TestWizardModel(TestCase):  # Inherit from unittest.TestCase
 
     def test_get_publish_options(self):
         data = WizardData(self.field_dict)
-        self.assertEqual(data.get_publish_options(), "{}")
+        self.assertEqual(data.get_publish_options(), {})
 
     def test_get_gdk_version(self):
         data = WizardData(self.field_dict)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixed a bug in the wizard
**Why is this change necessary:**
Two main issues: 
- checker and setter for publish and build options:
- ----- was setting strings to be the value for the build and publish options, essentially setting the value to be "{}" instead of {}, etc. 
------- JSON.load doesn't work for string dictionary objects that use single quotes for keys and values, so needed to convert each single quotation with double quotes for both the checkers and the setters 
- Custom Build Command setter:
- ------- automatically sets the input to be a string instead of trying to convert it to a list first
**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.