### PR TITLE
feat: get latest GTF release name from Github API

### DIFF
--- a/gdk/common/GithubUtils.py
+++ b/gdk/common/GithubUtils.py
@@ -1,0 +1,10 @@
+import requests
+
+
+class GithubUtils:
+    def get_latest_release_name(self, owner, repository):
+        latest_release_api_url = f"https://api.github.com/repos/{owner}/{repository}/releases/latest"
+        response = requests.get(latest_release_api_url)
+        if response.status_code != 200:
+            response.raise_for_status()
+        return response.json()["name"]

--- a/gdk/common/GithubUtils.py
+++ b/gdk/common/GithubUtils.py
@@ -7,4 +7,4 @@ class GithubUtils:
         response = requests.get(latest_release_api_url)
         if response.status_code != 200:
             response.raise_for_status()
-        return response.json()["name"]
+        return response.json().get("name")  # We typically name our GTF releases by the version.

--- a/gdk/common/config/TestConfiguration.py
+++ b/gdk/common/config/TestConfiguration.py
@@ -23,8 +23,12 @@ class TestConfiguration:
         github_utils = GithubUtils()
         try:
             latest_gtf_version = github_utils.get_latest_release_name(GTF_REPO_OWNER, GTF_REPO_NAME)
-            self.gtf_version = latest_gtf_version
-            logging.info("Discovered %s as latest GTF release name.", self.gtf_version)
+            if latest_gtf_version is not None:
+                self.gtf_version = latest_gtf_version
+                logging.info("Discovered %s as latest GTF release name.", self.gtf_version)
+            else:
+                logging.info("Unable to get the latest GTF release name. Using %s as the default value.", self.gtf_version)
+                logging.debug("GTF release name was found to be None, so using default.")
         except Exception as e:
             logging.info("Unable to get the latest GTF release name. Using %s as the default value.", self.gtf_version)
             logging.debug("Exception information for GTF release name API call: %s", str(e))

--- a/gdk/common/config/TestConfiguration.py
+++ b/gdk/common/config/TestConfiguration.py
@@ -1,7 +1,13 @@
+import logging
+
+from gdk.common.GithubUtils import GithubUtils
+from gdk.common.consts import GTF_REPO_OWNER, GTF_REPO_NAME
+
+
 class TestConfiguration:
     def __init__(self, test_config):
         self.test_build_system = "maven"
-        self.gtf_version = "1.2.0"  # TODO: Default value should be the latest version of otf testing standalone jar.
+        self.gtf_version = "1.2.0"  # Default value for when Github API call fails
         self.gtf_options = {}
 
         self._set_test_config(test_config)
@@ -14,6 +20,14 @@ class TestConfiguration:
         self.test_build_system = test_build_config.get("build_system", self.test_build_system)
 
     def _set_gtf_config(self, test_config):
+        github_utils = GithubUtils()
+        try:
+            latest_gtf_version = github_utils.get_latest_release_name(GTF_REPO_OWNER, GTF_REPO_NAME)
+            self.gtf_version = latest_gtf_version
+            logging.info("Discovered %s as latest GTF release name.", self.gtf_version)
+        except Exception as e:
+            logging.info("Unable to get the latest GTF release name. Using %s as the default value.", self.gtf_version)
+            logging.debug("Exception information for GTF release name API call: %s", str(e))
         self.gtf_version = (test_config.get("gtf_version")
                             if "gtf_version" in test_config
                             else test_config.get("otf_version", self.gtf_version))

--- a/gdk/common/consts.py
+++ b/gdk/common/consts.py
@@ -37,6 +37,8 @@ DOCS_RECIPE_LINK = "https://docs.aws.amazon.com/greengrass/v2/developerguide/com
 GDK_CONFIG_DOCS_LINK = (
     "https://docs.aws.amazon.com/greengrass/v2/developerguide/gdk-cli-configuration-file.html#gdk-config-format"
 )
+GTF_REPO_OWNER = "aws-greengrass"
+GTF_REPO_NAME = "aws-greengrass-testing"
 
 # DEFAULT LOGGING
 log_format = "[%(asctime)s] %(levelname)s - %(message)s"

--- a/integration_tests/gdk/common/config/test_GDKProject.py
+++ b/integration_tests/gdk/common/config/test_GDKProject.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import pytest
 from unittest import TestCase
 from gdk.common.config.GDKProject import GDKProject
+from gdk.common.GithubUtils import GithubUtils
 
 import gdk.common.exceptions.error_messages as error_messages
 import os
@@ -13,6 +14,7 @@ class GDKProjectTest(TestCase):
     @pytest.fixture(autouse=True)
     def __inject_fixtures(self, mocker, tmpdir):
         self.mocker = mocker
+        self.mocker.patch.object(GithubUtils, "get_latest_release_name", return_value="1.2.0")
         self.tmpdir = Path(tmpdir).resolve()
         self.c_dir = Path(".").resolve()
         os.chdir(self.tmpdir)

--- a/integration_tests/gdk/test/test_integ_uat_InitCommand.py
+++ b/integration_tests/gdk/test/test_integ_uat_InitCommand.py
@@ -8,6 +8,7 @@ import shutil
 from urllib3.exceptions import HTTPError
 import gdk.common.consts as consts
 from gdk.common.config.GDKProject import GDKProject
+from gdk.common.GithubUtils import GithubUtils
 import requests
 
 
@@ -27,6 +28,7 @@ class E2ETestInitCommandTest(TestCase):
             + "TestTemplateForCLI.zip"
         )
         self.mocker.patch.object(GDKProject, "_get_recipe_file", return_value=Path(".").joinpath("recipe.json").resolve())
+        self.mocker.patch.object(GithubUtils, "get_latest_release_name", return_value="1.2.0")
 
         os.chdir(tmpdir)
         yield

--- a/tests/gdk/commands/test/config/test_InitConfiguration.py
+++ b/tests/gdk/commands/test/config/test_InitConfiguration.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import os
 from gdk.commands.test.config.InitConfiguration import InitConfiguration
 from gdk.common.config.GDKProject import GDKProject
+from gdk.common.GithubUtils import GithubUtils
 import requests
 
 
@@ -12,6 +13,7 @@ class InitConfigurationUnitTest(TestCase):
     def __inject_fixtures(self, mocker, tmpdir):
         self.mocker = mocker
         self.tmpdir = tmpdir
+        self.mocker.patch.object(GithubUtils, "get_latest_release_name", return_value="1.2.0")
         self.c_dir = Path(".").resolve()
         self.mocker.patch.object(GDKProject, "_get_recipe_file", return_value=Path(".").joinpath("recipe.json").resolve())
         os.chdir(tmpdir)

--- a/tests/gdk/common/test_GithubUtils.py
+++ b/tests/gdk/common/test_GithubUtils.py
@@ -1,0 +1,26 @@
+from unittest import TestCase
+
+import pytest
+
+from gdk.common.GithubUtils import GithubUtils
+
+
+class MockGetResponse:
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_data
+
+
+class GithubUtilsTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker):
+        self.mocker = mocker
+
+    def test_GIVEN_latest_release_request_WHEN_request_successful_THEN_return_release_name(self):
+        self.mocker.patch("requests.get", return_value=MockGetResponse({"name": "1.0.0"}, 200))
+        github_utils = GithubUtils()
+        latest_release = github_utils.get_latest_release_name("author", "repo")
+        assert latest_release == "1.0.0"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Get the latest GTF release name from Github API and use it as the default value. If this API request fails (typically due to exceeding rate limits), fall bad on old behavior and use a hard-coded release value.

**Why is this change necessary:**
Getting the release dynamically should allow customers to benefit from GTF releases as soon as they are available, and lessen the need for us to release new GDK versions to followup GTF releases. The hard coded value will still need to be updated once in a while though.

**How was this change tested:**
Modified unit and integration tests that use the config value. Added new unit test for the new utils function. Manually tested as well.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.