### PR TITLE
chore: bump versions used during regression workflow

### DIFF
--- a/.github/workflows/Regression.yaml
+++ b/.github/workflows/Regression.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        gdk-version: [ HEAD, v1.6.0, v1.5.0]
+        gdk-version: [ HEAD, v1.6.2, v1.6.1]
         python-version: [3.7, 3.8, 3.x]
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Bump the versions used by regression workflow to the latest two patches.

**Why is this change necessary:**
We want to test latest 3 versions.

**How was this change tested:**
N/A

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.