### PR TITLE
fix: remove pyinquirer dependency to work with python 3.10+

### DIFF
--- a/gdk/wizard/Prompter.py
+++ b/gdk/wizard/Prompter.py
@@ -3,7 +3,6 @@ from gdk.wizard.ConfigEnum import ConfigEnum
 from gdk.wizard.WizardChecker import WizardChecker
 from gdk.wizard.WizardConfigUtils import WizardConfigUtils
 import logging
-from PyInquirer import prompt
 import argparse
 import sys
 
@@ -146,17 +145,11 @@ class Prompter:
         -------
             string: the value of field that the user has entered through the interactive prompt
         """
-        questions = [
-            {
-                "type": "input",
-                "name": "user_input",
-                "message": f"Current value of the {require}{field} is:",
-                "default": f"{value}",
-            }
-        ]
         try:
-            answer = prompt(questions)
-            return answer["user_input"]
+            answer = input(f"Current value of the {require}{field} is (default: {value}): ")
+            if not answer:
+                answer = value
+            return answer
         except (KeyError, TypeError):
             raise Exception("Wizard interrupted. Exiting...")
 
@@ -231,7 +224,7 @@ class Prompter:
 
     def prompt_fields(self):
         """
-        Wapper method that prompts users for required and optional field values
+        Wrapper method that prompts users for required and optional field values
         for the gdk config file
 
         Parameters

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ requests
 packaging
 semver
 aenum
-PyInquirer

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,4 +16,3 @@ behave-html-formatter
 Faker
 semver
 aenum
-PyInquirer

--- a/tests/gdk/wizard/test_Prompter.py
+++ b/tests/gdk/wizard/test_Prompter.py
@@ -1,0 +1,32 @@
+import pytest
+from unittest import TestCase
+from gdk.wizard.ConfigEnum import ConfigEnum
+from gdk.wizard.Prompter import Prompter
+from pathlib import Path
+
+
+class TestPrompter(TestCase):
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker):
+        self.mocker = mocker
+
+        self.mock_get_project_config_file = self.mocker.patch(
+            "gdk.common.configuration._get_project_config_file",
+            return_value=Path(".").joinpath("tests/gdk/static").joinpath("config.json"),
+        )
+
+    def test_GIVEN_prompt_for_value_WHEN_new_value_provided_THEN_use_new_value(self):
+        prompter = Prompter()
+        mock_input = self.mocker.patch("builtins.input", return_value="foo")
+        result = prompter.interactive_prompt(ConfigEnum.BUILD, "bar", True)
+        self.assertEqual(result, "foo")
+        self.assertEqual(mock_input.call_count, 1)
+        self.assertEqual(self.mock_get_project_config_file.call_count, 2)
+
+    def test_GIVEN_prompt_for_value_WHEN_no_value_provided_THEN_use_default_value(self):
+        prompter = Prompter()
+        mock_input = self.mocker.patch("builtins.input", return_value="")
+        result = prompter.interactive_prompt(ConfigEnum.BUILD, "foo", True)
+        self.assertEqual(result, "foo")
+        self.assertEqual(mock_input.call_count, 1)
+        self.assertEqual(self.mock_get_project_config_file.call_count, 2)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use python built-in input function to prompt for inputs instead of PyInquirer. To use the existing default value users should leave the input field blank. 

**Why is this change necessary:**
PyInquirer does not have a maintainer anymore (https://github.com/CITGuru/PyInquirer/issues/159) and does not work on python versions past 3.10 due to a deprecated import statement in one of PyInquirer's dependent packages. Since we cannot expect this project to be updated and we want to ensure that we support later and current releases of python we cannot use PyInquirer.

**How was this change tested:**
Manually tested the changes.

**Any additional information or context required to review the change:**
Unit tests don't exist (yet). They will be in a future PR. This is just a quick fix in the meantime to move away from this dependency.

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.