### PR TITLE
feat: support for both gtf and otf keys in gdk config

### DIFF
--- a/gdk/common/config/TestConfiguration.py
+++ b/gdk/common/config/TestConfiguration.py
@@ -14,5 +14,9 @@ class TestConfiguration:
         self.test_build_system = test_build_config.get("build_system", self.test_build_system)
 
     def _set_otf_config(self, test_config):
-        self.otf_version = test_config.get("otf_version", self.otf_version)
-        self.otf_options = test_config.get("otf_options", {})
+        self.otf_version = (test_config.get("gtf_version")
+                            if "gtf_version" in test_config
+                            else test_config.get("otf_version", self.otf_version))
+        self.otf_options = (test_config.get("gtf_options")
+                            if "gtf_options" in test_config
+                            else test_config.get("otf_options", {}))

--- a/integration_tests/gdk/common/config/test_GDKProject.py
+++ b/integration_tests/gdk/common/config/test_GDKProject.py
@@ -41,7 +41,7 @@ class GDKProjectTest(TestCase):
         assert c_dir.joinpath("greengrass-build/artifacts") == gdk_config.gg_build_artifacts_dir
         assert gdk_config.recipe_file == Path(".").joinpath("recipe.yaml").resolve()
 
-    def test_GIVEN_project_with_json_recipet_WHEN_read_test_config_THEN_read_default_values(self):
+    def test_GIVEN_project_with_json_recipe_WHEN_read_test_config_THEN_read_default_values(self):
         shutil.copy(
             self.c_dir.joinpath("integration_tests/test_data/config").joinpath("config.json").resolve(),
             self.tmpdir.joinpath("gdk-config.json"),
@@ -57,6 +57,28 @@ class GDKProjectTest(TestCase):
         assert self.tmpdir.joinpath("greengrass-build/recipes") == gdk_config.gg_build_recipes_dir
         assert self.tmpdir.joinpath("greengrass-build/artifacts") == gdk_config.gg_build_artifacts_dir
         assert gdk_config.recipe_file == self.tmpdir.joinpath("recipe.json").resolve()
+
+    def test_GIVEN_config_file_with_gtf_test_keys_WHEN_read_test_config_THEN_use_gtf_keys(self):
+        shutil.copy(
+            self.c_dir.joinpath("integration_tests/test_data/config").joinpath("config_gtf.json").resolve(),
+            self.tmpdir.joinpath("gdk-config.json"),
+        )
+        recipe_file = self.tmpdir.joinpath("recipe.json")
+        recipe_file.touch()
+        gdk_config = GDKProject()
+        assert gdk_config.test_config.otf_version == "1.2.0"
+        assert gdk_config.test_config.otf_options == {"tags": "testtags"}
+
+    def test_GIVEN_config_file_with_both_gtf_and_otf_test_keys_WHEN_read_test_config_THEN_use_gtf_keys(self):
+        shutil.copy(
+            self.c_dir.joinpath("integration_tests/test_data/config").joinpath("config_gtf_and_otf.json").resolve(),
+            self.tmpdir.joinpath("gdk-config.json"),
+        )
+        recipe_file = self.tmpdir.joinpath("recipe.json")
+        recipe_file.touch()
+        gdk_config = GDKProject()
+        assert gdk_config.test_config.otf_version == "1.0.0"
+        assert gdk_config.test_config.otf_options == {"tags": "testtags"}
 
     def test_GIVEN_project_WHEN_recipe_not_exists_THEN_raise_exception(self):
         # neither recipe.json nor recipe.yaml exists

--- a/integration_tests/test_data/config/config_gtf.json
+++ b/integration_tests/test_data/config/config_gtf.json
@@ -1,0 +1,22 @@
+{
+  "component": {
+    "abc": {
+      "author": "abc",
+      "version": "NEXT_PATCH",
+      "build": {
+        "build_system": "zip"
+      },
+      "publish": {
+        "bucket": "default",
+        "region": "us-east-1"
+      }
+    }
+  },
+  "test-e2e": {
+    "gtf_version": "1.2.0",
+    "gtf_options": {
+      "tags": "testtags"
+    }
+  },
+  "gdk_version": "1.0.0"
+}

--- a/integration_tests/test_data/config/config_gtf_and_otf.json
+++ b/integration_tests/test_data/config/config_gtf_and_otf.json
@@ -1,0 +1,26 @@
+{
+  "component": {
+    "abc": {
+      "author": "abc",
+      "version": "NEXT_PATCH",
+      "build": {
+        "build_system": "zip"
+      },
+      "publish": {
+        "bucket": "default",
+        "region": "us-east-1"
+      }
+    }
+  },
+  "test-e2e": {
+    "gtf_version": "1.0.0",
+    "otf_version": "1.2.0",
+    "gtf_options": {
+      "tags": "testtags"
+    },
+    "otf_options": {
+      "tags": "wrongtags"
+    }
+  },
+  "gdk_version": "1.0.0"
+}

--- a/tests/gdk/commands/test/config/test_InitConfiguration.py
+++ b/tests/gdk/commands/test/config/test_InitConfiguration.py
@@ -43,6 +43,31 @@ class InitConfigurationUnitTest(TestCase):
 
         assert init_config.otf_version == "1.2.3"
 
+    def test_GIVEN_gdk_config_with_gtf_version_WHEN_test_init_THEN_use_version_from_config(self):
+        config = self._get_config(
+            {
+                "test-e2e": {
+                    "gtf_version": "1.2.3",
+                    "otf_version": "1.3.4"
+                }
+            }
+        )
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+        init_config = InitConfiguration({})
+        assert init_config.otf_version == "1.2.3"
+
+    def test_GIVEN_gdk_config_with_gtf_and_otf_version_WHEN_test_init_THEN_use_gtf_version_from_config(self):
+        config = self._get_config(
+            {
+                "test-e2e": {
+                    "gtf_version": "1.2.3",
+                }
+            }
+        )
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+        init_config = InitConfiguration({})
+        assert init_config.otf_version == "1.2.3"
+
     def test_GIVEN_gdk_config_with_invalid_otf_version_WHEN_test_init_THEN_raise_exc(self):
         config = self._get_config(
             {

--- a/tests/gdk/commands/test/config/test_RunConfiguration.py
+++ b/tests/gdk/commands/test/config/test_RunConfiguration.py
@@ -52,6 +52,20 @@ class RunConfigurationUnitTest(TestCase):
 
         assert len(run_config.options) == 3
 
+    def test_GIVEN_gdk_config_with_gtf_and_otf_options_WHEN_run_without_args_THEN_use_gtf_options(self):
+        config = self._get_config(
+            {
+                "test-e2e": {
+                    "gtf_options": {"tags": "some-tags", "ggc-version": "1.0.0"},
+                    "otf_options": {"tags": "some-other-tags", "ggc-version": "1.1.0"},
+                }
+            }
+        )
+        self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
+        run_config = RunConfiguration({})
+        assert run_config.options.get("tags") == "some-tags"
+        assert run_config.options.get("ggc-version") == "1.0.0"
+
     def test_GIVEN_gdk_config_with_three_options_WHEN_run_with_two_overriding_args_THEN_merge_args(self):
         config = self._get_config(
             {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently, the gdk-config.json file can have "otf_version" and "otf_options" keys under test-e2e. This change updates them to "gtf_version" and "gtf_options", but will still support the use of the older keys. If both are present, it will use the gtf named keys.

**Why is this change necessary:**
OTF ("Open Test Framework") is being renamed to GTF ("Greengrass Test Framework") so this change reflects that in the config file.

**How was this change tested:**
Added unit and integ tests to confirm that when both keys are present, we are using the gtf named keys.

**Any additional information or context required to review the change:**
This doesn't include changes to revise or add the renaming to command line tags. Will be done in a later PR. Similarly, many OTF references in the code will be changed in a later PR. This PR focuses on the feature of updating the config keys.

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.