### PR TITLE
feat: add a suggestion to update GTF version if provided version is n…

### DIFF
--- a/gdk/commands/test/config/InitConfiguration.py
+++ b/gdk/commands/test/config/InitConfiguration.py
@@ -18,15 +18,6 @@ class InitConfiguration(GDKProject):
             _version_arg = self._args.get("otf_version", None)
         if _version_arg:
             logging.info("Using the GTF version provided in the command %s", _version_arg)
-            if not self.test_config.upgrade_suggestion:
-                try:
-                    if Version(_version_arg) < Version(self.test_config.latest_gtf_version):
-                        logging.info(
-                            f"The current latest version of GTF is {self.test_config.latest_gtf_version}. Please consider "
-                            "using the latest version."
-                        )
-                except Exception as e:
-                    logging.debug("Not providing GTF update suggestion due to caught version error: %s", str(e))
             return self._validated_gtf_version(_version_arg)
         logging.info("Using the GTF version provided in the GDK test config %s", self.test_config.gtf_version)
         return self._validated_gtf_version(self.test_config.gtf_version)
@@ -50,6 +41,16 @@ class InitConfiguration(GDKProject):
                 f"The specified Greengrass Test Framework (GTF) version '{_version}' does not exist. Please"
                 f" provide a valid GTF version from the releases here: {self._gtf_releases_url}"
             )
+
+        try:
+            if (Version(_version) < Version(self.test_config.latest_gtf_version) and
+                    not self.test_config.upgrade_suggestion_already_provided):
+                logging.info(
+                    f"The current latest version of GTF is {self.test_config.latest_gtf_version}. Please consider "
+                    "using the latest version."
+                )
+        except Exception as e:
+            logging.debug("Not providing GTF update suggestion due to caught version error: %s", str(e))
 
         return _version
 

--- a/gdk/commands/test/config/InitConfiguration.py
+++ b/gdk/commands/test/config/InitConfiguration.py
@@ -2,6 +2,7 @@ import semver
 from gdk.common.config.GDKProject import GDKProject
 import logging
 import requests
+from packaging.version import Version
 
 
 class InitConfiguration(GDKProject):
@@ -17,6 +18,15 @@ class InitConfiguration(GDKProject):
             _version_arg = self._args.get("otf_version", None)
         if _version_arg:
             logging.info("Using the GTF version provided in the command %s", _version_arg)
+            if not self.test_config.upgrade_suggestion:
+                try:
+                    if Version(_version_arg) < Version(self.test_config.latest_gtf_version):
+                        logging.info(
+                            f"The current latest version of GTF is {self.test_config.latest_gtf_version}. Please consider "
+                            "using the latest version."
+                        )
+                except Exception as e:
+                    logging.debug("Not providing GTF update suggestion due to caught version error: %s", str(e))
             return self._validated_gtf_version(_version_arg)
         logging.info("Using the GTF version provided in the GDK test config %s", self.test_config.gtf_version)
         return self._validated_gtf_version(self.test_config.gtf_version)

--- a/gdk/common/config/TestConfiguration.py
+++ b/gdk/common/config/TestConfiguration.py
@@ -10,7 +10,7 @@ class TestConfiguration:
         self.test_build_system = "maven"
         self.gtf_version = "1.2.0"  # Default value for when Github API call fails
         self.gtf_options = {}
-        self.upgrade_suggestion = False
+        self.upgrade_suggestion_already_provided = False
         self.latest_gtf_version = None
 
         self._set_test_config(test_config)
@@ -47,7 +47,7 @@ class TestConfiguration:
                     f"The current latest version of GTF is {self.latest_gtf_version}. Please consider updating your "
                     "gdk-config.json to use the latest version."
                 )
-                self.upgrade_suggestion = True
+                self.upgrade_suggestion_already_provided = True
         except Exception as e:
             logging.debug("Not providing GTF update suggestion due to caught version error: %s", str(e))
         self.gtf_options = (test_config.get("gtf_options")

--- a/gdk/common/config/TestConfiguration.py
+++ b/gdk/common/config/TestConfiguration.py
@@ -1,4 +1,5 @@
 import logging
+from packaging.version import Version
 
 from gdk.common.GithubUtils import GithubUtils
 from gdk.common.consts import GTF_REPO_OWNER, GTF_REPO_NAME
@@ -21,10 +22,12 @@ class TestConfiguration:
 
     def _set_gtf_config(self, test_config):
         github_utils = GithubUtils()
+        latest_gtf_version = None
         try:
-            latest_gtf_version = github_utils.get_latest_release_name(GTF_REPO_OWNER, GTF_REPO_NAME)
-            if latest_gtf_version is not None:
-                self.gtf_version = latest_gtf_version
+            release_name = github_utils.get_latest_release_name(GTF_REPO_OWNER, GTF_REPO_NAME)
+            if release_name is not None:
+                self.gtf_version = release_name
+                latest_gtf_version = release_name
                 logging.info("Discovered %s as latest GTF release name.", self.gtf_version)
             else:
                 logging.info("Unable to get the latest GTF release name. Using %s as the default value.", self.gtf_version)
@@ -35,6 +38,16 @@ class TestConfiguration:
         self.gtf_version = (test_config.get("gtf_version")
                             if "gtf_version" in test_config
                             else test_config.get("otf_version", self.gtf_version))
+        try:
+            # We have handling later to determine if user-provided version is incorrect, so if they are not proper
+            # versions to qualify for this warning, catch the error and just pass
+            if Version(self.gtf_version) < Version(latest_gtf_version):
+                logging.info(
+                    f"The current latest version of GTF is {latest_gtf_version}. Please consider updating your configuration "
+                    "to use the latest version."
+                )
+        except Exception as e:
+            logging.debug("Not providing GTF update suggestion due to caught version error: %s", str(e))
         self.gtf_options = (test_config.get("gtf_options")
                             if "gtf_options" in test_config
                             else test_config.get("otf_options", {}))


### PR DESCRIPTION
…ot latest

**Issue #, if available:**

**Description of changes:**
Adds a friendly suggestion to use the latest GTF version if a version provided in configuration is not the latest. Also provides a suggestion to use latest GTF if a version provided in command args is not the latest. However, the user will only see one of these suggestions and never see both.

**Why is this change necessary:**
Users may have old values in their configuration and not know when a new version is available. Similar if they are used to using a command with an older argument. This suggestion should help them use our latest versions.

**How was this change tested:**
Manually tested to see that the log appears correctly.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.