### PR TITLE
fix: only exclude files from root dir when building zip

### DIFF
--- a/gdk/build_system/Zip.py
+++ b/gdk/build_system/Zip.py
@@ -39,26 +39,21 @@ class Zip(GDKBuildSystem):
             artifacts_zip_build = Path(zip_build).joinpath(utils.get_current_directory().name).resolve()
             utils.clean_dir(zip_build)
             logging.debug("Copying over component files to the '{}' folder.".format(artifacts_zip_build.name))
+            root_directory_path = utils.get_current_directory()
 
-            def ignore_patterns_in_root(rootdir, *patterns):
-                def _ignore_patterns_in_root(path, names):
-                    if str(path) == str(rootdir):
-                        ignored_names = []
-                        for pattern in patterns:
-                            ignored_names.extend(fnmatch.filter(names, pattern))
-                        return set(ignored_names)
-                    else:
-                        return set()
-                return _ignore_patterns_in_root
+            def ignore_patterns_in_root(path, names):
+                if str(path) == str(root_directory_path):
+                    return {
+                        name
+                        for pattern in self.get_ignored_file_patterns(project_config)
+                        for name in fnmatch.filter(names, pattern)
+                    }
+                return set()
 
-            cwd = utils.get_current_directory()
             shutil.copytree(
-                cwd,
+                root_directory_path,
                 artifacts_zip_build,
-                ignore=ignore_patterns_in_root(
-                                                cwd,
-                                                *self.get_ignored_file_patterns(project_config)
-                                              ),
+                ignore=ignore_patterns_in_root,
             )
 
             # Get build file name without extension. This will be used as name of the archive.

--- a/integration_tests/gdk/components/test_integ_BuildCommand.py
+++ b/integration_tests/gdk/components/test_integ_BuildCommand.py
@@ -26,11 +26,11 @@ class ComponentBuildCommandIntegTest(TestCase):
         bc = BuildCommand({})
         bc.run()
         build_recipe_file = self.tmpdir.joinpath("greengrass-build/recipes/recipe.yaml").resolve()
-        included_file_path = "zip-build/" + self.tmpdir.name + "/src/test_do_want_this_file.txt"
-        excluded_file_path = "zip-build/" + self.tmpdir.name + "/test_dont_want_this_file.txt"
+        included_file_path = f"zip-build/{self.tmpdir.name}/src/test_do_want_this_file.txt"
+        excluded_file_path = f"zip-build/{self.tmpdir.name}/test_dont_want_this_file.txt"
         test_file_included = self.tmpdir.joinpath(included_file_path).resolve()
         test_file_excluded = self.tmpdir.joinpath(excluded_file_path).resolve()
-        assert self.tmpdir.joinpath("greengrass-build/artifacts/abc/NEXT_PATCH/" + self.tmpdir.name + ".zip").exists()
+        assert self.tmpdir.joinpath(f"greengrass-build/artifacts/abc/NEXT_PATCH/{self.tmpdir.name}.zip").exists()
         assert build_recipe_file.exists()
         assert test_file_included.exists()
         assert not test_file_excluded.exists()

--- a/integration_tests/gdk/components/test_integ_BuildCommand.py
+++ b/integration_tests/gdk/components/test_integ_BuildCommand.py
@@ -26,8 +26,14 @@ class ComponentBuildCommandIntegTest(TestCase):
         bc = BuildCommand({})
         bc.run()
         build_recipe_file = self.tmpdir.joinpath("greengrass-build/recipes/recipe.yaml").resolve()
+        included_file_path = "zip-build/" + self.tmpdir.name + "/src/test_do_want_this_file.txt"
+        excluded_file_path = "zip-build/" + self.tmpdir.name + "/test_dont_want_this_file.txt"
+        test_file_included = self.tmpdir.joinpath(included_file_path).resolve()
+        test_file_excluded = self.tmpdir.joinpath(excluded_file_path).resolve()
         assert self.tmpdir.joinpath("greengrass-build/artifacts/abc/NEXT_PATCH/" + self.tmpdir.name + ".zip").exists()
         assert build_recipe_file.exists()
+        assert test_file_included.exists()
+        assert not test_file_excluded.exists()
 
         with open(build_recipe_file, "r") as f:
             assert f"s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/{self.tmpdir.name}.zip" in f.read()
@@ -156,6 +162,9 @@ class ComponentBuildCommandIntegTest(TestCase):
             f.write(recipe)
 
         self.tmpdir.joinpath("hello_world.py").touch()
+        self.tmpdir.joinpath("test_dont_want_this_file.txt").touch()
+        self.tmpdir.joinpath("src").mkdir()
+        self.tmpdir.joinpath("src", "test_do_want_this_file.txt").touch()
 
     def zip_test_data_oversized_recipe(self):
         shutil.copy(


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-gdk-cli/issues/143

**Description of changes:**
Only exclude excluded files from the zip build, if they are in the root directory of the build.

**Why is this change necessary:**
See issue for correspondence. Certain projects may need to include files in sub-directories that were incorrectly being excluded.

**How was this change tested:**
Manually tested using a sample project that had test* prefixed files in both root directory and sub-directories. Change correctly packages it such that the excluded files in root are removed but the ones not in root were kept.

Updated integration test for build command to verify that test* prefixed file in src subfolder is kept, but test* prefixed file in root folder is excluded during zip build.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.