### PR TITLE
chore: update logging level for latest gtf release logs

### DIFF
--- a/gdk/common/config/TestConfiguration.py
+++ b/gdk/common/config/TestConfiguration.py
@@ -29,12 +29,11 @@ class TestConfiguration:
             if release_name is not None:
                 self.gtf_version = release_name
                 self.latest_gtf_version = release_name
-                logging.info("Discovered %s as latest GTF release name.", self.gtf_version)
+                logging.debug("Discovered %s as latest GTF release name.", self.gtf_version)
             else:
-                logging.info("Unable to get the latest GTF release name. Using %s as the default value.", self.gtf_version)
-                logging.debug("GTF release name was found to be None, so using default.")
+                logging.debug("GTF release name was found to be None. Using %s as the default value.", self.gtf_version)
         except Exception as e:
-            logging.info("Unable to get the latest GTF release name. Using %s as the default value.", self.gtf_version)
+            logging.debug("Unable to get the latest GTF release name. Using %s as the default value.", self.gtf_version)
             logging.debug("Exception information for GTF release name API call: %s", str(e))
         self.gtf_version = (test_config.get("gtf_version")
                             if "gtf_version" in test_config


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Changes some debug logs for grabbing the latest GTF release from info level logging to debug. These statements will appear on any command as they are run when setting up the tool configuration and we shouldn't show them by default.

**Why is this change necessary:**
Keep the cli tool output clean. We don't want to always display this information and especially not when a command unrelated to e2e testing is run.

**How was this change tested:**
Manually tested and the logs show with the debug flag and not otherwise. No unit/integration testing required.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.