### PR TITLE
feat: add recipe file size validation

### DIFF
--- a/gdk/commands/component/transformer/BuildRecipeTransformer.py
+++ b/gdk/commands/component/transformer/BuildRecipeTransformer.py
@@ -31,8 +31,7 @@ class BuildRecipeTransformer:
 
         # Validate the size of the recipe file before processing its content.
         if not utils.valid_recipe_file_size(self.project_config.recipe_file):
-            logging.error("The size of the recipe exceeds the maximum allowed size. Please ensure the recipe size "
-                          "does not exceed 16 KB.")
+            logging.error(error_messages.RECIPE_SIZE_INVALID.format(self.project_config.recipe_file))
             raise Exception(error_messages.RECIPE_SIZE_INVALID.format(self.project_config.recipe_file))
 
         component_recipe = CaseInsensitiveRecipeFile().read(self.project_config.recipe_file)

--- a/gdk/common/RecipeValidator.py
+++ b/gdk/common/RecipeValidator.py
@@ -28,6 +28,9 @@ class RecipeValidator:
 
     Methods
     -------
+    validate_recipe_format_version()
+        Validates that the provided RecipeFormatVersion in the recipe is valid and compatible with the gdk.
+
     validate_semantics()
         Validates the semantics of the component recipe against the Greengrass component recipe schema.
 
@@ -48,6 +51,33 @@ class RecipeValidator:
         """
         self.recipe_source = recipe_source
         self.recipe_data = self._convert_keys_to_lowercase(self._load_recipe())
+
+    def validate_recipe_format_version(self):
+        """
+        Validate the Recipe Format Version in the recipe data.
+
+        This method checks whether the provided Recipe Format Version is valid and supported.
+
+        Raises
+        ------
+        Exception
+            If the RecipeFormatVersion field is missing or unsupported.
+
+        """
+        recipe_format_version = self.recipe_data.get("recipeformatversion")
+        if not recipe_format_version:
+            logging.error("Recipe validation failed for 'RecipeFormatVersion'. This field is required but missing "
+                          "from the recipe. Please correct it and try again.")
+            raise Exception("The recipe file is invalid. The 'RecipeFormatVersion' field is mandatory in the recipe.")
+
+        supported_recipe_version = ["2020-01-25"]
+        if recipe_format_version not in supported_recipe_version:
+            logging.error(f"Recipe validation failed for: 'RecipeFormatVersion: {recipe_format_version}'.")
+            logging.error(f"The provided RecipeFormatVersion '{recipe_format_version}' is not supported in this gdk "
+                          f"version. Please ensure that it is a valid RecipeFormatVersion compatible with the gdk, "
+                          f"and refer to the list of supported RecipeFormatVersion: {supported_recipe_version}.")
+            raise Exception("The provided RecipeFormatVersion in the recipe is invalid. Please ensure that it follows "
+                            "the correct format and matches one of the supported versions.")
 
     def validate_semantics(self):
         """

--- a/gdk/common/RecipeValidator.py
+++ b/gdk/common/RecipeValidator.py
@@ -61,23 +61,21 @@ class RecipeValidator:
         Raises
         ------
         Exception
-            If the RecipeFormatVersion field is missing or unsupported.
+            If the RecipeFormatVersion field is missing.
 
         """
         recipe_format_version = self.recipe_data.get("recipeformatversion")
         if not recipe_format_version:
-            logging.error("Recipe validation failed for 'RecipeFormatVersion'. This field is required but missing "
-                          "from the recipe. Please correct it and try again.")
-            raise Exception("The recipe file is invalid. The 'RecipeFormatVersion' field is mandatory in the recipe.")
+            err_msg = "Recipe validation failed for 'RecipeFormatVersion'. This field is required but missing " \
+                      "from the recipe. Please correct it and try again."
+            logging.error(err_msg)
+            raise Exception(err_msg)
 
         supported_recipe_version = ["2020-01-25"]
         if recipe_format_version not in supported_recipe_version:
-            logging.error(f"Recipe validation failed for: 'RecipeFormatVersion: {recipe_format_version}'.")
-            logging.error(f"The provided RecipeFormatVersion '{recipe_format_version}' is not supported in this gdk "
-                          f"version. Please ensure that it is a valid RecipeFormatVersion compatible with the gdk, "
-                          f"and refer to the list of supported RecipeFormatVersion: {supported_recipe_version}.")
-            raise Exception("The provided RecipeFormatVersion in the recipe is invalid. Please ensure that it follows "
-                            "the correct format and matches one of the supported versions.")
+            logging.warning(f"The provided RecipeFormatVersion '{recipe_format_version}' is not supported in this gdk "
+                            f"version. Please ensure that it is a valid RecipeFormatVersion compatible with the gdk, "
+                            f"and refer to the list of supported RecipeFormatVersion: {supported_recipe_version}.")
 
     def validate_semantics(self):
         """

--- a/gdk/common/consts.py
+++ b/gdk/common/consts.py
@@ -13,6 +13,10 @@ arg_parameters = [
     "metavar",
     "dest",
 ]
+
+# FILE SIZE
+MAX_RECIPE_FILE_SIZE_BYTES = 16000
+
 # FILES
 config_schema_file = "config_schema.json"
 user_input_recipe_schema_file = "user_input_recipe_schema.json"

--- a/gdk/common/exceptions/error_messages.py
+++ b/gdk/common/exceptions/error_messages.py
@@ -8,6 +8,7 @@ PROJECT_RECIPE_FILE_NOT_FOUND = (
 )
 PROJECT_CONFIG_FILE_INVALID = "Project configuration file '{}' is invalid. Please correct its format and try again. Error: {} "
 RECIPE_FILE_INVALID = "The input recipe file '{}' is invalid. Please correct its format and try again. Error: {} "
+RECIPE_SIZE_INVALID = "The input recipe file '{}' has an invalid size. Please make sure it does not exceed 16KB and try again."
 CLI_MODEL_FILE_NOT_EXISTS = "Model validation failed. CLI model file doesn't exist."
 USER_INPUT_RECIPE_NOT_EXISTS = (
     "Recipe file not found. "

--- a/gdk/common/exceptions/error_messages.py
+++ b/gdk/common/exceptions/error_messages.py
@@ -8,7 +8,7 @@ PROJECT_RECIPE_FILE_NOT_FOUND = (
 )
 PROJECT_CONFIG_FILE_INVALID = "Project configuration file '{}' is invalid. Please correct its format and try again. Error: {} "
 RECIPE_FILE_INVALID = "The input recipe file '{}' is invalid. Please correct its format and try again. Error: {} "
-RECIPE_SIZE_INVALID = "The input recipe file '{}' has an invalid size. Please make sure it does not exceed 16KB and try again."
+RECIPE_SIZE_INVALID = "The input recipe file '{}' has an invalid size. Please make sure it does not exceed 16kB and try again."
 CLI_MODEL_FILE_NOT_EXISTS = "Model validation failed. CLI model file doesn't exist."
 USER_INPUT_RECIPE_NOT_EXISTS = (
     "Recipe file not found. "

--- a/gdk/common/utils.py
+++ b/gdk/common/utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import shutil
 from pathlib import Path
 
@@ -224,6 +225,11 @@ def parse_json_schema_errors(error):
         logging.info("To address this issue, consider the following steps: ")
         for fix in fixes:
             logging.info(f"\t {fix}")
+
+
+def valid_recipe_file_size(file_path):
+    file_size = os.path.getsize(file_path)
+    return file_size < 16234    # max allowed byte
 
 
 error_line = "\n=============================== ERROR ===============================\n"

--- a/gdk/common/utils.py
+++ b/gdk/common/utils.py
@@ -8,6 +8,7 @@ from packaging.version import Version
 
 import gdk
 import gdk._version as version
+from gdk.common import consts
 from gdk.common.exceptions import syntax_error_message
 
 
@@ -229,7 +230,7 @@ def parse_json_schema_errors(error):
 
 def valid_recipe_file_size(file_path):
     file_size = os.path.getsize(file_path)
-    return file_size < 16234    # max allowed byte
+    return file_size <= consts.MAX_RECIPE_FILE_SIZE_BYTES
 
 
 error_line = "\n=============================== ERROR ===============================\n"

--- a/tests/gdk/commands/component/transformer/test_BuildRecipeTransformer.py
+++ b/tests/gdk/commands/component/transformer/test_BuildRecipeTransformer.py
@@ -36,6 +36,7 @@ class BuildRecipeTransformerTest(TestCase):
         assert brg.project_config == pc
 
     def test_transform(self):
+        self.mocker.patch("gdk.common.utils.valid_recipe_file_size", return_value=True)
         brg = BuildRecipeTransformer(ComponentBuildConfiguration({}))
         build_folders = [Path("zip-build").resolve()]
         mock_update = self.mocker.patch.object(BuildRecipeTransformer, "update_component_recipe_file", return_value=None)
@@ -46,6 +47,7 @@ class BuildRecipeTransformerTest(TestCase):
         assert mock_create.call_args_list == [call(self.mock_component_recipe.return_value)]
 
     def test_transform_validation_successful(self):
+        mock_size = self.mocker.patch("gdk.common.utils.valid_recipe_file_size", return_value=True)
         mock_read = self.mocker.patch.object(CaseInsensitiveRecipeFile, "read",
                                              return_value=CaseInsensitiveDict(fake_recipe()))
         mock_update = self.mocker.patch.object(BuildRecipeTransformer, "update_component_recipe_file",
@@ -60,13 +62,74 @@ class BuildRecipeTransformerTest(TestCase):
 
         transformer.transform(build_folders)
 
+        mock_size.assert_called_once_with(config.recipe_file)
         mock_read.assert_called_once_with(config.recipe_file)
         mock_update.assert_called_once_with(mock_read.return_value, build_folders)
         mock_create.assert_called_once_with(mock_read.return_value)
 
-    def test_transform_validation_error(self):
+    def test_transform_invalid_recipe_size_expect_error(self):
+        mock_size = self.mocker.patch("gdk.common.utils.valid_recipe_file_size", return_value=False)
+        build_folders = [Path("build-folder")]
+        config = ComponentBuildConfiguration({})
+        transformer = BuildRecipeTransformer(config)
+
+        try:
+            transformer.transform(build_folders)
+        except Exception as e:
+            assert str(e) == error_messages.RECIPE_SIZE_INVALID.format(config.recipe_file)
+
+        mock_size.assert_called_once_with(config.recipe_file)
+
+    def test_transform_missing_recipe_format_version_expect_exception(self):
+        mock_size = self.mocker.patch("gdk.common.utils.valid_recipe_file_size", return_value=True)
         mock_read = self.mocker.patch.object(CaseInsensitiveRecipeFile, "read",
-                                             return_value=CaseInsensitiveDict({"dummy": "recipe"}))
+                                             return_value=CaseInsensitiveDict({}))
+        mock_update = self.mocker.patch.object(BuildRecipeTransformer, "update_component_recipe_file",
+                                               return_value=None)
+        mock_create = self.mocker.patch.object(BuildRecipeTransformer, "create_build_recipe_file", return_value=None)
+        build_folders = [Path("build-folder")]
+        config = ComponentBuildConfiguration({})
+        transformer = BuildRecipeTransformer(config)
+
+        try:
+            transformer.transform(build_folders)
+        except Exception as e:
+            assert str(e) == "The recipe file is invalid. The 'RecipeFormatVersion' field is mandatory in the recipe."
+
+        mock_size.assert_called_once_with(config.recipe_file)
+        mock_read.assert_called_once_with(config.recipe_file)
+        mock_update.assert_not_called()
+        mock_create.assert_not_called()
+
+    def test_transform_invalid_recipe_format_version_expect_exception(self):
+        mock_size = self.mocker.patch("gdk.common.utils.valid_recipe_file_size", return_value=True)
+        mock_read = self.mocker.patch.object(CaseInsensitiveRecipeFile, "read",
+                                             return_value=CaseInsensitiveDict({"RecipeFormatVersion": "77777"}))
+        mock_update = self.mocker.patch.object(BuildRecipeTransformer, "update_component_recipe_file",
+                                               return_value=None)
+        mock_create = self.mocker.patch.object(BuildRecipeTransformer, "create_build_recipe_file", return_value=None)
+        build_folders = [Path("build-folder")]
+        config = ComponentBuildConfiguration({})
+        transformer = BuildRecipeTransformer(config)
+
+        try:
+            transformer.transform(build_folders)
+        except Exception as e:
+            assert str(e) == "The provided RecipeFormatVersion in the recipe is invalid. Please ensure that it " \
+                             "follows the correct format and matches one of the supported versions."
+
+        mock_size.assert_called_once_with(config.recipe_file)
+        mock_read.assert_called_once_with(config.recipe_file)
+        mock_update.assert_not_called()
+        mock_create.assert_not_called()
+
+    def test_transform_invalid_recipe_semantic_expect_exception(self):
+        mock_size = self.mocker.patch("gdk.common.utils.valid_recipe_file_size", return_value=True)
+        mock_read = self.mocker.patch.object(CaseInsensitiveRecipeFile, "read",
+                                             return_value=CaseInsensitiveDict({
+                                                 "RecipeFormatVersion": "2020-01-25",
+                                                 "dummy": "recipe"
+                                             }))
         mock_update = self.mocker.patch.object(BuildRecipeTransformer, "update_component_recipe_file",
                                                return_value=None)
         mock_create = self.mocker.patch.object(BuildRecipeTransformer, "create_build_recipe_file", return_value=None)
@@ -78,13 +141,15 @@ class BuildRecipeTransformerTest(TestCase):
             transformer.transform(build_folders)
         except Exception as e:
             assert str(e) == error_messages.RECIPE_FILE_INVALID.format(config.recipe_file,
-                                                                       "'recipeformatversion' is a required property")
+                                                                       "'componentname' is a required property")
 
+        mock_size.assert_called_once_with(config.recipe_file)
         mock_read.assert_called_once_with(config.recipe_file)
         mock_update.assert_not_called()
         mock_create.assert_not_called()
 
     def test_transform_expect_input_validation_warning(self):
+        mock_size = self.mocker.patch("gdk.common.utils.valid_recipe_file_size", return_value=True)
         mock_read = self.mocker.patch.object(CaseInsensitiveRecipeFile, "read",
                                              return_value=CaseInsensitiveDict(fake_recipe_with_input_issues()))
         mock_update = self.mocker.patch.object(BuildRecipeTransformer, "update_component_recipe_file",
@@ -109,6 +174,7 @@ class BuildRecipeTransformerTest(TestCase):
         ]
         for expected_warning in expected_warnings:
             assert any(expected_warning in str(arg) for arg in warning_args_list)
+        mock_size.assert_called_once_with(config.recipe_file)
         mock_read.assert_called_once_with(config.recipe_file)
         mock_update.assert_called_once_with(mock_read.return_value, build_folders)
         mock_create.assert_called_once_with(mock_read.return_value)

--- a/tests/gdk/common/test_RecipeValidator.py
+++ b/tests/gdk/common/test_RecipeValidator.py
@@ -17,6 +17,30 @@ class RecipeValidatorTest(TestCase):
     def __inject_fixtures(self, mocker):
         self.mocker = mocker
 
+    def test_validate_missing_recipe_format_version_expect_exception(self):
+        mock_logging_error = self.mocker.patch('logging.error')
+        invalid_recipe = CaseInsensitiveDict({})
+        validator = RecipeValidator(invalid_recipe)
+        with pytest.raises(Exception) as e:
+            validator.validate_recipe_format_version()
+        self.assertEqual(str(e.value), "The recipe file is invalid. The 'RecipeFormatVersion' field is mandatory in "
+                                       "the recipe.")
+        mock_logging_error.assert_called_with("Recipe validation failed for 'RecipeFormatVersion'. This field is "
+                                              "required but missing from the recipe. Please correct it and try again.")
+
+    def test_validate_invalid_recipe_format_version_expect_exception(self):
+        mock_logging_error = self.mocker.patch('logging.error')
+        invalid_recipe = CaseInsensitiveDict({"RecipeFormatVersion": "99999"})
+        validator = RecipeValidator(invalid_recipe)
+        with pytest.raises(Exception) as e:
+            validator.validate_recipe_format_version()
+        self.assertEqual(str(e.value), "The provided RecipeFormatVersion in the recipe is invalid. Please ensure that "
+                                       "it follows the correct format and matches one of the supported versions.")
+        mock_logging_error.assert_called_with("The provided RecipeFormatVersion '99999' is not supported in this gdk "
+                                              "version. Please ensure that it is a valid RecipeFormatVersion "
+                                              "compatible with the gdk, and refer to the list of supported "
+                                              "RecipeFormatVersion: ['2020-01-25'].")
+
     def test_validate_semantics_valid_recipe(self):
         valid_recipe = CaseInsensitiveDict({
             "manifests": [{"artifacts": [{"uri": "example"}]}],

--- a/tests/gdk/common/test_utils.py
+++ b/tests/gdk/common/test_utils.py
@@ -275,3 +275,15 @@ def test_parse_json_schema_errors_with_unknown_validator(caplog):
     utils.parse_json_schema_errors(error)
     assert "This validation error may be due to: " not in caplog.text
     assert "To address this issue, consider the following steps: " not in caplog.text
+
+
+def test_valid_recipe_size(mocker):
+    mocker.patch("os.path.getsize", return_value=1000)
+    result = utils.valid_recipe_file_size('small_recipe.json')
+    assert result
+
+
+def test_invalid_recipe_size(mocker):
+    mocker.patch("os.path.getsize", return_value=17000)
+    result = utils.valid_recipe_file_size('large_recipe.yaml')
+    assert not result


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Incorporated a recipe file size validation to ensure the file size remains within the permissible limit of 16KB. Added a verification process for the validity and compatibility of the RecipeFormatVersion, with enhanced error messages for better customer guidance.

**Why is this change necessary:**
This change is crucial to establish a comprehensive recipe validation mechanism, encompassing both size and content checks. By doing so, we enhance the reliability of recipes for downstream processes.

**How was this change tested:**
Introduced new unit tests that successfully passed, affirming the functionality. Thoroughly validated the implementation locally to ensure it behaves as intended.

**Any additional information or context required to review the change:**
The file size validation is conducted prior to processing the recipe file's contents. Below are illustrative outputs for scenarios:

- Recipe with an invalid file size.
[2023-08-30 11:50:58] INFO - Building the component 'com.example.HelloWorld' with the given project configuration.
[2023-08-30 11:50:58] INFO - Using 'zip' build system to build the component.
[2023-08-30 11:50:58] WARNING - This component is identified as using 'zip' build system. If this is incorrect, please exit and specify custom build command in the 'gdk-config.json'.
[2023-08-30 11:50:58] INFO - Validating the recipe file /Users/yifanzyf/Desktop/HelloWorld/recipe.json
[2023-08-30 11:50:58] ERROR - The size of the recipe exceeds the maximum allowed size. Please ensure the recipe size does not exceed 16 KB.
[2023-08-30 11:50:58] ERROR - Failed to build the component with the given project configuration.

- Recipe missing the RecipeFormatVersion.
[2023-08-30 12:01:27] INFO - Building the component 'com.example.HelloWorld' with the given project configuration.
[2023-08-30 12:01:27] INFO - Using 'zip' build system to build the component.
[2023-08-30 12:01:27] WARNING - This component is identified as using 'zip' build system. If this is incorrect, please exit and specify custom build command in the 'gdk-config.json'.
[2023-08-30 12:01:27] INFO - Validating the recipe file /Users/yifanzyf/Desktop/HelloWorld/recipe.json
[2023-08-30 12:01:27] ERROR - Recipe validation failed for 'RecipeFormatVersion'. This field is required but missing from the recipe. Please correct it and try again.
[2023-08-30 12:01:27] ERROR - Failed to build the component with the given project configuration.

- Recipe containing an unsupported RecipeFormatVersion.
[2023-08-30 12:03:50] INFO - Building the component 'com.example.HelloWorld' with the given project configuration.
[2023-08-30 12:03:50] INFO - Using 'zip' build system to build the component.
[2023-08-30 12:03:50] WARNING - This component is identified as using 'zip' build system. If this is incorrect, please exit and specify custom build command in the 'gdk-config.json'.
[2023-08-30 12:03:50] INFO - Validating the recipe file /Users/yifanzyf/Desktop/HelloWorld/recipe.json
[2023-08-30 12:03:50] ERROR - Recipe validation failed for: 'RecipeFormatVersion: 2023-01-25'.
[2023-08-30 12:03:50] ERROR - The provided RecipeFormatVersion '2023-01-25' is not supported in this gdk version. Please ensure that it is a valid RecipeFormatVersion compatible with the gdk, and refer to the list of supported RecipeFormatVersion: ['2020-01-25'].
[2023-08-30 12:03:50] ERROR - Failed to build the component with the given project configuration.


**Checklist:**
- [ ] Updated the README if applicable
- [x] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.