### PR TITLE
refactor: consolidate similar error messages about invalid recipes

### DIFF
--- a/gdk/commands/component/transformer/PublishRecipeTransformer.py
+++ b/gdk/commands/component/transformer/PublishRecipeTransformer.py
@@ -7,7 +7,7 @@ from gdk.common.RecipeValidator import RecipeValidator
 
 import gdk.common.consts as consts
 import gdk.common.utils as utils
-from gdk.common.exceptions.error_messages import BUILT_RECIPE_SIZE_INVALID, BUILD_RECIPE_FILE_INVALID, SCHEMA_FILE_INVALID
+from gdk.common.exceptions.error_messages import BUILT_RECIPE_SIZE_INVALID, PROJECT_RECIPE_FILE_INVALID, SCHEMA_FILE_INVALID
 
 
 class PublishRecipeTransformer:
@@ -103,6 +103,6 @@ class PublishRecipeTransformer:
             validator = RecipeValidator(recipe_schema_path)
             validator.validate_recipe(parsed_component_recipe.to_dict())
         except jsonschema.exceptions.ValidationError as err:
-            raise Exception(BUILD_RECIPE_FILE_INVALID.format(recipe_path, err.message))
+            raise Exception(PROJECT_RECIPE_FILE_INVALID.format(recipe_path, err.message))
         except jsonschema.exceptions.SchemaError as err:
             raise Exception(SCHEMA_FILE_INVALID.format(err.message))

--- a/gdk/common/exceptions/error_messages.py
+++ b/gdk/common/exceptions/error_messages.py
@@ -16,11 +16,6 @@ SCHEMA_FILE_INVALID = (
     "The Greengrass recipe schema file has an unexpected error.\nPlease report it at " +
     "https://github.com/aws-greengrass/aws-greengrass-gdk-cli/issues if the issue persists.\nError details: {} "
 )
-BUILD_RECIPE_FILE_INVALID = (
-    "Built recipe file '{}' is invalid. Please correct its format and try again.\nFor more information regarding " +
-    "component recipes refer to the docs here: https://docs.aws.amazon.com/greengrass/v2/developerguide/" +
-    "component-recipe-reference.html\nError: {} "
-)
 CLI_MODEL_FILE_NOT_EXISTS = "Model validation failed. CLI model file doesn't exist."
 RECIPE_SIZE_INVALID = (
     "The input recipe file '{}' has an invalid size of {} bytes. Please make sure it does not exceed 16kB"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Followup from discussion here: https://github.com/aws-greengrass/aws-greengrass-gdk-cli/pull/262#discussion_r1393370377

Have both build and publish commands use the same invalid recipe error.

**Why is this change necessary:**
Keeps the code simple and cleaner with less items to update when we wish to change the error message.

**How was this change tested:**
Unit/Integration tests pass, manually tested

**Any additional information or context required to review the change:**


**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.