### PR TITLE
feat: prompt for component name during gdk config update

### DIFF
--- a/gdk/wizard/Prompter.py
+++ b/gdk/wizard/Prompter.py
@@ -238,6 +238,9 @@ class Prompter:
 
         self.add_parser_arguments()
 
+        component_name = self.prompter(ConfigEnum.COMPONENT_NAME, required=True)
+        self.data.set_component_name(component_name)
+
         response_author = self.prompter(ConfigEnum.AUTHOR, required=True)
         self.data.set_field(ConfigEnum.AUTHOR, response_author)
 

--- a/gdk/wizard/WizardChecker.py
+++ b/gdk/wizard/WizardChecker.py
@@ -7,6 +7,7 @@ import json
 class WizardChecker:
     def __init__(self):
         self.switch = {
+            ConfigEnum.COMPONENT_NAME: self.is_valid_component_name,
             ConfigEnum.AUTHOR: self.is_valid_author,
             ConfigEnum.VERSION: self.is_valid_version,
             ConfigEnum.CUSTOM_BUILD_COMMAND: self.is_valid_custom_build_command,
@@ -33,6 +34,10 @@ class WizardChecker:
             boolean: True if the input value is valid for the field, False otherwise.
         """
         return self.switch.get(field)(input_value)
+
+    def is_valid_component_name(self, input_value):
+        # input must be a non-empty string
+        return isinstance(input_value, str) and len(input_value) > 0
 
     def is_valid_author(self, input_value):
         # input must be a non-empty string

--- a/gdk/wizard/WizardData.py
+++ b/gdk/wizard/WizardData.py
@@ -19,6 +19,7 @@ class WizardData:
         )
 
         self.switch = {
+            ConfigEnum.COMPONENT_NAME: Model(self.get_component_name, self.set_component_name),
             ConfigEnum.AUTHOR: Model(self.get_author, self.set_author),
             ConfigEnum.VERSION: Model(self.get_version, self.set_version),
             ConfigEnum.BUILD_SYSTEM: Model(
@@ -43,6 +44,9 @@ class WizardData:
 
     def set_field(self, field, value):
         self.switch.get(field).setter(value)
+
+    def get_component_name(self):
+        return self.component_name
 
     def get_author(self):
         return self.component_config.get(
@@ -106,6 +110,11 @@ class WizardData:
         return self.field_dict.get(
             ConfigEnum.GDK_VERSION.value.key, ConfigEnum.GDK_VERSION.value.default
         )
+
+    def set_component_name(self, value):
+        if value is not None:
+            self.project_config[value] = self.project_config.pop(self.component_name)
+            self.component_name = value
 
     def set_author(self, value):
         if value is not None:

--- a/tests/gdk/wizard/test_WizardChecker.py
+++ b/tests/gdk/wizard/test_WizardChecker.py
@@ -4,6 +4,24 @@ from gdk.wizard.ConfigEnum import ConfigEnum
 
 
 @pytest.mark.parametrize(
+    "valid_component_name",
+    ["test", "com.example.HelloWorldComponent"],
+)
+def test_check_component_name_valid(valid_component_name):
+    checker = WizardChecker()
+    assert checker.is_valid_input(valid_component_name, ConfigEnum.COMPONENT_NAME) is True
+
+
+@pytest.mark.parametrize(
+    "invalid_component_name",
+    [""],
+)
+def test_check_component_name_invalid(invalid_component_name):
+    checker = WizardChecker()
+    assert checker.is_valid_input(invalid_component_name, ConfigEnum.COMPONENT_NAME) is False
+
+
+@pytest.mark.parametrize(
     "valid_author",
     ["test", "''[]''"],
 )

--- a/tests/gdk/wizard/test_WizardData.py
+++ b/tests/gdk/wizard/test_WizardData.py
@@ -20,6 +20,10 @@ class TestWizardModel(TestCase):  # Inherit from unittest.TestCase
             "gdk_version": "1.0.0",
         }
 
+    def test_get_component_name(self):
+        data = WizardData(self.field_dict)
+        self.assertEqual(data.get_component_name(), "1")
+
     def test_get_author(self):
         data = WizardData(self.field_dict)
         self.assertEqual(data.get_author(), "abc")
@@ -55,6 +59,11 @@ class TestWizardModel(TestCase):  # Inherit from unittest.TestCase
     def test_get_gdk_version(self):
         data = WizardData(self.field_dict)
         self.assertEqual(data.get_gdk_version(), "1.0.0")
+
+    def test_set_component_name(self):
+        data = WizardData(self.field_dict)
+        data.set_component_name("2")
+        self.assertEqual(data.get_component_name(), "2")
 
     def test_set_author(self):
         data = WizardData(self.field_dict)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add functionality to prompt for component name in the gdk-config.json file. This will be the first prompt when running `gdk config update -c`. If a name is given, it will change the component name in the gdk-config.json file to the given name, otherwise keep the existing one.

**Why is this change necessary:**
When users are using our provided templates, they are likely going to want to change the component name. Prompting for it will allow users to change it without opening the gdk-config.json file, which is the goal of the gdk config update command.

**How was this change tested:**
Manually tested. Also added some unit tests.

**Any additional information or context required to review the change:**
I know the two lines in the prompting function are missing coverage, unit tests for that will be added in a later PR when the entire class is tested.

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.