### PR TITLE
chore: add cli and dependencies installation to CI steps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,10 +38,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Python version
+      - name: Install CLI and dependencies
         run: |
           python -VV
           python -m pip install --upgrade pip
+          # Perform clean install without test dependencies to ensure none of test dependencies
+          # have been used in the gdk codebase.
+          pip install .
+          gdk --help
       - name: Lint with flake8
         run: |
           pip install flake8


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
During our CI steps add installation of the CLI/its dependencies. We do this in our regression steps but doing this here will help us spot issues sooner.

**Why is this change necessary:**
Help spot issues sooner.

**How was this change tested:**
Workflow on this PR. At the time of writing, the workflows are failing as https://github.com/aws-greengrass/aws-greengrass-gdk-cli/pull/279 fix is still waiting to be merged.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.