### PR TITLE
feat: update the default version of GTF used for end-to-end testing t…

### DIFF
--- a/gdk/common/config/TestConfiguration.py
+++ b/gdk/common/config/TestConfiguration.py
@@ -1,7 +1,7 @@
 class TestConfiguration:
     def __init__(self, test_config):
         self.test_build_system = "maven"
-        self.gtf_version = "1.1.0"  # TODO: Default value should be the latest version of otf testing standalone jar.
+        self.gtf_version = "1.2.0"  # TODO: Default value should be the latest version of otf testing standalone jar.
         self.gtf_options = {}
 
         self._set_test_config(test_config)

--- a/integration_tests/gdk/common/config/test_GDKProject.py
+++ b/integration_tests/gdk/common/config/test_GDKProject.py
@@ -30,7 +30,7 @@ class GDKProjectTest(TestCase):
 
         gdk_config = GDKProject()
         assert gdk_config.component_name == "abc"
-        assert gdk_config.test_config.gtf_version == "1.1.0"
+        assert gdk_config.test_config.gtf_version == "1.2.0"
         assert gdk_config.test_config.test_build_system == "maven"
         assert gdk_config.test_config.gtf_options == {}
 

--- a/tests/gdk/commands/test/config/test_InitConfiguration.py
+++ b/tests/gdk/commands/test/config/test_InitConfiguration.py
@@ -27,7 +27,7 @@ class InitConfigurationUnitTest(TestCase):
 
         self.mocker.patch("gdk.common.configuration.get_configuration", return_value=config)
         init_config = InitConfiguration({})
-        assert init_config.gtf_version == "1.1.0"
+        assert init_config.gtf_version == "1.2.0"
 
     def test_GIVEN_gdk_config_with_otf_version_WHEN_test_init_THEN_use_version_from_config(self):
         config = self._get_config(


### PR DESCRIPTION
…o 1.2.0

**Issue #, if available:**

**Description of changes:**
Update the default Greengrass Test Framework (GTF) version used by test-e2e command to 1.2.0, following the recent GTF 1.2.0 release.

**Why is this change necessary:**
This allows customers to use the latest GTF release by default, but also ensures that the confidence tests included in the test-e2e init template will have the steps they need to run in a default setting.

**How was this change tested:**
Updated unit/integration tests that tested the default value to the new default value.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.