### PR TITLE
feat: better logging for recipe syntax failures during build

### DIFF
--- a/gdk/common/CaseInsensitive.py
+++ b/gdk/common/CaseInsensitive.py
@@ -1,8 +1,10 @@
 import json
+import logging
 from pathlib import Path
 
 import yaml
 from requests.structures import CaseInsensitiveDict as _CaseInsensitiveDict
+from gdk.common.consts import DOCS_RECIPE_LINK
 
 
 class CaseInsensitiveDict(_CaseInsensitiveDict):
@@ -80,11 +82,21 @@ class CaseInsensitiveRecipeFile:
 
     def _read_from_yaml(self, file_path: Path) -> dict:
         with open(file_path, "r", encoding="utf-8") as f:
-            return yaml.safe_load(f.read())
+            try:
+                return yaml.safe_load(f.read())
+            except yaml.YAMLError as err:
+                logging.error(f"Syntax error when parsing the recipe file: {file_path}. For information and examples" +
+                              f" regarding component recipes refer to the docs here: {DOCS_RECIPE_LINK}")
+                raise err
 
     def _read_from_json(self, file_path: Path) -> dict:
         with open(file_path, "r", encoding="utf-8") as f:
-            return json.loads(f.read())
+            try:
+                return json.loads(f.read())
+            except json.JSONDecodeError as err:
+                logging.error(f"Syntax error when parsing the recipe file: {file_path}. For information and examples" +
+                              f" regarding component recipes refer to the docs here: {DOCS_RECIPE_LINK}")
+                raise err
 
     def _write_to_json(self, file_path: Path, content: dict) -> None:
         with open(file_path, "w", encoding="utf-8") as f:

--- a/gdk/common/consts.py
+++ b/gdk/common/consts.py
@@ -32,6 +32,7 @@ repository_list_url = (
     "https://raw.githubusercontent.com/aws-greengrass/aws-greengrass-software-catalog/main/cli-components/"
     + "community-components.json"
 )
+DOCS_RECIPE_LINK = "https://docs.aws.amazon.com/greengrass/v2/developerguide/component-recipe-reference.html"
 
 # DEFAULT LOGGING
 log_format = "[%(asctime)s] %(levelname)s - %(message)s"

--- a/tests/gdk/common/test_CaseInsensitive.py
+++ b/tests/gdk/common/test_CaseInsensitive.py
@@ -42,7 +42,7 @@ class CaseInsensitiveRecipeFileTest(TestCase):
         assert "uri" in case_insensitive_recipe["Manifests"][0]["Artifacts"][0]
         assert "URI" in case_insensitive_recipe["Manifests"][0]["Artifacts"][0]
 
-    def test_read_json_with_syntax_err(self):
+    def test_GIVEN_json_recipe_file_with_syntax_err_WHEN_read_recipe_THEN_throw_err_logging_and_exception(self):
         self.caplog.set_level(logging.ERROR)
         json_file = Path(".").joinpath("tests/gdk/static/project_utils").joinpath("recipe_missing_comma.json").resolve()
         with pytest.raises(Exception) as e:
@@ -51,11 +51,11 @@ class CaseInsensitiveRecipeFileTest(TestCase):
         assert "For information and examples regarding component recipes refer to the docs here" in logs
         assert "Expecting ',' delimiter: line 6 column 3" in str(e)
 
-    def test_read_yaml_with_syntax_err(self):
+    def test_GIVEN_yaml_recipe_file_with_syntax_err_WHEN_read_recipe_THEN_throw_err_logging_and_exception(self):
         self.caplog.set_level(logging.ERROR)
-        json_file = Path(".").joinpath("tests/gdk/static/project_utils").joinpath("invalid_component_recipe.yaml").resolve()
+        yaml_file = Path(".").joinpath("tests/gdk/static/project_utils").joinpath("invalid_component_recipe.yaml").resolve()
         with pytest.raises(Exception) as e:
-            CaseInsensitiveRecipeFile().read(json_file)
+            CaseInsensitiveRecipeFile().read(yaml_file)
         logs = self.caplog.text
         assert "For information and examples regarding component recipes refer to the docs here" in logs
         assert "expected <block end>, but found '<block mapping start>'" in str(e)

--- a/tests/gdk/static/project_utils/recipe_missing_comma.json
+++ b/tests/gdk/static/project_utils/recipe_missing_comma.json
@@ -1,0 +1,55 @@
+{
+  "RecipeFormatVersion": "2020-01-25",
+  "ComponentName": "com.example.HelloWorld",
+  "ComponentVersion": "1.0.0",
+  "ComponentDescription": "My first Greengrass component."
+  "ComponentPublisher": "Amazon",
+  "ComponentConfiguration": {
+    "DefaultConfiguration": {
+      "Message": "world",
+      "SampleList": [
+        "1",
+        "2",
+        "3"
+      ],
+      "SampleNestedList": [
+        [
+          "1"
+        ],
+        [
+          "2"
+        ],
+        [
+          "3"
+        ]
+      ],
+      "SampleMap": {
+        "key1": "value1",
+        "key2": {
+          "key3": [
+            "value2",
+            "value3"
+          ],
+          "key4": {
+            "key41": "value4"
+          }
+        }
+      }
+    }
+  },
+  "Manifests": [
+    {
+      "Platform": {
+        "os": "linux"
+      },
+      "Lifecycle": {
+        "Run": "python3 -u {artifacts:path}/hello_world.py '{configuration:/Message}'"
+      },
+      "Artifacts": [
+        {
+          "URI": "s3://DOC-EXAMPLE-BUCKET/artifacts/com.example.HelloWorld/1.0.0/hello_world.py"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add better logging during build stage for recipe syntax validation. Before, when a build fails due to a recipe syntax issue it just prints the error that there was some problem during the build. Now, it will notify the user that there was an issue with the recipe syntax and link to the component recipe docs for reference.

**Why is this change necessary:**
Provides more clarity for what is going wrong.

**How was this change tested:**
Added unit tests for recipes with a common syntax error.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.