### PR TITLE
feat: add recipe validation to build and publish commands

### DIFF
--- a/gdk/commands/component/transformer/BuildRecipeTransformer.py
+++ b/gdk/commands/component/transformer/BuildRecipeTransformer.py
@@ -9,7 +9,7 @@ import gdk.common.consts as consts
 import gdk.common.utils as utils
 from gdk.commands.component.config.ComponentBuildConfiguration import ComponentBuildConfiguration
 from gdk.aws_clients.S3Client import S3Client
-from gdk.common.exceptions.error_messages import RECIPE_SIZE_INVALID, PROJECT_RECIPE_FILE_INVALID
+from gdk.common.exceptions.error_messages import RECIPE_SIZE_INVALID, PROJECT_RECIPE_FILE_INVALID, SCHEMA_FILE_INVALID
 
 
 class BuildRecipeTransformer:
@@ -42,6 +42,8 @@ class BuildRecipeTransformer:
             validator.validate_recipe(component_recipe.to_dict())
         except jsonschema.exceptions.ValidationError as err:
             raise Exception(PROJECT_RECIPE_FILE_INVALID.format(self.project_config.recipe_file, err.message))
+        except jsonschema.exceptions.SchemaError as err:
+            raise Exception(SCHEMA_FILE_INVALID.format(err.message))
 
         self.create_build_recipe_file(component_recipe)
 

--- a/gdk/commands/component/transformer/BuildRecipeTransformer.py
+++ b/gdk/commands/component/transformer/BuildRecipeTransformer.py
@@ -33,6 +33,7 @@ class BuildRecipeTransformer:
             raise Exception(RECIPE_SIZE_INVALID.format(self.project_config.recipe_file, input_recipe_file_size))
 
         component_recipe = CaseInsensitiveRecipeFile().read(self.project_config.recipe_file)
+        self.update_component_recipe_file(component_recipe, build_folders)
 
         logging.info("Validating the recipe against the Greengrass recipe schema.")
         try:
@@ -42,7 +43,6 @@ class BuildRecipeTransformer:
         except jsonschema.exceptions.ValidationError as err:
             raise Exception(PROJECT_RECIPE_FILE_INVALID.format(self.project_config.recipe_file, err.message))
 
-        self.update_component_recipe_file(component_recipe, build_folders)
         self.create_build_recipe_file(component_recipe)
 
     def update_component_recipe_file(self, parsed_component_recipe: CaseInsensitiveDict, build_folders):

--- a/gdk/commands/component/transformer/BuildRecipeTransformer.py
+++ b/gdk/commands/component/transformer/BuildRecipeTransformer.py
@@ -1,13 +1,15 @@
+import jsonschema
 import logging
 import shutil
 from pathlib import Path
 from gdk.common.CaseInsensitive import CaseInsensitiveRecipeFile, CaseInsensitiveDict
+from gdk.common.RecipeValidator import RecipeValidator
 
 import gdk.common.consts as consts
 import gdk.common.utils as utils
 from gdk.commands.component.config.ComponentBuildConfiguration import ComponentBuildConfiguration
 from gdk.aws_clients.S3Client import S3Client
-from gdk.common.exceptions.error_messages import RECIPE_SIZE_INVALID
+from gdk.common.exceptions.error_messages import RECIPE_SIZE_INVALID, PROJECT_RECIPE_FILE_INVALID
 
 
 class BuildRecipeTransformer:
@@ -31,6 +33,15 @@ class BuildRecipeTransformer:
             raise Exception(RECIPE_SIZE_INVALID.format(self.project_config.recipe_file, input_recipe_file_size))
 
         component_recipe = CaseInsensitiveRecipeFile().read(self.project_config.recipe_file)
+
+        logging.info("Validating the recipe against the Greengrass recipe schema.")
+        try:
+            recipe_schema_path = utils.get_static_file_path(consts.recipe_schema_file)
+            validator = RecipeValidator(recipe_schema_path)
+            validator.validate_recipe(component_recipe.to_dict())
+        except jsonschema.exceptions.ValidationError as err:
+            raise Exception(PROJECT_RECIPE_FILE_INVALID.format(self.project_config.recipe_file, err.message))
+
         self.update_component_recipe_file(component_recipe, build_folders)
         self.create_build_recipe_file(component_recipe)
 

--- a/gdk/commands/component/transformer/PublishRecipeTransformer.py
+++ b/gdk/commands/component/transformer/PublishRecipeTransformer.py
@@ -7,7 +7,7 @@ from gdk.common.RecipeValidator import RecipeValidator
 
 import gdk.common.consts as consts
 import gdk.common.utils as utils
-from gdk.common.exceptions.error_messages import BUILT_RECIPE_SIZE_INVALID, BUILD_RECIPE_FILE_INVALID
+from gdk.common.exceptions.error_messages import BUILT_RECIPE_SIZE_INVALID, BUILD_RECIPE_FILE_INVALID, SCHEMA_FILE_INVALID
 
 
 class PublishRecipeTransformer:
@@ -104,3 +104,5 @@ class PublishRecipeTransformer:
             validator.validate_recipe(parsed_component_recipe.to_dict())
         except jsonschema.exceptions.ValidationError as err:
             raise Exception(BUILD_RECIPE_FILE_INVALID.format(recipe_path, err.message))
+        except jsonschema.exceptions.SchemaError as err:
+            raise Exception(SCHEMA_FILE_INVALID.format(err.message))

--- a/gdk/common/RecipeValidator.py
+++ b/gdk/common/RecipeValidator.py
@@ -1,0 +1,27 @@
+import json
+import jsonschema
+
+
+class RecipeValidator:
+    def __init__(self, schema_file):
+        self._setup_schema(schema_file)
+
+    def validate_recipe(self, recipe):
+        processed_recipe = self._keys_to_lower(recipe)
+        jsonschema.validate(instance=processed_recipe, schema=self.schema, cls=jsonschema.validators.Draft7Validator)
+
+    def _setup_schema(self, schema_file):
+        with open(schema_file, 'r') as file:
+            self.schema = json.loads(file.read())
+            jsonschema.Draft7Validator.check_schema(schema=self.schema)
+
+    def _keys_to_lower(self, obj):
+        if type(obj) is dict:
+            return_dict = {}
+            for key, item in obj.items():
+                return_dict[key.lower()] = self._keys_to_lower(item)
+            return return_dict
+        elif type(obj) is list:
+            return [self._keys_to_lower(i) for i in obj]
+        else:
+            return obj

--- a/gdk/common/consts.py
+++ b/gdk/common/consts.py
@@ -19,6 +19,7 @@ MAX_RECIPE_FILE_SIZE_BYTES = 16000
 
 # FILES
 config_schema_file = "config_schema.json"
+recipe_schema_file = "recipe_schema.json"
 cli_model_file = "cli_model.json"
 cli_project_config_file = "gdk-config.json"
 greengrass_build_dir = "greengrass-build"

--- a/gdk/common/exceptions/error_messages.py
+++ b/gdk/common/exceptions/error_messages.py
@@ -8,6 +8,7 @@ PROJECT_RECIPE_FILE_NOT_FOUND = (
 )
 PROJECT_CONFIG_FILE_INVALID = "Project configuration file '{}' is invalid. Please correct its format and try again. Error: {} "
 PROJECT_RECIPE_FILE_INVALID = "Project recipe file '{}' is invalid. Please correct its format and try again. Error: {} "
+SCHEMA_FILE_INVALID = "The Greengrass recipe schema file has an unexpected error. Error: {} "
 BUILD_RECIPE_FILE_INVALID = "Built recipe file '{}' is invalid. Please correct its format and try again. Error: {} "
 CLI_MODEL_FILE_NOT_EXISTS = "Model validation failed. CLI model file doesn't exist."
 RECIPE_SIZE_INVALID = (

--- a/gdk/common/exceptions/error_messages.py
+++ b/gdk/common/exceptions/error_messages.py
@@ -7,6 +7,8 @@ PROJECT_RECIPE_FILE_NOT_FOUND = (
     "No valid component recipe is found. Please include a valid recipe file of the component to build with default."
 )
 PROJECT_CONFIG_FILE_INVALID = "Project configuration file '{}' is invalid. Please correct its format and try again. Error: {} "
+PROJECT_RECIPE_FILE_INVALID = "Project recipe file '{}' is invalid. Please correct its format and try again. Error: {} "
+BUILD_RECIPE_FILE_INVALID = "Built recipe file '{}' is invalid. Please correct its format and try again. Error: {} "
 CLI_MODEL_FILE_NOT_EXISTS = "Model validation failed. CLI model file doesn't exist."
 RECIPE_SIZE_INVALID = (
     "The input recipe file '{}' has an invalid size of {} bytes. Please make sure it does not exceed 16kB"

--- a/gdk/common/exceptions/error_messages.py
+++ b/gdk/common/exceptions/error_messages.py
@@ -8,7 +8,10 @@ PROJECT_RECIPE_FILE_NOT_FOUND = (
 )
 PROJECT_CONFIG_FILE_INVALID = "Project configuration file '{}' is invalid. Please correct its format and try again. Error: {} "
 PROJECT_RECIPE_FILE_INVALID = "Project recipe file '{}' is invalid. Please correct its format and try again. Error: {} "
-SCHEMA_FILE_INVALID = "The Greengrass recipe schema file has an unexpected error. Error: {} "
+SCHEMA_FILE_INVALID = (
+    "The Greengrass recipe schema file has an unexpected error.\nPlease report it at " +
+    "https://github.com/aws-greengrass/aws-greengrass-gdk-cli/issues if the issue persists.\nError details: {} "
+)
 BUILD_RECIPE_FILE_INVALID = "Built recipe file '{}' is invalid. Please correct its format and try again. Error: {} "
 CLI_MODEL_FILE_NOT_EXISTS = "Model validation failed. CLI model file doesn't exist."
 RECIPE_SIZE_INVALID = (

--- a/gdk/static/recipe_schema.json
+++ b/gdk/static/recipe_schema.json
@@ -378,7 +378,7 @@
             "$id": "#/properties/ComponentSource",
             "type": "string",
             "title": "The ComponentSource schema",
-            "pattern": "^arn:aws:lambda:.*$",
+            "pattern": "^arn:aws(-(cn|us-gov|iso(-[a-z])?))?:lambda:.*$",
             "description": "The lambda arn which is source of this component.",
             "default": ""
         },

--- a/gdk/static/recipe_schema.json
+++ b/gdk/static/recipe_schema.json
@@ -26,11 +26,7 @@
     "definitions": {
         "permissions": {
             "type": "string",
-            "enum": [
-                "NONE",
-                "OWNER",
-                "ALL"
-            ]
+            "pattern": "^(?i)(NONE|OWNER|ALL)$"
         },
         "lifecycle": {
             "type": "object",
@@ -221,7 +217,7 @@
                         }
                     ],
                     "additionalProperties": {
-                        "anyOf": [
+                        "anyof": [
                             {
                                 "type": "number"
                             },
@@ -334,10 +330,10 @@
             "type": "string",
             "title": "The ComponentVersion schema",
             "description": "",
-            "default": "",
+            "default": "1.0.0",
             "maxLength": 64,
             "examples": [
-                "1.0.0-aplpha"
+                "1.0.0-alpha"
             ]
         },
         "componentconfiguration": {
@@ -367,12 +363,7 @@
             "title": "The ComponentType schema",
             "description": "The type of this component.",
             "default": "aws.greengrass.generic",
-            "enum": [
-                "aws.greengrass.generic",
-                "aws.greengrass.plugin",
-                "aws.greengrass.nucleus",
-                "aws.greengrass.lambda"
-            ]
+            "pattern" : "^(?i)(aws\\.greengrass\\.(nucleus|generic|plugin|lambda))$"
         },
         "componentsource": {
             "$id": "#/properties/ComponentSource",
@@ -430,11 +421,8 @@
                             "type": "string",
                             "title": "The DependencyType schema",
                             "description": "The type of this dependency.",
-                            "default": "",
-                            "enum": [
-                                "SOFT",
-                                "HARD"
-                            ],
+                            "default": "HARD",
+                            "pattern": "^(?i)(SOFT|HARD)$",
                             "examples": [
                                 "SOFT"
                             ]
@@ -491,10 +479,8 @@
                                 },
                                 "unarchive": {
                                     "type": "string",
-                                    "enum": [
-                                        "ZIP",
-                                        "NONE"
-                                    ]
+                                    "default": "NONE",
+                                    "pattern": "^(?i)(ZIP|NONE)$"
                                 },
                                 "permission": {
                                     "type": "object",

--- a/gdk/static/recipe_schema.json
+++ b/gdk/static/recipe_schema.json
@@ -1,0 +1,568 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "title": "The AWS IoT Greengrass v2 recipe schema",
+    "default": {
+        "recipeformatversion": "2020-01-25",
+        "componentname": "com.example.hello",
+        "componentpublisher": "Me",
+        "componentversion": "1.0.0",
+        "manifests": [
+            {
+                "Lifecycle": {
+                    "run": "echo Hello"
+                }
+            }
+        ]
+    },
+    "examples": [],
+    "required": [
+        "recipeformatversion",
+        "componentname",
+        "componentversion",
+        "manifests"
+    ],
+    "additionalProperties": false,
+    "definitions": {
+        "permissions": {
+            "type": "string",
+            "enum": [
+                "NONE",
+                "OWNER",
+                "ALL"
+            ]
+        },
+        "lifecycle": {
+            "type": "object",
+            "properties": {
+                "setenv": {
+                    "$ref": "#/definitions/setenv"
+                },
+                "bootstrap": {
+                    "$ref": "#/definitions/lifecycleElement"
+                },
+                "install": {
+                    "$ref": "#/definitions/lifecycleElement"
+                },
+                "startup": {
+                    "$ref": "#/definitions/lifecycleElement"
+                },
+                "run": {
+                    "$ref": "#/definitions/lifecycleElement"
+                },
+                "shutdown": {
+                    "$ref": "#/definitions/lifecycleElement"
+                },
+                "recover": {
+                    "$ref": "#/definitions/lifecycleElement"
+                }
+            }
+        },
+        "baseLifecycle": {
+            "type": "object",
+            "properties": {
+                "setenv": {
+                    "$ref": "#/definitions/setenv"
+                },
+                "bootstrap": {
+                    "$ref": "#/definitions/baseLifecycleElement"
+                },
+                "install": {
+                    "$ref": "#/definitions/baseLifecycleElement"
+                },
+                "startup": {
+                    "$ref": "#/definitions/baseLifecycleElement"
+                },
+                "run": {
+                    "$ref": "#/definitions/baseLifecycleElement"
+                },
+                "shutdown": {
+                    "$ref": "#/definitions/baseLifecycleElement"
+                },
+                "recover": {
+                    "$ref": "#/definitions/baseLifecycleElement"
+                }
+            }
+        },
+        "globalLifecycle": {
+            "type": "object",
+            "properties": {
+                "setenv": {
+                    "$ref": "#/definitions/setenv"
+                },
+                "bootstrap": {
+                    "$ref": "#/definitions/globalLifecycleElement"
+                },
+                "install": {
+                    "$ref": "#/definitions/globalLifecycleElement"
+                },
+                "startup": {
+                    "$ref": "#/definitions/globalLifecycleElement"
+                },
+                "run": {
+                    "$ref": "#/definitions/globalLifecycleElement"
+                },
+                "shutdown": {
+                    "$ref": "#/definitions/globalLifecycleElement"
+                },
+                "recover": {
+                    "$ref": "#/definitions/globalLifecycleElement"
+                }
+            }
+        },
+        "globalLifecycleElement": {
+            "$ref": "#/definitions/lifecycleElement",
+            "properties": {
+                "script": {
+                    "$ref": "#/definitions/selections"
+                }
+            }
+        },
+        "lifecycleElement": {
+            "anyOf": [
+                {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/baseLifecycleElement"
+                        },
+                        {
+                            "required": [
+                                "script"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "baseLifecycleElement": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "skipif": {
+                            "type": "string",
+                            "description": "The check to determine whether or not to run the script. You can define to check if an executable is on the path or if a file exists. If the output is true, then the AWS IoT Greengrass Core software skips the step.",
+                            "default": "",
+                            "pattern": "(onpath|exists)\\s+.*",
+                            "examples": [
+                                "exists /usr/local/bin/python3"
+                            ]
+                        },
+                        "script": {
+                            "type": "string",
+                            "description": "The shell script to execute for this lifecycle",
+                            "examples": [
+                                "sudo apt-get install git"
+                            ]
+                        },
+                        "requiresprivilege": {
+                            "oneOf": [
+                                {
+                                    "type": "boolean",
+                                    "description": "If set to true the script will be execute with root privileges",
+                                    "default": false,
+                                    "examples": [
+                                        false
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "description": "If set to true the script will be execute with root privileges.",
+                                    "default": "false",
+                                    "examples": [
+                                        "false"
+                                    ]
+                                }
+                            ]
+                        },
+                        "setenv": {
+                            "$ref": "#/definitions/setenv"
+                        },
+                        "timeout": {
+                            "oneOf": [
+                                {
+                                    "type": "integer",
+                                    "description": "The maximum amount of time in seconds that the script can run before the AWS IoT Greengrass Core software terminates the process.",
+                                    "default": 120,
+                                    "examples": [
+                                        120
+                                    ]
+                                },
+                                {
+                                    "type": "string",
+                                    "description": "The maximum amount of time in seconds that the script can run before the AWS IoT Greengrass Core software terminates the process.",
+                                    "default": "120",
+                                    "examples": [
+                                        "120"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "setenv": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "title": "The Setenv schema",
+                    "description": "Setting environment variable, which will be provided to the process executed by the lifecycle script",
+                    "default": "{}",
+                    "examples": [
+                        {
+                            "VAR_A": "10"
+                        }
+                    ],
+                    "additionalProperties": {
+                        "anyof": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "boolean"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "selections": {
+            "oneOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "const": "all"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "topLevelSelections": {
+            "properties": {
+                "all": {
+                    "$ref": "#/definitions/lifecycle"
+                }
+            },
+            "patternProperties": {
+                ".*": {
+                    "$ref": "#/definitions/lifecycle"
+                }
+            }
+        },
+        "multiLevelSelections": {
+            "properties": {
+                "all": {
+                    "$ref": "#/definitions/globalLifecycle"
+                }
+            },
+            "patternProperties": {
+                ".*": {
+                    "$ref": "#/definitions/globalLifecycle"
+                }
+            }
+        }
+    },
+    "properties": {
+        "recipeformatversion": {
+            "$id": "#/properties/RecipeFormatVersion",
+            "type": "string",
+            "title": "The RecipeFormatVersion schema",
+            "description": "",
+            "default": "2020-01-25",
+            "enum": [
+                "2020-01-25"
+            ],
+            "examples": [
+                {
+                    "RecipeFormatVersion": "2020-01-25"
+                }
+            ]
+        },
+        "componentname": {
+            "$id": "#/properties/ComponentName",
+            "type": "string",
+            "title": "The ComponentName schema",
+            "description": "The name of the component",
+            "pattern": "^[a-zA-Z0-9-_.]+$",
+            "maxLength": 128,
+            "examples": [
+                "com.example.FooService"
+            ]
+        },
+        "componentdescription": {
+            "$id": "#/properties/ComponentDescription",
+            "type": "string",
+            "title": "The ComponentDescription schema",
+            "description": "The description of the component",
+            "default": "",
+            "examples": [
+                "Complete recipe for AWS IoT Greengrass components"
+            ]
+        },
+        "componentpublisher": {
+            "$id": "#/properties/ComponentPublisher",
+            "type": "string",
+            "title": "The ComponentPublisher schema",
+            "description": "The publisher of this component.",
+            "default": "Me"
+        },
+        "componentversion": {
+            "$id": "#/properties/ComponentVersion",
+            "type": "string",
+            "title": "The ComponentVersion schema",
+            "description": "",
+            "default": "",
+            "maxLength": 64,
+            "examples": [
+                "1.0.0-aplpha"
+            ]
+        },
+        "componentconfiguration": {
+            "$id": "#/properties/ComponentConfiguration",
+            "type": "object",
+            "title": "The ComponentConfiguration schema",
+            "description": "The default configuration for this component\nDefines arbitrary configuration objects and accessControl object",
+            "default": "{}",
+            "examples": [
+                {
+                    "defaultconfiguration": {
+                        "TestParam": "TestValue"
+                    }
+                }
+            ],
+            "properties": {
+                "defaultconfiguration": {
+                    "title": "The DefaultConfiguration schema",
+                    "description": "Default configuration parameters for the component",
+                    "default": "{}"
+                }
+            }
+        },
+        "componenttype": {
+            "$id": "#/properties/ComponentType",
+            "type": "string",
+            "title": "The ComponentType schema",
+            "description": "The type of this component.",
+            "default": "aws.greengrass.generic",
+            "enum": [
+                "aws.greengrass.generic",
+                "aws.greengrass.plugin",
+                "aws.greengrass.nucleus",
+                "aws.greengrass.lambda"
+            ]
+        },
+        "componentsource": {
+            "$id": "#/properties/ComponentSource",
+            "type": "string",
+            "title": "The ComponentSource schema",
+            "pattern": "^arn:aws:lambda:.*$",
+            "description": "The lambda arn which is source of this component.",
+            "default": ""
+        },
+        "componentdependencies": {
+            "$id": "#/properties/ComponentDependencies",
+            "type": "object",
+            "title": "The ComponentDependencies schema",
+            "description": "Map describing the dependencies for this component",
+            "default": "{}",
+            "examples": [
+                {
+                    "BarService": {
+                        "versionrequirement": "^1.1.0",
+                        "dependencytype": "SOFT"
+                    },
+                    "BazService": {
+                        "versionrequirement": "^2.0.0"
+                    }
+                }
+            ],
+            "patternProperties": {
+                "^[a-zA-Z0-9-_.]+$": {
+                    "type": "object",
+                    "title": "The dependency schema",
+                    "description": "Dependency configuration for this component",
+                    "default": {
+                        "VersionRequirement": ">0.0.0"
+                    },
+                    "examples": [
+                        {
+                            "VersionRequirement": "^1.1.0",
+                            "DependencyType": "SOFT"
+                        }
+                    ],
+                    "required": [
+                        "versionrequirement"
+                    ],
+                    "properties": {
+                        "versionrequirement": {
+                            "type": "string",
+                            "title": "The VersionRequirement schema",
+                            "description": "The version of the dependency",
+                            "default": "",
+                            "examples": [
+                                "^1.1.0"
+                            ]
+                        },
+                        "dependencytype": {
+                            "type": "string",
+                            "title": "The DependencyType schema",
+                            "description": "The type of this dependency.",
+                            "default": "",
+                            "enum": [
+                                "SOFT",
+                                "HARD"
+                            ],
+                            "examples": [
+                                "SOFT"
+                            ]
+                        }
+                    },
+                    "additionalProperties": true
+                }
+            }
+        },
+        "manifests": {
+            "$id": "#/properties/Manifests",
+            "type": "array",
+            "title": "The Manifests schema",
+            "description": "List of manifests describing the component lifecycle and artifacts for specific platform",
+            "items": {
+                "$id": "#/properties/Manifests/items",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "platform": {
+                        "type": "object",
+                        "properties": {
+                            "os": {
+                                "type": "string"
+                            },
+                            "architecture": {
+                                "type": "string"
+                            }
+                        },
+                        "patternProperties": {
+                            ".*": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "lifecycle": {
+                        "$ref": "#/definitions/baseLifecycle"
+                    },
+                    "selections": {
+                        "$ref": "#/definitions/selections"
+                    },
+                    "artifacts": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "uri"
+                            ],
+                            "properties": {
+                                "uri": {
+                                    "type": "string"
+                                },
+                                "unarchive": {
+                                    "type": "string",
+                                    "enum": [
+                                        "ZIP",
+                                        "NONE"
+                                    ]
+                                },
+                                "permission": {
+                                    "type": "object",
+                                    "examples": [
+                                        {
+                                            "read": "OWNER",
+                                            "execute": "NONE"
+                                        }
+                                    ],
+                                    "properties": {
+                                        "read": {
+                                            "$ref": "#/definitions/permissions"
+                                        },
+                                        "execute": {
+                                            "$ref": "#/definitions/permissions"
+                                        }
+                                    }
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "the digest of the component",
+                                    "readOnly": true
+                                },
+                                "algorithm": {
+                                    "type": "string",
+                                    "description": "The hash algorithm that AWS IoT Greengrass uses to calculate the digest hash of the artifact",
+                                    "readOnly": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "lifecycle": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/topLevelSelections"
+                },
+                {
+                    "$ref": "#/definitions/globalLifecycle"
+                },
+                {
+                    "$ref": "#/definitions/multiLevelSelections"
+                }
+            ]
+        }
+    },
+    "if": {
+        "not": {
+            "properties": {
+                "componenttype": {
+                    "const": "aws.greengrass.plugin"
+                }
+            }
+        }
+    },
+    "then": {
+        "properties": {
+            "manifests": {
+                "items": {
+                    "properties": {
+                        "lifecycle": {
+                            "$ref": "#/definitions/lifecycle"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/gdk/static/recipe_schema.json
+++ b/gdk/static/recipe_schema.json
@@ -221,7 +221,7 @@
                         }
                     ],
                     "additionalProperties": {
-                        "anyof": [
+                        "anyOf": [
                             {
                                 "type": "number"
                             },

--- a/integration_tests/gdk/common/test_integ_recipe_schema.py
+++ b/integration_tests/gdk/common/test_integ_recipe_schema.py
@@ -1,0 +1,13 @@
+import json
+import jsonschema
+
+import gdk.common.utils as utils
+
+recipe_schema_file = "recipe_schema.json"
+
+
+def test_recipe_schema_is_valid():
+    # Integ test for validating that the recipe schema is a valid json schema
+    with open(utils.get_static_file_path(recipe_schema_file), "r") as schema_file:
+        schema = json.loads(schema_file.read())
+    jsonschema.Draft7Validator.check_schema(schema=schema)

--- a/integration_tests/gdk/components/test_integ_BuildCommand.py
+++ b/integration_tests/gdk/components/test_integ_BuildCommand.py
@@ -188,6 +188,16 @@ class ComponentBuildCommandIntegTest(TestCase):
         build_recipe_file = self.tmpdir.joinpath("greengrass-build/recipes/recipe.yaml").resolve()
         assert not build_recipe_file.exists()
 
+    def test_GIVEN_gdk_project_with_semantically_invalid_recipe_WHEN_build_THEN_raise_exception(self):
+        self.zip_test_data_invalid_recipe()
+        bc = BuildCommand({})
+        with pytest.raises(Exception) as e:
+            bc.run()
+        assert "is invalid. Please correct its format and try again. Error: '20-01-25' is not one of" in str(e)
+
+        build_recipe_file = self.tmpdir.joinpath("greengrass-build/recipes/recipe.yaml").resolve()
+        assert not build_recipe_file.exists()
+
     def zip_test_data(self):
         shutil.copy(
             self.c_dir.joinpath("integration_tests/test_data/config/config.json"), self.tmpdir.joinpath("gdk-config.json")
@@ -211,6 +221,24 @@ class ComponentBuildCommandIntegTest(TestCase):
         self.tmpdir.joinpath("node_modules").mkdir()
         self.tmpdir.joinpath("src", "node_modules").mkdir()
         self.tmpdir.joinpath("src", "node_modules", "excluded_file.txt").touch()
+
+    def zip_test_data_invalid_recipe(self):
+        shutil.copy(
+            self.c_dir.joinpath("integration_tests/test_data/config/config.json"), self.tmpdir.joinpath("gdk-config.json")
+        )
+
+        shutil.copy(
+            self.c_dir.joinpath("integration_tests/test_data/recipes/hello_world_recipe_invalid.yaml"),
+            self.tmpdir.joinpath("recipe.yaml"),
+        )
+        with open(self.tmpdir.joinpath("recipe.yaml"), "r") as f:
+            recipe = f.read()
+            recipe = recipe.replace("$GG_ARTIFACT", self.tmpdir.name + ".zip")
+
+        with open(self.tmpdir.joinpath("recipe.yaml"), "w") as f:
+            f.write(recipe)
+
+        self.tmpdir.joinpath("hello_world.py").touch()
 
     def zip_old_excludes_test_data(self):
         old_excludes_config_path = "integration_tests/test_data/config/config_old_excludes.json"

--- a/integration_tests/test_data/recipes/build_recipe_invalid.yaml
+++ b/integration_tests/test_data/recipes/build_recipe_invalid.yaml
@@ -1,0 +1,33 @@
+---
+RecipeFormatVersion: '2020-05-25'
+ComponentName: com.example.HelloWorld
+ComponentVersion: '1.0.0'
+ComponentDescription: My first AWS IoT Greengrass component.
+ComponentPublisher: Amazon
+ComponentConfiguration:
+  DefaultConfiguration:
+    Message: world
+    SampleList:
+      - '1'
+      - '2'
+      - '3'
+    SampleNestedList:
+      - - '1'
+      - - '2'
+      - - '3'
+    SampleMap:
+      key1: value1
+      key2:
+        key3:
+          - value2
+          - value3
+        key4:
+          key41: value4
+Manifests:
+  - Platform:
+      os: linux
+    Lifecycle:
+      Run: |
+        python3 -u {artifacts:path}/hello_world.py '{configuration:/Message}'
+    Artifacts:
+      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/hello_world.py

--- a/integration_tests/test_data/recipes/hello_world_recipe_invalid.yaml
+++ b/integration_tests/test_data/recipes/hello_world_recipe_invalid.yaml
@@ -1,0 +1,34 @@
+---
+RecipeFormatVersion: '20-01-25'
+ComponentName: com.example.HelloWorld
+ComponentVersion: '1.0.0'
+ComponentDescription: My first AWS IoT Greengrass component.
+ComponentPublisher: Amazon
+ComponentConfiguration:
+  DefaultConfiguration:
+    Message: world
+    SampleList:
+      - '1'
+      - '2'
+      - '3'
+    SampleNestedList:
+      - - '1'
+      - - '2'
+      - - '3'
+    SampleMap:
+      key1: value1
+      key2:
+        key3:
+          - value2
+          - value3
+        key4:
+          key41: value4
+Manifests:
+  - Platform:
+      os: linux
+    Lifecycle:
+      Run: |
+        python3 -u {artifacts:path}/hello_world.py '{configuration:/Message}'
+    Artifacts:
+      - URI: s3://some/path/$GG_ARTIFACT
+      - URI: docker://docker-uri

--- a/tests/gdk/common/test_RecipeValidator.py
+++ b/tests/gdk/common/test_RecipeValidator.py
@@ -1,0 +1,51 @@
+from unittest import TestCase
+
+import pytest
+
+import gdk.common.consts as consts
+import gdk.common.utils as utils
+from gdk.common.RecipeValidator import RecipeValidator
+
+
+class RecipeValidatorTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker):
+        self.mocker = mocker
+
+    def test_GIVEN_valid_recipe_WHEN_validate_recipe_THEN_no_exceptions(self):
+        valid_recipe_object = {
+            "recipeformatversion": "2020-01-25",
+            "componentname": "com.example.hello",
+            "componentpublisher": "Me",
+            "componentversion": "1.0.0",
+            "manifests": [
+                {
+                    "Lifecycle": {
+                      "run": "echo Hello"
+                    }
+                }
+            ]
+        }
+        schema = utils.get_static_file_path(consts.recipe_schema_file)
+        validator = RecipeValidator(schema)
+        validator.validate_recipe(valid_recipe_object)
+
+    def test_GIVEN_invalid_recipe_WHEN_validate_recipe_THEN_raise_exception(self):
+        invalid_recipe_object = {
+            "recipeformatversion": "202-01-25",
+            "componentname": "com.example.hello",
+            "componentpublisher": "Me",
+            "componentversion": "1.0.0",
+            "manifests": [
+                {
+                    "Lifecycle": {
+                      "run": "echo Hello"
+                    }
+                }
+            ]
+        }
+        schema = utils.get_static_file_path(consts.recipe_schema_file)
+        validator = RecipeValidator(schema)
+        with pytest.raises(Exception) as e:
+            validator.validate_recipe(invalid_recipe_object)
+        assert "ValidationError" in str(e)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds the Greengrass recipe schema to GDK. This is temporary until a more permanent solution to pull the schema down from a cloud source is added.

Add recipe schema validation to the component build and component publish commands. These will compare the project recipe file against the included Greengrass recipe schema and stop the command and produce a ValidationError if the recipe does not validate against the schema.

**Why is this change necessary:**
Validating component recipes against the schema is a planned feature and allows users of GDK to identify issues with their recipes earlier in the development process.

**How was this change tested:**
Manually tested. Added unit/integration tests for the additions.

**Any additional information or context required to review the change:**
Output of the build/publish commands may change depending on the cloud api implementation of schema validation. If changes need to be this output may be changed in a future PR.

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.