### PR TITLE
GTF renaming

### DIFF
--- a/gdk/commands/test/BuildCommand.py
+++ b/gdk/commands/test/BuildCommand.py
@@ -117,7 +117,7 @@ class BuildCommand(Command):
                     continue
                 artifact_path = self._gdk_project.gg_build_component_artifacts_dir.joinpath(Path(artifact_uri).name).resolve()
                 if not artifact_path.exists():
-                    # TODO: Currently, OTF supports artifacts at local file or class path only.
+                    # TODO: Currently, GTF supports artifacts at local file or class path only.
                     # Raise an exception if the artifact is not found.
                     logging.warning(
                         "Could not update the artifact URI %s as it does not exist in the build directory", artifact_uri

--- a/gdk/commands/test/InitCommand.py
+++ b/gdk/commands/test/InitCommand.py
@@ -35,9 +35,9 @@ class InitCommand(Command):
         logging.info("Downloading the E2E testing template from GitHub into %s directory...", consts.E2E_TESTS_DIR_NAME)
 
         URLDownloader(self.template_url).download_and_extract(self.test_directory)
-        self.update_testing_module_build_identifiers(self._test_config.test_build_system, self._init_config.otf_version)
+        self.update_testing_module_build_identifiers(self._test_config.test_build_system, self._init_config.gtf_version)
 
-    def update_testing_module_build_identifiers(self, build_system_str, otf_version):
+    def update_testing_module_build_identifiers(self, build_system_str, gtf_version):
         build_system = E2ETestBuildSystem.get(build_system_str)
         for identifier in build_system.build_system_identifier:
             build_file = self.test_directory.joinpath(identifier)
@@ -49,7 +49,7 @@ class InitCommand(Command):
             with open(build_file, "r", encoding="utf-8") as f:
                 build_file_content = f.read()
 
-            build_file_content = build_file_content.replace("GDK_TESTING_VERSION", otf_version + "-SNAPSHOT")
+            build_file_content = build_file_content.replace("GDK_TESTING_VERSION", gtf_version + "-SNAPSHOT")
 
             with open(build_file, "w", encoding="utf-8") as f:
                 f.write(build_file_content)

--- a/gdk/commands/test/config/InitConfiguration.py
+++ b/gdk/commands/test/config/InitConfiguration.py
@@ -8,40 +8,40 @@ class InitConfiguration(GDKProject):
     def __init__(self, _args) -> None:
         super().__init__()
         self._args = _args
-        self._otf_releases_url = "https://github.com/aws-greengrass/aws-greengrass-testing/releases"
-        self.otf_version = self._get_otf_version()
+        self._gtf_releases_url = "https://github.com/aws-greengrass/aws-greengrass-testing/releases"
+        self.gtf_version = self._get_gtf_version()
 
-    def _get_otf_version(self):
-        _version_arg = self._args.get("otf_version", None)
+    def _get_gtf_version(self):
+        _version_arg = self._args.get("gtf_version", None)
         if _version_arg:
-            logging.info("Using the OTF version provided in the command %s", _version_arg)
-            return self._validated_otf_version(_version_arg)
-        logging.info("Using the OTF version provided in the GDK test config %s", self.test_config.otf_version)
-        return self._validated_otf_version(self.test_config.otf_version)
+            logging.info("Using the GTF version provided in the command %s", _version_arg)
+            return self._validated_gtf_version(_version_arg)
+        logging.info("Using the GTF version provided in the GDK test config %s", self.test_config.gtf_version)
+        return self._validated_gtf_version(self.test_config.gtf_version)
 
-    def _validated_otf_version(self, version) -> str:
+    def _validated_gtf_version(self, version) -> str:
         _version = version.strip()
 
         if not _version:
             raise ValueError(
-                "OTF version cannot be empty. Please specify a valid OTF version in the GDK config or in the command argument."
+                "GTF version cannot be empty. Please specify a valid GTF version in the GDK config or in the command argument."
             )
 
         if not semver.Version.is_valid(_version):
             raise ValueError(
-                f"OTF version {_version} is not a valid semver. Please specify a valid OTF version in the GDK config or in"
+                f"GTF version {_version} is not a valid semver. Please specify a valid GTF version in the GDK config or in"
                 " the command argument."
             )
 
-        if not self._otf_version_exists(_version):
+        if not self._gtf_version_exists(_version):
             raise ValueError(
-                f"The specified Open Test Framework (OTF) version '{_version}' does not exist. Please"
-                f" provide a valid OTF version from the releases here: {self._otf_releases_url}"
+                f"The specified Greengrass Test Framework (GTF) version '{_version}' does not exist. Please"
+                f" provide a valid GTF version from the releases here: {self._gtf_releases_url}"
             )
 
         return _version
 
-    def _otf_version_exists(self, _version) -> bool:
+    def _gtf_version_exists(self, _version) -> bool:
         _testing_jar_url = "https://github.com/aws-greengrass/aws-greengrass-testing/releases/tag/v" + _version
         head_response = requests.head(_testing_jar_url, timeout=10)
         return head_response.status_code == 200

--- a/gdk/commands/test/config/RunConfiguration.py
+++ b/gdk/commands/test/config/RunConfiguration.py
@@ -8,14 +8,14 @@ class RunConfiguration(GDKProject):
     def __init__(self, _args) -> None:
         super().__init__()
         self._args = _args
-        self._test_options_from_config = self.test_config.otf_options
+        self._test_options_from_config = self.test_config.gtf_options
         self._default_tags = "Sample"
         self.default_nucleus_archive_path = self.gg_build_dir.joinpath("greengrass-nucleus-latest.zip").resolve()
         self.options = self._get_options()
 
     def _get_options_from_config(self) -> dict:
         """
-        Read otf_options provided in the gdk-config.json. Validate and update only `tags` and `ggc-archive` for now as these
+        Read gtf_options provided in the gdk-config.json. Validate and update only `tags` and `ggc-archive` for now as these
         are required options. Use rest of the options as they're provided in the test config.
         """
         options = self._test_options_from_config.copy()
@@ -51,7 +51,7 @@ class RunConfiguration(GDKProject):
         return tags
 
     def _get_options(self) -> dict:
-        _options_args = self._args.get("otf_options", "")
+        _options_args = self._args.get("gtf_options", "")
         _options_from_config = self._get_options_from_config()
         if not _options_args:
             return _options_from_config

--- a/gdk/common/config/TestConfiguration.py
+++ b/gdk/common/config/TestConfiguration.py
@@ -1,18 +1,22 @@
 class TestConfiguration:
     def __init__(self, test_config):
         self.test_build_system = "maven"
-        self.otf_version = "1.1.0"  # TODO: Default value should be the latest version of otf testing standalone jar.
-        self.otf_options = {}
+        self.gtf_version = "1.1.0"  # TODO: Default value should be the latest version of gtf testing standalone jar.
+        self.gtf_options = {}
 
         self._set_test_config(test_config)
 
     def _set_test_config(self, test_config):
         self._set_build_config(test_config.get("build", {}))
-        self._set_otf_config(test_config)
+        self._set_gtf_config(test_config)
 
     def _set_build_config(self, test_build_config):
         self.test_build_system = test_build_config.get("build_system", self.test_build_system)
 
-    def _set_otf_config(self, test_config):
-        self.otf_version = test_config.get("otf_version", self.otf_version)
-        self.otf_options = test_config.get("otf_options", {})
+    def _set_gtf_config(self, test_config):
+        self.gtf_version = (test_config.get("gtf_version")
+                            if "gtf_version" in test_config
+                            else test_config.get("otf_version", self.gtf_version))
+        self.gtf_options = (test_config.get("gtf_options")
+                            if "gtf_options" in test_config
+                            else test_config.get("otf_options", {}))

--- a/gdk/static/cli_model.json
+++ b/gdk/static/cli_model.json
@@ -134,10 +134,10 @@
                     "init": {
                         "help": "Initialize GDK project with user acceptance testing module",
                         "arguments": {
-                            "otf_version": {
+                            "gtf_version": {
                                 "name": [
-                                    "-ov",
-                                    "--otf-version"
+                                    "-gv",
+                                    "--gtf-version"
                                 ],
                                 "help": "Version of the testing jar."
                             }
@@ -148,12 +148,12 @@
                     },
                     "run": {
                         "arguments": {
-                            "otf_options": {
+                            "gtf_options": {
                                 "name": [
-                                    "-oo",
-                                    "--otf-options"
+                                    "-go",
+                                    "--gtf-options"
                                 ],
-                                "help": "OTF configuration options used when running the E2E tests. This argument needs to be a valid json string or file path to a JSON file containing the config options. This argument overrides the options provided in the gdk configuration."
+                                "help": "GTF configuration options used when running the E2E tests. This argument needs to be a valid json string or file path to a JSON file containing the config options. This argument overrides the options provided in the gdk configuration."
                             }
                         },
                         "help": "Run user acceptance tests on GreengrassV2 components."

--- a/gdk/static/cli_model_schema.json
+++ b/gdk/static/cli_model_schema.json
@@ -279,10 +279,10 @@
                 "arguments": {
                     "description": "List of all the arguments that can be passed with the test-e2e init command.",
                     "required": [
-                        "otf_version"
+                        "gtf_version"
                     ],
                     "properties": {
-                        "otf_version": {
+                        "gtf_version": {
                             "$ref": "#/$defs/argument"
                         }
                     }
@@ -303,10 +303,10 @@
                 "arguments": {
                     "description": "List of all the arguments that can be passed with the test-e2e run command.",
                     "required": [
-                        "otf_options"
+                        "gtf_options"
                     ],
                     "properties": {
-                        "otf_options": {
+                        "gtf_options": {
                             "$ref": "#/$defs/argument"
                         }
                     }

--- a/gdk/wizard/Prompter.py
+++ b/gdk/wizard/Prompter.py
@@ -89,8 +89,8 @@ class Prompter:
 
     def retry_messages(self, field, attempt, max_attempts):
         link = "https://docs.aws.amazon.com/greengrass/v2/developerguide/gdk-cli-configuration-file.html#gdk-config-format"
-        default_message = f"Attempt {attempt}/{max_attempts}: Invalid response. Please try again.\nPlease vist: {link}"
-        custom_message = f"Attempt {attempt}/{max_attempts}: Must Specify a custum build command.\nPlease vist: {link}"
+        default_message = f"Attempt {attempt}/{max_attempts}: Invalid response. Please try again.\nPlease visit: {link}"
+        custom_message = f"Attempt {attempt}/{max_attempts}: Must Specify a custom build command.\nPlease visit: {link}"
         if attempt < max_attempts:
             if field == ConfigEnum.CUSTOM_BUILD_COMMAND:
                 logging.warning(custom_message)
@@ -112,7 +112,7 @@ class Prompter:
         """
         self.parser.add_argument(
             f"--change_{field_key}",
-            help=f"Change componenet {field_key} configurations",
+            help=f"Change component {field_key} configurations",
         )
 
         for _ in range(max_attempts):
@@ -129,7 +129,7 @@ class Prompter:
                 return True
             elif response in {"n", "no"}:
                 return False
-            logging.warning("Your input was invalid response. Please respond again.")
+            logging.warning("Your input was an invalid response. Please respond again.")
         return False
 
     def interactive_prompt(self, field, value, require):

--- a/integration_tests/gdk/common/config/test_GDKProject.py
+++ b/integration_tests/gdk/common/config/test_GDKProject.py
@@ -30,9 +30,9 @@ class GDKProjectTest(TestCase):
 
         gdk_config = GDKProject()
         assert gdk_config.component_name == "abc"
-        assert gdk_config.test_config.otf_version == "1.1.0"
+        assert gdk_config.test_config.gtf_version == "1.1.0"
         assert gdk_config.test_config.test_build_system == "maven"
-        assert gdk_config.test_config.otf_options == {}
+        assert gdk_config.test_config.gtf_options == {}
 
         c_dir = Path(".").resolve()
         assert c_dir.joinpath("greengrass-build") == gdk_config.gg_build_dir
@@ -50,7 +50,7 @@ class GDKProjectTest(TestCase):
         recipe_file.touch()
         gdk_config = GDKProject()
         assert gdk_config.component_name == "abc"
-        assert gdk_config.test_config.otf_version == "1.2.0"
+        assert gdk_config.test_config.gtf_version == "1.2.0"
         assert gdk_config.test_config.test_build_system == "maven"
         assert self.tmpdir.joinpath("greengrass-build") == gdk_config.gg_build_dir
         assert self.tmpdir.joinpath("greengrass-build/artifacts/abc/NEXT_PATCH") == gdk_config.gg_build_component_artifacts_dir

--- a/integration_tests/gdk/test/test_integ_uat_InitCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_InitCommand.py
@@ -79,34 +79,34 @@ class E2ETestInitCommandTest(TestCase):
         # existing consts.E2E_TESTS_DIR_NAME folder is not overridden
         e2e_test_folder = Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME)
         assert e2e_test_folder.exists()
-        # OTF version is updated in pom.xml
+        # GTF version is updated in pom.xml
         with open(e2e_test_folder.joinpath("pom.xml"), "r", encoding="utf-8") as f:
             content = f.read()
             assert "GDK_TESTING_VERSION" not in content
-            # OTF version set in config file
+            # GTF version set in config file
             assert "<otf.version>1.2.0-SNAPSHOT</otf.version>" in content
 
-    def test_GIVEN_gdk_project_WHEN_test_init_with_otf_version_arg_THEN_version_is_arg_is_used(self):
+    def test_GIVEN_gdk_project_WHEN_test_init_with_gtf_version_arg_THEN_version_is_arg_is_used(self):
         self.setup_test_data_config("config.json")
-        InitCommand({"otf_version": "1.0.0"}).run()
+        InitCommand({"gtf_version": "1.0.0"}).run()
         assert self.mock_template_download.call_args_list == [call(self.url_for_template, stream=True, timeout=30)]
 
         # existing consts.E2E_TESTS_DIR_NAME folder is not overridden
         e2e_test_folder = Path(self.tmpdir).joinpath(consts.E2E_TESTS_DIR_NAME)
         assert e2e_test_folder.exists()
-        # OTF version is updated in pom.xml
+        # GTF version is updated in pom.xml
         with open(e2e_test_folder.joinpath("pom.xml"), "r", encoding="utf-8") as f:
             content = f.read()
             assert "GDK_TESTING_VERSION" not in content
-            # OTF version set in config file
+            # GTF version set in config file
             assert "<otf.version>1.0.0-SNAPSHOT</otf.version>" in content
 
-    def test_GIVEN_gdk_project_WHEN_test_init_with_otf_version_and_otf_version_not_exists_THEN_raise_exc(self):
+    def test_GIVEN_gdk_project_WHEN_test_init_with_gtf_version_and_gtf_version_not_exists_THEN_raise_exc(self):
         self.setup_test_data_config("config.json")
 
         with pytest.raises(ValueError) as e:
-            InitCommand({"otf_version": "10.0.0"}).run()
-        assert "The specified Open Test Framework (OTF) version '10.0.0' does not exist." in e.value.args[0]
+            InitCommand({"gtf_version": "10.0.0"}).run()
+        assert "The specified Greengrass Test Framework (GTF) version '10.0.0' does not exist." in e.value.args[0]
 
         assert not self.mock_template_download.called
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests
 packaging
 semver
 aenum
+PyInquirer

--- a/tests/gdk/commands/test/config/test_InitConfiguration.py
+++ b/tests/gdk/commands/test/config/test_InitConfiguration.py
@@ -27,13 +27,13 @@ class InitConfigurationUnitTest(TestCase):
 
         self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
         init_config = InitConfiguration({})
-        assert init_config.otf_version == "1.1.0"
+        assert init_config.gtf_version == "1.1.0"
 
-    def test_GIVEN_gdk_config_with_otf_version_WHEN_test_init_THEN_use_version_from_config(self):
+    def test_GIVEN_gdk_config_with_gtf_version_WHEN_test_init_THEN_use_version_from_config(self):
         config = self._get_config(
             {
                 "test-e2e": {
-                    "otf_version": "1.2.3",
+                    "gtf_version": "1.2.3",
                 }
             }
         )
@@ -41,13 +41,13 @@ class InitConfigurationUnitTest(TestCase):
 
         init_config = InitConfiguration({})
 
-        assert init_config.otf_version == "1.2.3"
+        assert init_config.gtf_version == "1.2.3"
 
-    def test_GIVEN_gdk_config_with_invalid_otf_version_WHEN_test_init_THEN_raise_exc(self):
+    def test_GIVEN_gdk_config_with_invalid_gtf_version_WHEN_test_init_THEN_raise_exc(self):
         config = self._get_config(
             {
                 "test-e2e": {
-                    "otf_version": "1.a.b",
+                    "gtf_version": "1.a.b",
                 }
             }
         )
@@ -57,47 +57,47 @@ class InitConfigurationUnitTest(TestCase):
             InitConfiguration({})
 
         assert (
-            "OTF version 1.a.b is not a valid semver. Please specify a valid OTF version in the GDK config or in the command"
+            "GTF version 1.a.b is not a valid semver. Please specify a valid GTF version in the GDK config or in the command"
             " argument."
             in str(e.value)
         )
 
-    def test_GIVEN_gdk_config_WHEN_test_init_with_otf_version_arg_THEN_use_version_from_arg(self):
+    def test_GIVEN_gdk_config_WHEN_test_init_with_gtf_version_arg_THEN_use_version_from_arg(self):
         config = self._get_config()
         self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
-        init_config = InitConfiguration({"otf_version": "1.1.0+12-build"})
-        assert init_config.otf_version == "1.1.0+12-build"
+        init_config = InitConfiguration({"gtf_version": "1.1.0+12-build"})
+        assert init_config.gtf_version == "1.1.0+12-build"
 
-    def test_GIVEN_gdk_config_WHEN_test_init_with_invalid_otf_version_arg_THEN_raise_exc(self):
+    def test_GIVEN_gdk_config_WHEN_test_init_with_invalid_gtf_version_arg_THEN_raise_exc(self):
         config = self._get_config()
 
         self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
         with pytest.raises(ValueError) as e:
-            InitConfiguration({"otf_version": "1.a.b"})
+            InitConfiguration({"gtf_version": "1.a.b"})
 
         assert (
-            "OTF version 1.a.b is not a valid semver. Please specify a valid OTF version in the GDK config or in the command"
+            "GTF version 1.a.b is not a valid semver. Please specify a valid GTF version in the GDK config or in the command"
             " argument."
             in str(e.value)
         )
 
-    def test_GIVEN_gdk_config_with_otf_version_WHEN_test_init_with_otf_version_arg_THEN_use_version_from_arg(self):
+    def test_GIVEN_gdk_config_with_gtf_version_WHEN_test_init_with_gtf_version_arg_THEN_use_version_from_arg(self):
         config = self._get_config(
             {
                 "test-e2e": {
-                    "otf_version": "1.a.b",
+                    "gtf_version": "1.a.b",
                 }
             }
         )
         self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
-        init_config = InitConfiguration({"otf_version": "1.2.3"})
-        assert init_config.otf_version == "1.2.3"
+        init_config = InitConfiguration({"gtf_version": "1.2.3"})
+        assert init_config.gtf_version == "1.2.3"
 
-    def test_GIVEN_gdk_config_with_otf_version_and_version_not_exits_and_WHEN_test_init_THEN_raise_ex(self):
+    def test_GIVEN_gdk_config_with_gtf_version_and_version_not_exits_and_WHEN_test_init_THEN_raise_ex(self):
         config = self._get_config(
             {
                 "test-e2e": {
-                    "otf_version": "1.a.b",
+                    "gtf_version": "1.a.b",
                 }
             }
         )
@@ -107,10 +107,10 @@ class InitConfigurationUnitTest(TestCase):
         self.mocker.patch("requests.head", return_value=response)
         self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
         with pytest.raises(ValueError) as e:
-            InitConfiguration({"otf_version": "1.2.3"})
+            InitConfiguration({"gtf_version": "1.2.3"})
         assert (
-            "The specified Open Test Framework (OTF) version '1.2.3' does not exist. Please provide a valid OTF version from"
-            " the releases here:"
+            "The specified Greengrass Test Framework (GTF) version '1.2.3' does not exist. Please provide a valid GTF "
+            "version from the releases here:"
             in e.value.args[0]
         )
 

--- a/tests/gdk/commands/test/config/test_RunConfiguration.py
+++ b/tests/gdk/commands/test/config/test_RunConfiguration.py
@@ -35,14 +35,14 @@ class RunConfigurationUnitTest(TestCase):
         config = self._get_config(
             {
                 "test-e2e": {
-                    "otf_options": {"tags": "some-tags", "ggc-version": "1.0.0"},
+                    "gtf_options": {"tags": "some-tags", "ggc-version": "1.0.0"},
                 }
             }
         )
 
         self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
 
-        run_config = RunConfiguration({"otf_options": '{"tags": "some-other-tags"}'})
+        run_config = RunConfiguration({"gtf_options": '{"tags": "some-other-tags"}'})
 
         assert run_config.options.get("tags") == "some-other-tags"
         assert (
@@ -56,7 +56,7 @@ class RunConfigurationUnitTest(TestCase):
         config = self._get_config(
             {
                 "test-e2e": {
-                    "otf_options": {
+                    "gtf_options": {
                         "tags": "some-tags",
                         "ggc-install-root": "some-install-root",
                         "gg-runtime": "some-runtime",
@@ -68,7 +68,7 @@ class RunConfigurationUnitTest(TestCase):
         self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
 
         run_config = RunConfiguration(
-            {"otf_options": '{"tags": "tags-from-args", "ggc-install-root": "install-root-from-args"}'}
+            {"gtf_options": '{"tags": "tags-from-args", "ggc-install-root": "install-root-from-args"}'}
         )
 
         assert run_config.options.get("tags") == "tags-from-args"
@@ -84,7 +84,7 @@ class RunConfigurationUnitTest(TestCase):
         config = self._get_config(
             {
                 "test-e2e": {
-                    "otf_options": {
+                    "gtf_options": {
                         "tags": "some-tags",
                         "ggc-install-root": "some-install-root",
                         "gg-runtime": "some-runtime",
@@ -99,7 +99,7 @@ class RunConfigurationUnitTest(TestCase):
             "builtins.open",
             mock.mock_open(read_data='{"tags": "tags-from-args", "ggc-install-root": "install-root-from-args"}'),
         ) as mock_file:
-            run_config = RunConfiguration({"otf_options": "/path/to/otf_options.json"})
+            run_config = RunConfiguration({"gtf_options": "/path/to/gtf_options.json"})
             assert mock_file.return_value.read.call_count == 1
 
         assert run_config.options.get("tags") == "tags-from-args"
@@ -115,7 +115,7 @@ class RunConfigurationUnitTest(TestCase):
         config = self._get_config(
             {
                 "test-e2e": {
-                    "otf_options": {"tags": "some-tags", "ggc-version": "1.0.0"},
+                    "gtf_options": {"tags": "some-tags", "ggc-version": "1.0.0"},
                 }
             }
         )
@@ -136,7 +136,7 @@ class RunConfigurationUnitTest(TestCase):
         config = self._get_config(
             {
                 "test-e2e": {
-                    "otf_options": {"tags": "", "ggc-version": "1.0.0"},
+                    "gtf_options": {"tags": "", "ggc-version": "1.0.0"},
                 }
             }
         )
@@ -154,7 +154,7 @@ class RunConfigurationUnitTest(TestCase):
         config = self._get_config(
             {
                 "test-e2e": {
-                    "otf_options": {"ggc-archive": "some-path.zip"},
+                    "gtf_options": {"ggc-archive": "some-path.zip"},
                 }
             }
         )
@@ -173,7 +173,7 @@ class RunConfigurationUnitTest(TestCase):
         config = self._get_config(
             {
                 "test-e2e": {
-                    "otf_options": {"ggc-archive": "some-path.zip"},
+                    "gtf_options": {"ggc-archive": "some-path.zip"},
                 }
             }
         )

--- a/uat/steps/test_e2e.py
+++ b/uat/steps/test_e2e.py
@@ -10,14 +10,14 @@ def verify_test_files(context):
     assert Path(cwd).joinpath(GDK_TEST_DIR).resolve().exists(), f"{GDK_TEST_DIR} does not exist"
 
 
-@step("we verify that the OTF version used is {version}")
+@step("we verify that the GTF version used is {version}")
 def verify_test_framework_version(context, version):
     cwd = context.cwd if "cwd" in context else os.getcwd()
     build_system_file = Path(cwd).joinpath(GDK_TEST_DIR, "pom.xml")
 
     with open(build_system_file, "r") as f:
         content = f.read()
-        assert f"<otf.version>{version}-SNAPSHOT</otf.version>" in content, f"OTF version {version} is not used."
+        assert f"<otf.version>{version}-SNAPSHOT</otf.version>" in content, f"GTF version {version} is not used."
 
 
 @step("we verify the test build files")

--- a/uat/test_init.feature
+++ b/uat/test_init.feature
@@ -1,4 +1,4 @@
-Feature: As a component builder, I can run `gdk test-e2e init` command to initialize an existing GDK project with the testing module that uses OTF.
+Feature: As a component builder, I can run `gdk test-e2e init` command to initialize an existing GDK project with the testing module that uses GTF.
 
     @version(min='1.3.0')
     @change_cwd
@@ -15,16 +15,16 @@ Feature: As a component builder, I can run `gdk test-e2e init` command to initia
 
     @version(min='1.3.0')
     @change_cwd
-    Scenario: test-e2e-init-2: Initialize a GDK project with an end-to-end testing module using a specific version of OTF
+    Scenario: test-e2e-init-2: Initialize a GDK project with an end-to-end testing module using a specific version of GTF
         Given we have cli installed
         When we run gdk component init -t HelloWorld -l python -n test-dir
         Then command was successful
         And we change directory to test-dir
         And change component name to com.example.PythonHelloWorld
         And we verify gdk project files
-        When we run gdk test-e2e init --otf-version 1.0.0
+        When we run gdk test-e2e init --gtf-version 1.0.0
         Then we verify gdk test files
-        Then we verify that the OTF version used is 1.0.0
+        Then we verify that the GTF version used is 1.0.0
 
     @version(min='1.3.0')
     @change_cwd
@@ -35,21 +35,21 @@ Feature: As a component builder, I can run `gdk test-e2e init` command to initia
         And we change directory to test-dir
         And change component name to com.example.PythonHelloWorld
         And we verify gdk project files
-        When we run gdk test-e2e init --otf-version 1.1.0
+        When we run gdk test-e2e init --gtf-version 1.1.0
         Then we verify gdk test files
-        When we run gdk test-e2e init --otf-version 1.0.0
-        Then we verify that the OTF version used is 1.1.0
+        When we run gdk test-e2e init --gtf-version 1.0.0
+        Then we verify that the GTF version used is 1.1.0
 
 
     @version(min='1.3.0')
     @change_cwd
-    Scenario: test-e2e-init-4: When I initialize a GDK project with an e2e testing module using a version of OTF that doesn't exist, the command exits with an error
+    Scenario: test-e2e-init-4: When I initialize a GDK project with an e2e testing module using a version of GTF that doesn't exist, the command exits with an error
         Given we have cli installed
         When we run gdk component init -t HelloWorld -l python -n test-dir
         Then command was successful
         And we change directory to test-dir
         And change component name to com.example.PythonHelloWorld
         And we verify gdk project files
-        When we run gdk test-e2e init --otf-version 10.0.0
+        When we run gdk test-e2e init --gtf-version 10.0.0
         Then command was unsuccessful
         Then command output contains "'10.0.0' does not exist"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Rename instances of OTF to GTF due to the Greengrass Test Framework being referred to as GTF now. GDK CLI now takes -go or --gtf_options as an option for the run command and -gv or --gtf_version for the init command. GDK will support both otf_options and otf_version parameters in the gdk-config file, but will prefer gtf_options and gtf_version if both the gtf and otf named parameters exist.

**Why is this change necessary:**
OTF is now renamed to GTF and this change keeps the naming consistent across our services.

**How was this change tested:**
Updated unit tests/integration tests/UATs to use the updated keys.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.