### PR TITLE
fix: publish options update does not error when dict

### DIFF
--- a/gdk/commands/config/update/ConfigData.py
+++ b/gdk/commands/config/update/ConfigData.py
@@ -162,8 +162,7 @@ class ConfigData:
 
     def set_publish_options(self, value):
         # value can be a dict object or a string
-        formatted_input = value.replace("'", '"')
-        new_value = json.loads(formatted_input) if isinstance(value, str) else value
+        new_value = json.loads(value.replace("'", '"')) if isinstance(value, str) else value
         self._set_publish_config_values(ConfigEnum.PUBLISH_OPTIONS.value, new_value)
 
     def set_gdk_version(self, value):

--- a/gdk/commands/config/update/Prompter.py
+++ b/gdk/commands/config/update/Prompter.py
@@ -62,7 +62,7 @@ class Prompter:
                 [
                     f"--{parser_argument}",
                     self.interactive_prompt(
-                        parser_argument, current_field_value, require
+                        parser_argument, str(current_field_value), require
                     ),
                 ]
             )

--- a/tests/gdk/commands/config/update/test_ConfigData.py
+++ b/tests/gdk/commands/config/update/test_ConfigData.py
@@ -102,9 +102,14 @@ class TestConfigModel(TestCase):  # Inherit from unittest.TestCase
         data.set_field(ConfigEnum.REGION, "random-region123")
         self.assertEqual(data.get_region(), "random-region123")
 
-    def test_set_publish_options(self):
+    def test_set_publish_options_str(self):
         data = ConfigData(self.field_dict)
         data.set_field(ConfigEnum.PUBLISH_OPTIONS, '{"bar": "foo"}')
+        self.assertEqual(data.get_publish_options(), {"bar": "foo"})
+
+    def test_set_publish_options_dict(self):
+        data = ConfigData(self.field_dict)
+        data.set_field(ConfigEnum.PUBLISH_OPTIONS, {"bar": "foo"})
         self.assertEqual(data.get_publish_options(), {"bar": "foo"})
 
     def test_set_gdk_version(self):


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
There were two bugs having to do with publish command prompting.
- When default value is used, a dict is passed which errors due to a string method. Now, we always take a string as the input for default value (as it should be)
- When improper input is passed 3 times, it uses the original value which is a dict. This also errors because of a string method.

Both bugs are fixed and the corresponding string manipulation methods are only used on strings.

**Why is this change necessary:**
Bugfix

**How was this change tested:**
Added a new unit test for set_publish_options to cover the case where a dict is passed. This should verify this bug is fixed in future updates.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.