### PR TITLE
fix(setuptools): exclude test related packages from build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license=license,
-    packages=find_packages(),
+    packages=find_packages(include=["gdk"]),
     entry_points=entry_points,
     classifiers=classifiers,
     install_requires=get_requirements(),


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Setuptools build includes only gdk package. Test-related packages are excluded.

**Why is this change necessary:**
Build package currently contains `tests` and `integration_tests`. These are common in many projects which lead to name collisions. In my case, I spotted the issue when Pycharm tried to search for project tests in the gdk installed tests package.

**How was this change tested:**
`python setup.py build`, results verified visually.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.