### PR TITLE
feat: add smart warning if old excludes config is provided

### DIFF
--- a/gdk/build_system/Zip.py
+++ b/gdk/build_system/Zip.py
@@ -141,6 +141,8 @@ class Zip(GDKBuildSystem):
                           "only match at the root level of the project. If this is intentional, you can ignore this " +
                           "warning, but to achieve the old behavior excluding from each subdirectory, append \'**/\' " +
                           "to each pattern as such: ")
+        warning_string_2 = (". To ignore this warning in the future, set the GDK_EXCLUDES_WARN_IGNORE environment " +
+                            "variable to true.")
         GDK_EXCLUDES_ENV_KEY = "GDK_EXCLUDES_WARN_IGNORE"
         build_options = project_config.build_options
         excludes_list = build_options.get("excludes", [])
@@ -152,6 +154,6 @@ class Zip(GDKBuildSystem):
             # not need the warning.
             suggestion_list = [f"**/{old_pattern}" for old_pattern in excludes_list]
             suggestion_list_str = str(suggestion_list).replace("'", '"')
-            logging.warning(f"{warning_string}{suggestion_list_str}")
+            logging.warning(f"{warning_string}{suggestion_list_str}{warning_string_2}")
         else:
             return

--- a/gdk/build_system/Zip.py
+++ b/gdk/build_system/Zip.py
@@ -147,6 +147,9 @@ class Zip(GDKBuildSystem):
         if not excludes_list or os.environ.get(GDK_EXCLUDES_ENV_KEY, "False").lower() == "true":
             return
         elif all(pattern.find("/") == -1 for pattern in excludes_list):
+            # We check if we issue the warning by seeing if there are any slashes in any items in the provided excludes
+            # configuration. If there are any slashes, we assume that the project is created using GDK 1.5.0+ and does
+            # not need the warning.
             suggestion_list = [f"**/{old_pattern}" for old_pattern in excludes_list]
             suggestion_list_str = str(suggestion_list).replace("'", '"')
             logging.warning(f"{warning_string}{suggestion_list_str}")

--- a/integration_tests/gdk/components/test_integ_BuildCommand.py
+++ b/integration_tests/gdk/components/test_integ_BuildCommand.py
@@ -72,6 +72,15 @@ class ComponentBuildCommandIntegTest(TestCase):
         assert "In GDK version 1.5.0, patterns for exclusions in zip builds" not in logs
         assert "[\"**/node_modules\", \"**/test*\", \"**/*.txt\"]" not in logs
 
+    def test_GIVEN_zip_build_system_WHEN_excludes_provided_with_new_patterns_THEN_no_warn_in_logs(self):
+        self.caplog.set_level(logging.WARNING)
+        self.zip_new_excludes_test_data()
+        bc = BuildCommand({})
+        bc.run()
+
+        logs = self.caplog.text
+        assert "In GDK version 1.5.0, patterns for exclusions in zip builds" not in logs
+
     def test_GIVEN_zip_build_system_WHEN_build_and_artifacts_not_on_s3_THEN_build_raises_exception(self):
         self.zip_test_data()
         content = CaseInsensitiveRecipeFile().read(self.tmpdir.joinpath("recipe.yaml"))
@@ -207,6 +216,25 @@ class ComponentBuildCommandIntegTest(TestCase):
         old_excludes_config_path = "integration_tests/test_data/config/config_old_excludes.json"
         shutil.copy(
             self.c_dir.joinpath(old_excludes_config_path), self.tmpdir.joinpath("gdk-config.json")
+        )
+
+        shutil.copy(
+            self.c_dir.joinpath("integration_tests/test_data/recipes/hello_world_recipe.yaml"),
+            self.tmpdir.joinpath("recipe.yaml"),
+        )
+        with open(self.tmpdir.joinpath("recipe.yaml"), "r") as f:
+            recipe = f.read()
+            recipe = recipe.replace("$GG_ARTIFACT", self.tmpdir.name + ".zip")
+
+        with open(self.tmpdir.joinpath("recipe.yaml"), "w") as f:
+            f.write(recipe)
+
+        self.tmpdir.joinpath("hello_world.py").touch()
+
+    def zip_new_excludes_test_data(self):
+        new_excludes_config_path = "integration_tests/test_data/config/config_new_excludes.json"
+        shutil.copy(
+            self.c_dir.joinpath(new_excludes_config_path), self.tmpdir.joinpath("gdk-config.json")
         )
 
         shutil.copy(

--- a/integration_tests/gdk/components/test_integ_BuildCommand.py
+++ b/integration_tests/gdk/components/test_integ_BuildCommand.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 import pytest
+import logging
 from pathlib import Path
 import os
 import shutil
@@ -20,6 +21,10 @@ class ComponentBuildCommandIntegTest(TestCase):
         os.chdir(self.tmpdir)
         yield
         os.chdir(self.c_dir)
+
+    @pytest.fixture(autouse=True)
+    def caplog(self, caplog):
+        self.caplog = caplog
 
     def test_GIVEN_zip_build_system_WHEN_build_THEN_build_zip_artifacts(self):
         self.zip_test_data()
@@ -45,6 +50,27 @@ class ComponentBuildCommandIntegTest(TestCase):
 
         with open(build_recipe_file, "r") as f:
             assert f"s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/{self.tmpdir.name}.zip" in f.read()
+
+    def test_GIVEN_zip_build_system_WHEN_excludes_provided_with_old_patterns_THEN_warn_in_logs(self):
+        self.caplog.set_level(logging.WARNING)
+        self.zip_old_excludes_test_data()
+        bc = BuildCommand({})
+        bc.run()
+
+        logs = self.caplog.text
+        assert "In GDK version 1.5.0, patterns for exclusions in zip builds" in logs
+        assert "[\"**/node_modules\", \"**/test*\", \"**/*.txt\"]" in logs
+
+    def test_GIVEN_zip_build_system_WHEN_excludes_provided_with_old_patterns_and_env_var_set_THEN_no_warn_in_logs(self):
+        self.caplog.set_level(logging.WARNING)
+        self.mocker.patch.dict(os.environ, {"GDK_EXCLUDES_WARN_IGNORE": "true"})
+        self.zip_old_excludes_test_data()
+        bc = BuildCommand({})
+        bc.run()
+
+        logs = self.caplog.text
+        assert "In GDK version 1.5.0, patterns for exclusions in zip builds" not in logs
+        assert "[\"**/node_modules\", \"**/test*\", \"**/*.txt\"]" not in logs
 
     def test_GIVEN_zip_build_system_WHEN_build_and_artifacts_not_on_s3_THEN_build_raises_exception(self):
         self.zip_test_data()
@@ -176,6 +202,25 @@ class ComponentBuildCommandIntegTest(TestCase):
         self.tmpdir.joinpath("node_modules").mkdir()
         self.tmpdir.joinpath("src", "node_modules").mkdir()
         self.tmpdir.joinpath("src", "node_modules", "excluded_file.txt").touch()
+
+    def zip_old_excludes_test_data(self):
+        old_excludes_config_path = "integration_tests/test_data/config/config_old_excludes.json"
+        shutil.copy(
+            self.c_dir.joinpath(old_excludes_config_path), self.tmpdir.joinpath("gdk-config.json")
+        )
+
+        shutil.copy(
+            self.c_dir.joinpath("integration_tests/test_data/recipes/hello_world_recipe.yaml"),
+            self.tmpdir.joinpath("recipe.yaml"),
+        )
+        with open(self.tmpdir.joinpath("recipe.yaml"), "r") as f:
+            recipe = f.read()
+            recipe = recipe.replace("$GG_ARTIFACT", self.tmpdir.name + ".zip")
+
+        with open(self.tmpdir.joinpath("recipe.yaml"), "w") as f:
+            f.write(recipe)
+
+        self.tmpdir.joinpath("hello_world.py").touch()
 
     def zip_test_data_oversized_recipe(self):
         shutil.copy(

--- a/integration_tests/test_data/config/config_new_excludes.json
+++ b/integration_tests/test_data/config/config_new_excludes.json
@@ -1,0 +1,29 @@
+{
+  "component": {
+    "abc": {
+      "author": "abc",
+      "version": "NEXT_PATCH",
+      "build": {
+        "build_system": "zip",
+        "options": {
+          "excludes": [
+            "**/node_modules",
+            "test*",
+            "**/*.txt"
+          ]
+        }
+      },
+      "publish": {
+        "bucket": "default",
+        "region": "us-east-1"
+      }
+    }
+  },
+  "test-e2e": {
+    "otf_version": "1.2.0",
+    "otf_options": {
+      "tags": "testtags"
+    }
+  },
+  "gdk_version": "1.0.0"
+}

--- a/integration_tests/test_data/config/config_old_excludes.json
+++ b/integration_tests/test_data/config/config_old_excludes.json
@@ -1,0 +1,29 @@
+{
+  "component": {
+    "abc": {
+      "author": "abc",
+      "version": "NEXT_PATCH",
+      "build": {
+        "build_system": "zip",
+        "options": {
+          "excludes": [
+            "node_modules",
+            "test*",
+            "*.txt"
+          ]
+        }
+      },
+      "publish": {
+        "bucket": "default",
+        "region": "us-east-1"
+      }
+    }
+  },
+  "test-e2e": {
+    "otf_version": "1.2.0",
+    "otf_options": {
+      "tags": "testtags"
+    }
+  },
+  "gdk_version": "1.0.0"
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds a smart warning during component build that notifies user of the glob behavior change during zip exclusions if their provided excludes config uses exclusively the patterns that do not match to directories (old format). The warning also informs the user of how to achieve the old behavior by updating their config and specifies the exact change that needs to be made for this to happen.

The warning can be ignored by setting the GDK_EXCLUDES_WARN_IGNORE environment variable to true.

Example output (given ["node_modules"] as the excludes config):

`[2023-10-24 15:47:07] WARNING - Build option 'excludes' found in config and none of the provided patterns include directory matching. In GDK version 1.5.0, patterns for exclusions in zip builds were changed to use the glob format, so patterns with no specified directory pattern will only match at the root level of the project. If this is intentional, you can ignore this warning, but to achieve the old behavior excluding from each subdirectory, append '**/' to each pattern as such: ["**/node_modules"]. To ignore this warning in the future, set the GDK_EXCLUDES_WARN_IGNORE environment variable to true.`

**Why is this change necessary:**
Since there is a behavior change with how excludes patterns are handled, this change will notify users with a warning about the new behavior and provide steps to update their project if they desire the old behavior.

**How was this change tested:**
Manually tested. Also added integration tests to verify the warning exists if excludes is provided with old format patterns, but not when the env var is set.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.