### PR TITLE
Update README.md with note about where gdk is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ To install the latest version of CLI using this git repository and pip, run the 
 
 `pip3 install git+https://github.com/aws-greengrass/aws-greengrass-gdk-cli.git@v1.6.2`
 
+This installs the gdk executable into your python environment bin. You'll want to add it to your path, or reference the executable absolutely in the commands below.
+
 Run `gdk --help` to check if the cli tool is successfully installed.
 
 #### 2. Configure AWS credentials


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

I got tripped up when installing into a venv because the python bin was not on my path. This note helps avoid this pitfall and can be easily ignored for people who already understand how python installation works

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.