### PR TITLE
chore: bump regression workflow versions to use latest

### DIFF
--- a/.github/workflows/Regression.yaml
+++ b/.github/workflows/Regression.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        gdk-version: [ HEAD, v1.5.0, v1.4.0]
+        gdk-version: [ HEAD, v1.6.0, v1.5.0]
         python-version: [3.7, 3.8, 3.x]
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Bump the regression workflow matrix to test against 1.6.0 and 1.5.0 following the GDk 1.6.0 release.

**Why is this change necessary:**
Keep our workflows up to date so that they provide value for future development.

**How was this change tested:**
N/A

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.