### PR TITLE
feat: exclude test from all subdirectories by default

### DIFF
--- a/gdk/build_system/Zip.py
+++ b/gdk/build_system/Zip.py
@@ -109,7 +109,7 @@ class Zip(GDKBuildSystem):
         if not options:
             ignore_list.extend(
                 [
-                    "test*",
+                    "**/test*",
                     "**/.*",
                     "**/node_modules",
                 ]

--- a/integration_tests/gdk/components/test_integ_BuildCommand.py
+++ b/integration_tests/gdk/components/test_integ_BuildCommand.py
@@ -26,10 +26,10 @@ class ComponentBuildCommandIntegTest(TestCase):
         bc = BuildCommand({})
         bc.run()
         build_recipe_file = self.tmpdir.joinpath("greengrass-build/recipes/recipe.yaml").resolve()
-        included_file_path = f"zip-build/{self.tmpdir.name}/src/test_do_want_this_file.txt"
-        excluded_file_path = f"zip-build/{self.tmpdir.name}/test_dont_want_this_file.txt"
-        test_file_included = self.tmpdir.joinpath(included_file_path).resolve()
-        test_file_excluded = self.tmpdir.joinpath(excluded_file_path).resolve()
+        test_subdir_file_path = f"zip-build/{self.tmpdir.name}/src/test_subdir.txt"
+        test_root_file_path = f"zip-build/{self.tmpdir.name}/test_root.txt"
+        test_root_file = self.tmpdir.joinpath(test_root_file_path).resolve()
+        test_subdir_file = self.tmpdir.joinpath(test_subdir_file_path).resolve()
         node_modules_root_excluded = self.tmpdir.joinpath(f"zip-build/{self.tmpdir.name}/node_modules").resolve()
         node_modules_subdir_excluded = self.tmpdir.joinpath(f"zip-build/{self.tmpdir.name}/src/node_modules").resolve()
         node_modules_file_path = f"zip-build/{self.tmpdir.name}/src/node_modules/excluded_file.txt"
@@ -37,8 +37,8 @@ class ComponentBuildCommandIntegTest(TestCase):
 
         assert self.tmpdir.joinpath(f"greengrass-build/artifacts/abc/NEXT_PATCH/{self.tmpdir.name}.zip").exists()
         assert build_recipe_file.exists()
-        assert test_file_included.exists()
-        assert not test_file_excluded.exists()
+        assert not test_root_file.exists()
+        assert not test_subdir_file.exists()
         assert not node_modules_root_excluded.exists()
         assert not node_modules_subdir_excluded.exists()
         assert not node_modules_file_excluded.exists()
@@ -170,9 +170,9 @@ class ComponentBuildCommandIntegTest(TestCase):
             f.write(recipe)
 
         self.tmpdir.joinpath("hello_world.py").touch()
-        self.tmpdir.joinpath("test_dont_want_this_file.txt").touch()
+        self.tmpdir.joinpath("test_root.txt").touch()
         self.tmpdir.joinpath("src").mkdir()
-        self.tmpdir.joinpath("src", "test_do_want_this_file.txt").touch()
+        self.tmpdir.joinpath("src", "test_subdir.txt").touch()
         self.tmpdir.joinpath("node_modules").mkdir()
         self.tmpdir.joinpath("src", "node_modules").mkdir()
         self.tmpdir.joinpath("src", "node_modules", "excluded_file.txt").touch()

--- a/tests/gdk/build_system/test_Zip.py
+++ b/tests/gdk/build_system/test_Zip.py
@@ -44,7 +44,7 @@ class ZipTests(TestCase):
             "gdk-config.json",
             "greengrass-build",
             "recipe.json",
-            "test*",
+            "**/test*",
             "**/.*",
             "**/node_modules",
         ] == zip.get_ignored_file_patterns(config)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Change the default behavior for zip build to exclude test from all subdirectories, consistent with past GDK versions (1.4.0 and before).

**Why is this change necessary:**
Changing default behavior to be in line with past behavior.

**How was this change tested:**
I changed the tests that had to do with default behavior. Also verified that the change worked as expected manually.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.