### PR TITLE
fix: fix regex format for python 3.11+

### DIFF
--- a/gdk/static/recipe_schema.json
+++ b/gdk/static/recipe_schema.json
@@ -26,7 +26,7 @@
     "definitions": {
         "permissions": {
             "type": "string",
-            "pattern": "^(?i)(NONE|OWNER|ALL)$"
+            "pattern": "(?i)^(NONE|OWNER|ALL)$"
         },
         "lifecycle": {
             "type": "object",
@@ -363,7 +363,7 @@
             "title": "The ComponentType schema",
             "description": "The type of this component.",
             "default": "aws.greengrass.generic",
-            "pattern" : "^(?i)(aws\\.greengrass\\.(nucleus|generic|plugin|lambda))$"
+            "pattern" : "(?i)^(aws\\.greengrass\\.(nucleus|generic|plugin|lambda))$"
         },
         "componentsource": {
             "$id": "#/properties/ComponentSource",
@@ -422,7 +422,7 @@
                             "title": "The DependencyType schema",
                             "description": "The type of this dependency.",
                             "default": "HARD",
-                            "pattern": "^(?i)(SOFT|HARD)$",
+                            "pattern": "(?i)^(SOFT|HARD)$",
                             "examples": [
                                 "SOFT"
                             ]
@@ -480,7 +480,7 @@
                                 "unarchive": {
                                     "type": "string",
                                     "default": "NONE",
-                                    "pattern": "^(?i)(ZIP|NONE)$"
+                                    "pattern": "(?i)^(ZIP|NONE)$"
                                 },
                                 "permission": {
                                     "type": "object",


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Global flags must be in front of the regex expression in python 3.11+. This PR moves them there for regex instances that have them in the schema.

**Why is this change necessary:**
Maintain compatibility with later versions of python.

**How was this change tested:**
Using python 3.12, with these changes I no longer get warnings/errors about the regex.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.