### PR TITLE
feat: add recipe input validation

### DIFF
--- a/gdk/commands/component/transformer/BuildRecipeTransformer.py
+++ b/gdk/commands/component/transformer/BuildRecipeTransformer.py
@@ -31,6 +31,7 @@ class BuildRecipeTransformer:
         try:
             validator = RecipeValidator(component_recipe)
             validator.validate_semantics()
+            validator.validate_input()
         except jsonschema.exceptions.ValidationError as err:
             raise Exception(error_messages.RECIPE_FILE_INVALID.format(self.project_config.recipe_file, err.message))
         self.update_component_recipe_file(component_recipe, build_folders)

--- a/gdk/commands/component/transformer/BuildRecipeTransformer.py
+++ b/gdk/commands/component/transformer/BuildRecipeTransformer.py
@@ -28,6 +28,7 @@ class BuildRecipeTransformer:
 
     def transform(self, build_folders):
         component_recipe = CaseInsensitiveRecipeFile().read(self.project_config.recipe_file)
+        logging.info(f"Validating the recipe file {self.project_config.recipe_file}")
         try:
             validator = RecipeValidator(component_recipe)
             validator.validate_semantics()

--- a/gdk/common/RecipeValidator.py
+++ b/gdk/common/RecipeValidator.py
@@ -113,7 +113,8 @@ class RecipeValidator:
             lifecycle = self.recipe_data["lifecycle"]
             if "startup" in lifecycle and "run" in lifecycle:
                 logging.warning(
-                    "You can define only one startup or run lifecycle. Defining both may lead to unexpected behavior.")
+                    "You can define only one startup or run lifecycle in a recipe. Defining both may lead to "
+                    "unexpected behavior.")
 
     def _validate_manifests(self):
         """
@@ -129,8 +130,8 @@ class RecipeValidator:
                 # Similar to the lifecycle check above, but this check is specific to the manifests section.
                 if "lifecycle" in manifest and "startup" in manifest["lifecycle"] and "run" in manifest["lifecycle"]:
                     logging.warning(
-                        "You can define only one startup or run lifecycle in manifest. "
-                        "Defining both may lead to unexpected behavior.")
+                        "You can define only one startup or run lifecycle in the recipe manifest. Defining both may "
+                        "result in unexpected behavior.")
 
     def _validate_artifacts(self, manifest):
         """
@@ -146,7 +147,7 @@ class RecipeValidator:
                     uris.append(uri)
                     # check if the URI of an artifact is an S3 bucket
                     if not uri.startswith(utils.s3_prefix):
-                        logging.warning(f"Provided URI '{uri}' is not an S3 bucket.")
+                        logging.warning(f"The provided URI '{uri}' in the recipe is not an S3 bucket.")
 
             # One potential scenario is when a user specifies an artifact URI, but the script to run
             # references a different artifact. Displaying a warning here can help identify such issues early
@@ -160,9 +161,9 @@ class RecipeValidator:
                 if script and uris:
                     artifact_names = [uri.split("/")[-1] for uri in uris]
                     if not any(artifact in script for artifact in artifact_names):
-                        logging.warning("The file name in the script does not match the artifact names in the "
-                                        "URI. If this is incorrect, please exit and ensure the artifacts and "
-                                        "the script are correct.")
+                        logging.warning("The filename in the script does not match the artifact names in the URI "
+                                        "provided in the recipe. If this is inaccurate, please exit and verify that "
+                                        "both the artifacts and the script are correct.")
 
     def _validate_platform(self, manifest):
         """
@@ -185,7 +186,8 @@ class RecipeValidator:
                     }
                     if os in os_architecture_dict and architecture not in os_architecture_dict[os]:
                         logging.warning(
-                            f"The specified architecture '{architecture}' may not be supported by the os '{os}'.")
+                            f"The specified architecture '{architecture}' may not be supported by the os '{os}' as "
+                            f"provided in the recipe.")
 
     def _load_recipe(self):
         """

--- a/gdk/static/user_input_recipe_schema.json
+++ b/gdk/static/user_input_recipe_schema.json
@@ -170,7 +170,7 @@
                                             "script": {
                                                 "type": "string"
                                             },
-                                            "requiresPrivilege": {
+                                            "requiresprivilege": {
                                                 "type": "boolean"
                                             },
                                             "skipif": {

--- a/tests/gdk/commands/component/transformer/test_BuildRecipeTransformer.py
+++ b/tests/gdk/commands/component/transformer/test_BuildRecipeTransformer.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest import TestCase
+from unittest import TestCase, mock
 from unittest.mock import call, Mock
 
 import pytest
@@ -83,6 +83,34 @@ class BuildRecipeTransformerTest(TestCase):
         mock_read.assert_called_once_with(config.recipe_file)
         mock_update.assert_not_called()
         mock_create.assert_not_called()
+
+    def test_transform_expect_input_validation_warning(self):
+        mock_read = self.mocker.patch.object(CaseInsensitiveRecipeFile, "read",
+                                             return_value=CaseInsensitiveDict(fake_recipe_with_input_issues()))
+        mock_update = self.mocker.patch.object(BuildRecipeTransformer, "update_component_recipe_file",
+                                               return_value=None)
+        mock_create = self.mocker.patch.object(BuildRecipeTransformer, "create_build_recipe_file", return_value=None)
+        build_folders = [Path("build-folder")]
+        config = ComponentBuildConfiguration({})
+        transformer = BuildRecipeTransformer(config)
+
+        with mock.patch('gdk.common.RecipeValidator.logging') as mock_logging:
+            transformer.transform(build_folders)
+
+        assert mock_logging.warning.call_count == 5
+        warning_args_list = mock_logging.warning.call_args_list
+        expected_warnings = [
+            "It's not recommended to specify the component type in a recipe.",
+            "It's not recommended to specify the component source in a recipe.",
+            "You can define only one startup or run lifecycle. Defining both may lead to unexpected behavior.",
+            "The file name in the script does not match the artifact names in the URI.",
+            "The specified architecture 'x86' may not be supported by the os 'macos'."
+        ]
+        for expected_warning in expected_warnings:
+            assert any(expected_warning in str(arg) for arg in warning_args_list)
+        mock_read.assert_called_once_with(config.recipe_file)
+        mock_update.assert_called_once_with(mock_read.return_value, build_folders)
+        mock_create.assert_called_once_with(mock_read.return_value)
 
     def test_update_component_recipe_file_in_build(self):
         brg = BuildRecipeTransformer(ComponentBuildConfiguration({}))
@@ -323,4 +351,33 @@ def fake_recipe():
                 "Artifacts": [{"URI": "s3://DOC-EXAMPLE-BUCKET/artifacts/com.example.HelloWorld/1.0.0/hello_world.py"}],
             }
         ],
+    }
+
+
+def fake_recipe_with_input_issues():
+    return {
+        "RecipeFormatVersion": "2020-01-25",
+        "ComponentName": "com.example.HelloWorld",
+        "ComponentVersion": "1.0.0",
+        "ComponentDescription": "My first Greengrass component.",
+        "ComponentPublisher": "Amazon",
+        "ComponentConfiguration": {"DefaultConfiguration": {"Message": "world"}},
+        "ComponentType": "aws.greengrass.generic",
+        "ComponentSource": "arn:aws:lambda:us-east-1:123456789012:function:example-function",
+        "LifeCycle": {
+            "startup": {},
+            "run": {}
+        },
+        "Manifests": [{
+            "Artifacts": [{"uri": "s3://example-bucket/file.txt"}],
+            "Platform": {
+                "os": "macos",
+                "architecture": "x86"
+            },
+            "LifeCycle": {
+                "Run": {
+                    "Script": "python3 -u {artifacts:decompressedPath}/HelloWorld/hello_world.py"
+                }
+            }
+        }]
     }

--- a/tests/gdk/commands/component/transformer/test_BuildRecipeTransformer.py
+++ b/tests/gdk/commands/component/transformer/test_BuildRecipeTransformer.py
@@ -102,9 +102,10 @@ class BuildRecipeTransformerTest(TestCase):
         expected_warnings = [
             "It's not recommended to specify the component type in a recipe.",
             "It's not recommended to specify the component source in a recipe.",
-            "You can define only one startup or run lifecycle. Defining both may lead to unexpected behavior.",
-            "The file name in the script does not match the artifact names in the URI.",
-            "The specified architecture 'x86' may not be supported by the os 'macos'."
+            "You can define only one startup or run lifecycle in a recipe. Defining both may lead to unexpected "
+            "behavior.",
+            "The filename in the script does not match the artifact names in the URI provided in the recipe.",
+            "The specified architecture 'x86' may not be supported by the os 'macos' as provided in the recipe."
         ]
         for expected_warning in expected_warnings:
             assert any(expected_warning in str(arg) for arg in warning_args_list)

--- a/tests/gdk/common/test_RecipeValidator.py
+++ b/tests/gdk/common/test_RecipeValidator.py
@@ -81,7 +81,7 @@ class RecipeValidatorTest(TestCase):
             validator.validate_input()
         assert mock_logging.warning.call_count == 1
         warnings = mock_logging.warning.call_args[0]
-        expected_warnings = "You can define only one startup or run lifecycle. " \
+        expected_warnings = "You can define only one startup or run lifecycle in a recipe. " \
                             "Defining both may lead to unexpected behavior."
         assert any(expected_warnings in arg for arg in warnings)
 
@@ -102,7 +102,7 @@ class RecipeValidatorTest(TestCase):
             validator.validate_input()
         assert mock_logging.warning.call_count == 1
         warnings = mock_logging.warning.call_args[0]
-        expected_warnings = "Provided URI 'https://example.com/file.txt' is not an S3 bucket."
+        expected_warnings = "The provided URI 'https://example.com/file.txt' in the recipe is not an S3 bucket."
         assert any(expected_warnings in arg for arg in warnings)
 
     def test_validate_input_script_does_not_match_artifact_uri_expect_warning(self):
@@ -125,8 +125,9 @@ class RecipeValidatorTest(TestCase):
             validator.validate_input()
         assert mock_logging.warning.call_count == 1
         warnings = mock_logging.warning.call_args[0]
-        expected_warnings = "The file name in the script does not match the artifact names in the URI. If this is " \
-                            "incorrect, please exit and ensure the artifacts and the script are correct."
+        expected_warnings = "The filename in the script does not match the artifact names in the URI provided in the " \
+                            "recipe. If this is inaccurate, please exit and verify that both the artifacts and the " \
+                            "script are correct."
         assert any(expected_warnings in arg for arg in warnings)
 
     def test_validate_input_script_in_run_does_not_match_artifact_uri_expect_warning(self):
@@ -151,8 +152,9 @@ class RecipeValidatorTest(TestCase):
             validator.validate_input()
         assert mock_logging.warning.call_count == 1
         warnings = mock_logging.warning.call_args[0]
-        expected_warnings = "The file name in the script does not match the artifact names in the URI. If this is " \
-                            "incorrect, please exit and ensure the artifacts and the script are correct."
+        expected_warnings = "The filename in the script does not match the artifact names in the URI provided in the " \
+                            "recipe. If this is inaccurate, please exit and verify that both the artifacts and the " \
+                            "script are correct."
         assert any(expected_warnings in arg for arg in warnings)
 
     def test_validate_input_mismatched_platform_architecture_expect_warning(self):
@@ -171,7 +173,8 @@ class RecipeValidatorTest(TestCase):
             validator.validate_input()
         assert mock_logging.warning.call_count == 1
         warnings = mock_logging.warning.call_args[0]
-        expected_warnings = "The specified architecture 'unknown_architecture' may not be supported by the os 'linux'."
+        expected_warnings = "The specified architecture 'unknown_architecture' may not be supported by the os " \
+                            "'linux' as provided in the recipe."
         assert any(expected_warnings in arg for arg in warnings)
 
     def test_validate_input_specify_both_startup_and_run_in_manifests_lifecycle_expect_warning(self):
@@ -194,8 +197,8 @@ class RecipeValidatorTest(TestCase):
             validator.validate_input()
         assert mock_logging.warning.call_count == 1
         warnings = mock_logging.warning.call_args[0]
-        expected_warnings = "You can define only one startup or run lifecycle in manifest. " \
-                            "Defining both may lead to unexpected behavior."
+        expected_warnings = "You can define only one startup or run lifecycle in the recipe manifest. " \
+                            "Defining both may result in unexpected behavior."
         assert any(expected_warnings in arg for arg in warnings)
 
     def test_validate_input_expect_multiple_warnings(self):
@@ -237,11 +240,11 @@ class RecipeValidatorTest(TestCase):
         expected_warnings = [
             "It's not recommended to specify the component type in a recipe.",
             "It's not recommended to specify the component source in a recipe.",
-            "You can define only one startup or run lifecycle. Defining both may lead to unexpected behavior.",
-            "Provided URI 's4://example-bucket/file.txt' is not an S3 bucket.",
-            "The file name in the script does not match the artifact names in the URI.",
-            "The specified architecture 'x86' may not be supported by the os 'macos'.",
-            "The specified architecture 'unknown' may not be supported by the os 'linux'."
+            "You can define only one startup or run lifecycle in a recipe.",
+            "The provided URI 's4://example-bucket/file.txt' in the recipe is not an S3 bucket.",
+            "The filename in the script does not match the artifact names in the URI provided in the recipe.",
+            "The specified architecture 'x86' may not be supported by the os 'macos' as provided in the recipe.",
+            "The specified architecture 'unknown' may not be supported by the os 'linux' as provided in the recipe."
         ]
         for expected_warning in expected_warnings:
             assert any(expected_warning in str(arg) for arg in warning_list)
@@ -303,7 +306,6 @@ class RecipeValidatorTest(TestCase):
         ]
         validator = RecipeValidator(CaseInsensitiveDict())
         output = validator._convert_keys_to_lowercase(input_list)
-        print(output)
         assert output == expected_output
 
     def test_convert_keys_to_lowercase_mixed(self):
@@ -351,7 +353,6 @@ class RecipeValidatorTest(TestCase):
         recipe_data = validator._load_recipe()
         assert isinstance(recipe_data, CaseInsensitiveDict)
         assert "componentconfiguration" in recipe_data
-        print(recipe_data["componentconfiguration"])
         assert "defaultconfiguration" in recipe_data["componentconfiguration"]
         assert "message" in recipe_data["componentconfiguration"]["defaultconfiguration"]
 

--- a/tests/gdk/common/test_RecipeValidator.py
+++ b/tests/gdk/common/test_RecipeValidator.py
@@ -36,6 +36,243 @@ class RecipeValidatorTest(TestCase):
         with pytest.raises(exceptions.ValidationError):
             validator.validate_semantics()
 
+    def test_validate_input_specify_component_type_expect_warning(self):
+        recipe_data = CaseInsensitiveDict({
+            "ComponentName": "example",
+            "RecipeFormatVersion": "2020-01-25",
+            "ComponentType": "aws.greengrass.generic"
+        })
+        validator = RecipeValidator(recipe_data)
+        with mock.patch('gdk.common.RecipeValidator.logging') as mock_logging:
+            validator.validate_input()
+        assert mock_logging.warning.call_count == 1
+        warnings = mock_logging.warning.call_args[0]
+        expected_warnings = "It's not recommended to specify the component type in a recipe. " \
+                            "AWS IoT Greengrass sets the type for you when you create a component."
+        assert any(expected_warnings in arg for arg in warnings)
+
+    def test_validate_input_specify_component_source_expect_warning(self):
+        recipe_data = CaseInsensitiveDict({
+            "ComponentName": "example",
+            "RecipeFormatVersion": "2020-01-25",
+            "ComponentSource": "arn:aws:lambda:us-east-1:123456789012:function:example-function"
+        })
+        validator = RecipeValidator(recipe_data)
+        with mock.patch('gdk.common.RecipeValidator.logging') as mock_logging:
+            validator.validate_input()
+        assert mock_logging.warning.call_count == 1
+        warnings = mock_logging.warning.call_args[0]
+        expected_warnings = "It's not recommended to specify the component source in a recipe. " \
+                            "AWS IoT Greengrass sets this parameter for you when you create a " \
+                            "component from a Lambda function."
+        assert any(expected_warnings in arg for arg in warnings)
+
+    def test_validate_input_specify_both_startup_and_run_expect_warning(self):
+        recipe_data = CaseInsensitiveDict({
+            "ComponentName": "example",
+            "RecipeFormatVersion": "2020-01-25",
+            "lifecycle": {
+                "startup": {},
+                "run": {}
+            }
+        })
+        validator = RecipeValidator(recipe_data)
+        with mock.patch('gdk.common.RecipeValidator.logging') as mock_logging:
+            validator.validate_input()
+        assert mock_logging.warning.call_count == 1
+        warnings = mock_logging.warning.call_args[0]
+        expected_warnings = "You can define only one startup or run lifecycle. " \
+                            "Defining both may lead to unexpected behavior."
+        assert any(expected_warnings in arg for arg in warnings)
+
+    def test_validate_input_non_s3_uri_expect_warning(self):
+        recipe_data = CaseInsensitiveDict({
+            "ComponentName": "example",
+            "RecipeFormatVersion": "2020-01-25",
+            "Manifests": [{
+                "Artifacts": [
+                    {
+                        "URI": "https://example.com/file.txt"
+                    }
+                ]
+            }]
+        })
+        validator = RecipeValidator(recipe_data)
+        with mock.patch('gdk.common.RecipeValidator.logging') as mock_logging:
+            validator.validate_input()
+        assert mock_logging.warning.call_count == 1
+        warnings = mock_logging.warning.call_args[0]
+        expected_warnings = "Provided URI 'https://example.com/file.txt' is not an S3 bucket."
+        assert any(expected_warnings in arg for arg in warnings)
+
+    def test_validate_input_script_does_not_match_artifact_uri_expect_warning(self):
+        recipe_data = CaseInsensitiveDict({
+            "ComponentName": "example",
+            "RecipeFormatVersion": "2020-01-25",
+            "Manifests": [{
+                "Artifacts": [
+                    {
+                        "URI": "s3://greengrasscomponent/sample.py"
+                    }
+                ],
+                "LifeCycle": {
+                    "Run": "python3 {artifacts:path}/sample555.py '{configuration:/Message}'"
+                }
+            }]
+        })
+        validator = RecipeValidator(recipe_data)
+        with mock.patch('gdk.common.RecipeValidator.logging') as mock_logging:
+            validator.validate_input()
+        assert mock_logging.warning.call_count == 1
+        warnings = mock_logging.warning.call_args[0]
+        expected_warnings = "The file name in the script does not match the artifact names in the URI. If this is " \
+                            "incorrect, please exit and ensure the artifacts and the script are correct."
+        assert any(expected_warnings in arg for arg in warnings)
+
+    def test_validate_input_script_in_run_does_not_match_artifact_uri_expect_warning(self):
+        recipe_data = CaseInsensitiveDict({
+            "ComponentName": "example",
+            "RecipeFormatVersion": "2020-01-25",
+            "Manifests": [{
+                "Artifacts": [
+                    {
+                        "URI": "s3://greengrasscomponent/sample.py"
+                    }
+                ],
+                "LifeCycle": {
+                    "Run": {
+                        "Script": "python3 {artifacts:path}/sample555.py '{configuration:/Message}'"
+                    }
+                }
+            }]
+        })
+        validator = RecipeValidator(recipe_data)
+        with mock.patch('gdk.common.RecipeValidator.logging') as mock_logging:
+            validator.validate_input()
+        assert mock_logging.warning.call_count == 1
+        warnings = mock_logging.warning.call_args[0]
+        expected_warnings = "The file name in the script does not match the artifact names in the URI. If this is " \
+                            "incorrect, please exit and ensure the artifacts and the script are correct."
+        assert any(expected_warnings in arg for arg in warnings)
+
+    def test_validate_input_mismatched_platform_architecture_expect_warning(self):
+        recipe_data = CaseInsensitiveDict({
+            "ComponentName": "example",
+            "RecipeFormatVersion": "2020-01-25",
+            "Manifests": [{
+                "Platform": {
+                    "os": "linux",
+                    "architecture": "unknown_architecture"
+                }
+            }]
+        })
+        validator = RecipeValidator(recipe_data)
+        with mock.patch('gdk.common.RecipeValidator.logging') as mock_logging:
+            validator.validate_input()
+        assert mock_logging.warning.call_count == 1
+        warnings = mock_logging.warning.call_args[0]
+        expected_warnings = "The specified architecture 'unknown_architecture' may not be supported by the os 'linux'."
+        assert any(expected_warnings in arg for arg in warnings)
+
+    def test_validate_input_specify_both_startup_and_run_in_manifests_lifecycle_expect_warning(self):
+        recipe_data = CaseInsensitiveDict({
+            "ComponentName": "example",
+            "RecipeFormatVersion": "2020-01-25",
+            "Manifests": [{
+                "Platform": {
+                    "os": "linux",
+                    "architecture": "x86"
+                },
+                "LifeCycle": {
+                    "Startup": {},
+                    "Run": {}
+                }
+            }]
+        })
+        validator = RecipeValidator(recipe_data)
+        with mock.patch('gdk.common.RecipeValidator.logging') as mock_logging:
+            validator.validate_input()
+        assert mock_logging.warning.call_count == 1
+        warnings = mock_logging.warning.call_args[0]
+        expected_warnings = "You can define only one startup or run lifecycle in manifest. " \
+                            "Defining both may lead to unexpected behavior."
+        assert any(expected_warnings in arg for arg in warnings)
+
+    def test_validate_input_expect_multiple_warnings(self):
+        recipe_data = CaseInsensitiveDict({
+            "ComponentType": "aws.greengrass.generic",
+            "ComponentSource": "arn:aws:lambda:us-east-1:123456789012:function:example-function",
+            "LifeCycle": {
+                "startup": {},
+                "run": {}
+            },
+            "Manifests": [
+                {
+                    "Platform": {
+                        "os": "linux",
+                        "architecture": "unknown"
+                    },
+                    "Artifacts": [
+                        {"uri": "s3://example-bucket/file.txt"},
+                        {"uri": "s4://example-bucket/file.txt"}],
+                    "LifeCycle": {
+                        "Run": {
+                            "Script": "python3 -u {artifacts:decompressedPath}/HelloWorld/hello_world.py"
+                        }
+                    }
+                },
+                {
+                    "Platform": {
+                        "os": "macos",
+                        "architecture": "x86"
+                    },
+                }
+            ]
+        })
+        validator = RecipeValidator(recipe_data)
+        with mock.patch('gdk.common.RecipeValidator.logging') as mock_logging:
+            validator.validate_input()
+        assert mock_logging.warning.call_count == 7
+        warning_list = mock_logging.warning.call_args_list
+        expected_warnings = [
+            "It's not recommended to specify the component type in a recipe.",
+            "It's not recommended to specify the component source in a recipe.",
+            "You can define only one startup or run lifecycle. Defining both may lead to unexpected behavior.",
+            "Provided URI 's4://example-bucket/file.txt' is not an S3 bucket.",
+            "The file name in the script does not match the artifact names in the URI.",
+            "The specified architecture 'x86' may not be supported by the os 'macos'.",
+            "The specified architecture 'unknown' may not be supported by the os 'linux'."
+        ]
+        for expected_warning in expected_warnings:
+            assert any(expected_warning in str(arg) for arg in warning_list)
+
+    def test_validate_input_expect_no_warnings(self):
+        recipe_data = CaseInsensitiveDict({
+            "RecipeFormatVersion": "2020-01-25",
+            "ComponentName": "{COMPONENT_NAME}",
+            "ComponentVersion": "{COMPONENT_VERSION}",
+            "Manifests": [
+                {
+                    "Platform": {
+                        "os": "*",
+                        "architecture": "arm"
+                    },
+                    "Lifecycle": {
+                        "Run": "java -jar {artifacts:path}/aws.greengrass.example.jar"
+                    },
+                    "Artifacts": [
+                        {
+                            "URI": "s3://aws.greengrass.example.jar"
+                        }
+                    ]
+                }
+            ]
+        })
+        validator = RecipeValidator(recipe_data)
+        with mock.patch('gdk.common.RecipeValidator.logging') as mock_logging:
+            validator.validate_input()
+        assert mock_logging.warning.call_count == 0
+
     def test_convert_keys_to_lowercase_dict(self):
         input_dict = CaseInsensitiveDict({
             "Key1": "Value1",
@@ -51,7 +288,7 @@ class RecipeValidatorTest(TestCase):
                 "subkey2": "SubValue2"
             }
         }
-        validator = RecipeValidator(None)
+        validator = RecipeValidator(CaseInsensitiveDict())
         output = validator._convert_keys_to_lowercase(input_dict)
         assert output == expected_output
 
@@ -64,7 +301,7 @@ class RecipeValidatorTest(TestCase):
             {"key1": "Value1"},
             {"key2": "Value2"}
         ]
-        validator = RecipeValidator(None)
+        validator = RecipeValidator(CaseInsensitiveDict())
         output = validator._convert_keys_to_lowercase(input_list)
         print(output)
         assert output == expected_output
@@ -84,7 +321,7 @@ class RecipeValidatorTest(TestCase):
             ],
             "key2": "Value2"
         }
-        validator = RecipeValidator(None)
+        validator = RecipeValidator(CaseInsensitiveDict())
         output = validator._convert_keys_to_lowercase(input_mixed)
         assert output == expected_output
 
@@ -100,9 +337,9 @@ class RecipeValidatorTest(TestCase):
     def test_load_from_file_invalid_json(self):
         json_file = Path(".").joinpath("tests/gdk/static/project_utils").joinpath(
             "invalid_component_recipe.json").resolve()
-        validator = RecipeValidator(json_file)
+
         with pytest.raises(json.JSONDecodeError) as e:
-            validator._load_recipe()
+            RecipeValidator(json_file)
 
         assert isinstance(e.value, json.JSONDecodeError)
 
@@ -122,17 +359,17 @@ class RecipeValidatorTest(TestCase):
         yaml_file = Path(".").joinpath("tests/gdk/static/project_utils").joinpath(
             "invalid_component_recipe.yaml"
         ).resolve()
-        validator = RecipeValidator(yaml_file)
+
         with pytest.raises(yaml.YAMLError) as e:
-            validator._load_recipe()
+            RecipeValidator(yaml_file)
 
         assert isinstance(e.value, yaml.YAMLError)
 
     def test_load_from_file_invalid_format(self):
         invalid_file = Path(".").joinpath("tests/gdk/static/project_utils").joinpath("not_exists.txt").resolve()
-        validator = RecipeValidator(invalid_file)
+
         with pytest.raises(Exception) as e:
-            validator._load_recipe()
+            RecipeValidator(invalid_file)
         assert "Recipe file must be in json or yaml format" in e.value.args[0]
 
     def test_load_from_dict(self):
@@ -145,9 +382,9 @@ class RecipeValidatorTest(TestCase):
 
     def test_load_from_invalid_type(self):
         invalid_data = "invalid_data"
-        validator = RecipeValidator(invalid_data)
+
         with pytest.raises(ValueError) as e:
-            validator._load_recipe()
+            RecipeValidator(invalid_data)
         assert "Invalid recipe source type" in e.value.args[0]
 
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Added recipe input validation to check specific recipe properties and log a warning if any violations are detected.

**Why is this change necessary:**
This change is necessary to proactively identify and address potential issues during the build stage.

**How was this change tested:**
New unit tests have been added and all tests passed successfully.

**Any additional information or context required to review the change:**
The decision to display warnings instead of raising errors is based on the understanding that these issues may not be critical enough to block component deployment or runtime. The warnings are intended to alert customers early in the process, allowing them to be aware of and mitigate potential issues.

An example output for a recipe with potential issues:
[2023-08-18 13:14:36] INFO - Building the component 'com.example.PythonHelloWorld' with the given project configuration.
[2023-08-18 13:14:36] INFO - Using 'zip' build system to build the component.
[2023-08-18 13:14:36] WARNING - This component is identified as using 'zip' build system. If this is incorrect, please exit and specify custom build command in the 'gdk-config.json'.
[2023-08-18 13:14:36] WARNING - It's not recommended to specify the component type in a recipe. AWS IoT Greengrass sets the type for you when you create a component.
[2023-08-18 13:14:36] WARNING - The file name in the script does not match the artifact names in the URI. If this is incorrect, please exit and ensure the artifacts and the script are correct.
[2023-08-18 13:14:36] INFO - Copying over the build artifacts to the greengrass component artifacts build folder.
[2023-08-18 13:14:36] INFO - Updating artifact URIs in the recipe.


**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.