### PR TITLE
fix: include packages from subdirectories of gdk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license=license,
-    packages=find_packages(include=["gdk"]),
+    packages=find_packages(include=["gdk", "gdk.*"]),
     entry_points=entry_points,
     classifiers=classifiers,
     install_requires=get_requirements(),


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Include packages from subdirectories when building. This should fix failing workflows on commit https://github.com/aws-greengrass/aws-greengrass-gdk-cli/commit/3545476003eb5b9a2907e05794352db4b908f94e

**Why is this change necessary:**

**How was this change tested:**
python3 setup.py build no longer warns about missing gdk.common from the build.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.