### PR TITLE
feat: add link to recipe reference in docs in error message if schema…

### DIFF
--- a/gdk/common/exceptions/error_messages.py
+++ b/gdk/common/exceptions/error_messages.py
@@ -7,12 +7,20 @@ PROJECT_RECIPE_FILE_NOT_FOUND = (
     "No valid component recipe is found. Please include a valid recipe file of the component to build with default."
 )
 PROJECT_CONFIG_FILE_INVALID = "Project configuration file '{}' is invalid. Please correct its format and try again. Error: {} "
-PROJECT_RECIPE_FILE_INVALID = "Project recipe file '{}' is invalid. Please correct its format and try again. Error: {} "
+PROJECT_RECIPE_FILE_INVALID = (
+    "Project recipe file '{}' is invalid. Please correct its format and try again.\nFor more information regarding " +
+    "component recipes refer to the docs here: https://docs.aws.amazon.com/greengrass/v2/developerguide/" +
+    "component-recipe-reference.html\nError: {} "
+)
 SCHEMA_FILE_INVALID = (
     "The Greengrass recipe schema file has an unexpected error.\nPlease report it at " +
     "https://github.com/aws-greengrass/aws-greengrass-gdk-cli/issues if the issue persists.\nError details: {} "
 )
-BUILD_RECIPE_FILE_INVALID = "Built recipe file '{}' is invalid. Please correct its format and try again. Error: {} "
+BUILD_RECIPE_FILE_INVALID = (
+    "Built recipe file '{}' is invalid. Please correct its format and try again.\nFor more information regarding " +
+    "component recipes refer to the docs here: https://docs.aws.amazon.com/greengrass/v2/developerguide/" +
+    "component-recipe-reference.html\nError: {} "
+)
 CLI_MODEL_FILE_NOT_EXISTS = "Model validation failed. CLI model file doesn't exist."
 RECIPE_SIZE_INVALID = (
     "The input recipe file '{}' has an invalid size of {} bytes. Please make sure it does not exceed 16kB"

--- a/integration_tests/gdk/components/test_integ_BuildCommand.py
+++ b/integration_tests/gdk/components/test_integ_BuildCommand.py
@@ -188,12 +188,12 @@ class ComponentBuildCommandIntegTest(TestCase):
         build_recipe_file = self.tmpdir.joinpath("greengrass-build/recipes/recipe.yaml").resolve()
         assert not build_recipe_file.exists()
 
-    def test_GIVEN_gdk_project_with_semantically_invalid_recipe_WHEN_build_THEN_raise_exception(self):
+    def test_GIVEN_gdk_project_with_invalid_recipe_WHEN_build_THEN_raise_exception(self):
         self.zip_test_data_invalid_recipe()
         bc = BuildCommand({})
         with pytest.raises(Exception) as e:
             bc.run()
-        assert "is invalid. Please correct its format and try again. Error: '20-01-25' is not one of" in str(e)
+        assert "Error: '20-01-25' is not one of" in str(e)
 
         build_recipe_file = self.tmpdir.joinpath("greengrass-build/recipes/recipe.yaml").resolve()
         assert not build_recipe_file.exists()

--- a/integration_tests/gdk/components/test_integ_PublishCommand.py
+++ b/integration_tests/gdk/components/test_integ_PublishCommand.py
@@ -255,7 +255,7 @@ class ComponentPublishCommandIntegTest(TestCase):
             PublishCommand({"options": str(self.tmpdir.joinpath("options.json").resolve())})
         assert "JSON string is incorrectly formatted." in e.value.args[0]
 
-    def test_GIVEN_built_artifacts_WHEN_publish_with_semantically_invalid_recipe_THEN_raise_exception(self):
+    def test_GIVEN_built_artifacts_WHEN_publish_with_invalid_recipe_THEN_raise_exception(self):
         self.zip_test_data_invalid_recipe()
 
         self.tmpdir.joinpath("greengrass-build/artifacts/abc/2.0.0/").mkdir(parents=True, exist_ok=True)
@@ -282,7 +282,7 @@ class ComponentPublishCommandIntegTest(TestCase):
         with pytest.raises(Exception) as e:
             pc = PublishCommand({})
             pc.run()
-        assert "is invalid. Please correct its format and try again. Error: '2020-05-25' is not one of" in str(e)
+        assert "Error: '2020-05-25' is not one of" in str(e)
 
     def test_GIVEN_built_artifacts_WHEN_publish_with_oversized_recipe_THEN_raise_exception(self):
         self.zip_test_data_oversized_recipe()


### PR DESCRIPTION
… validation fails

**Issue #, if available:**

**Description of changes:**
Adds link to docs in output when schema validation fails.
**Why is this change necessary:**
Referring to the recipe docs may be helpful for customers facing recipes that are failing schema validation.
**How was this change tested:**
Manually tested that the error message looks good. Adjusted the tests that expect a different error message.
**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.